### PR TITLE
fix(857): Support RHL proxied components in custom type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.omit": "^4.5.0",
+    "react-hot-loader": "^4.1.2",
     "warning": "3.0.0",
     "window-or-global": "^1.0.1"
   },

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -75,6 +75,7 @@ module.exports = {
           'PropTypes',
           'createElement',
         ],
+        'node_modules/react-hot-loader/patch.js': ['areComponentsEqual'],
         'node_modules/react-dom/index.js': ['render'],
       },
     }),

--- a/src/prop-types/__tests__/childrenOf-test.js
+++ b/src/prop-types/__tests__/childrenOf-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import reactHotLoader from 'react-hot-loader/patch';
 import childrenOf from '../childrenOf';
 
 const StatelessComponent = () => <div />;
@@ -20,10 +21,25 @@ describe('childrenOf', () => {
     // on the number of times this is called to make sure we aren't swallowing
     // any errors unexpectedly.
     spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    reactHotLoader.disableProxyCreation = true;
   });
 
   afterEach(() => {
     spy.mockRestore();
+    reactHotLoader.reset();
+  });
+
+  it('should Validate RHL proxied children of given a enum of types', () => {
+    reactHotLoader.disableProxyCreation = false;
+    const ProxiedChildrenEnumValid = ({ children }) => <div>{children}</div>;
+    ProxiedChildrenEnumValid.propTypes = {
+      children: childrenOf([StatelessComponent, ClassComponent]),
+    };
+    <ProxiedChildrenEnumValid>
+      <StatelessComponent />
+      <ClassComponent />
+    </ProxiedChildrenEnumValid>;
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('should validate children of a given enum of types', () => {

--- a/src/prop-types/__tests__/childrenOfType-test.js
+++ b/src/prop-types/__tests__/childrenOfType-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import reactHotLoader from 'react-hot-loader/patch';
 import childrenOfType from '../childrenOfType';
 
 const Element = <span />;
@@ -21,10 +22,24 @@ describe('childrenOfType', () => {
     // on the number of times this is called to make sure we aren't swallowing
     // any errors unexpectedly.
     spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    reactHotLoader.disableProxyCreation = true;
   });
 
   afterEach(() => {
     spy.mockRestore();
+    reactHotLoader.reset();
+  });
+
+  it('should validate RHL Proxied children of a given element type', () => {
+    reactHotLoader.disableProxyCreation = false;
+    const ProxiedChildValidTest = ({ children }) => <div>{children}</div>;
+    ProxiedChildValidTest.propTypes = {
+      children: childrenOfType(StatelessComponent),
+    };
+    <ProxiedChildValidTest>
+      <StatelessComponent />
+    </ProxiedChildValidTest>;
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('should validate children of a given element type', () => {

--- a/src/prop-types/childrenOf.js
+++ b/src/prop-types/childrenOf.js
@@ -1,4 +1,5 @@
 import { Children } from 'react';
+import { areComponentsEqual } from 'react-hot-loader/patch';
 import createChainableTypeChecker from './tools/createChainableTypeChecker';
 import getDisplayName from './tools/getDisplayName';
 
@@ -21,7 +22,13 @@ const childrenOf = expectedChildTypes => {
         return;
       }
       const childDisplayName = getDisplayName(child.type || child);
-      if (!expectedChildTypes.includes(child.type)) {
+      const expectedChildType = expectedChildTypes.find(
+        c =>
+          typeof c === 'string'
+            ? c === childDisplayName
+            : c.name === childDisplayName
+      );
+      if (!areComponentsEqual(child.type, expectedChildType)) {
         throw new Error(
           `Invalid prop \`children\` of type \`${childDisplayName}\` ` +
             `supplied to \`${componentName}\`, expected each child to be one ` +

--- a/src/prop-types/childrenOfType.js
+++ b/src/prop-types/childrenOfType.js
@@ -1,11 +1,13 @@
 import { Children } from 'react';
+import { areComponentsEqual } from 'react-hot-loader/patch';
 import createChainableTypeChecker from './tools/createChainableTypeChecker';
 import getDisplayName from './tools/getDisplayName';
 
 /**
  * `childrenOfType` is used for asserting that children of a given React
  * component are only of a given type. Currently, this supports React elements,
- * Stateless Functional Components, and Class-based components.
+ * Stateless Functional Components, and Class-based components (even Proxied
+ * via React-Hot-Loader)
  *
  * This prop validator also supports chaining through `isRequired`
  */
@@ -18,8 +20,8 @@ const childrenOfType = expectedChildType => {
     Children.forEach(props[propName], child => {
       const childDisplayName = getDisplayName(child.type);
       if (
-        child.type !== expectedChildType.type &&
-        child.type !== expectedChildType
+        !areComponentsEqual(child.type, expectedChildType.type) &&
+        !areComponentsEqual(child.type, expectedChildType)
       ) {
         throw new Error(
           `Invalid prop \`children\` of type \`${childDisplayName}\` ` +

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,9 +2757,9 @@ caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
 
-carbon-components@^8.18.14:
-  version "8.18.14"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.18.14.tgz#579383adfe880469cd1bd78bb2c2b12d47a43273"
+carbon-components@^8.18.15:
+  version "8.18.22"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.18.22.tgz#e55ee0872c568aa5b203dc38dd8d1b4bef053af8"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"
@@ -4429,7 +4429,7 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
@@ -4937,7 +4937,7 @@ global-prefix@^0.1.4:
     is-windows "^0.2.0"
     which "^1.2.12"
 
-global@^4.3.2:
+global@^4.3.0, global@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:
@@ -5159,6 +5159,10 @@ hoek@4.x.x:
 hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -8226,6 +8230,14 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.6.tgz#f8bb263ea1b5fd7a7604d26b8be39bd77678bf8a"
@@ -8434,6 +8446,17 @@ react-fuzzy@^0.5.1:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
+react-hot-loader@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.1.2.tgz#5e8025f5bc5605506586b46eb2c6cc4006fd54d7"
+  dependencies:
+    fast-levenshtein "^2.0.6"
+    global "^4.3.0"
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.2"
+    shallowequal "^1.0.2"
+
 react-html-attributes@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.1.tgz#97b5ec710da68833598c8be6f89ac436216840a5"
@@ -8456,6 +8479,10 @@ react-inspector@^2.2.2:
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
+
+react-lifecycles-compat@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz#7279047275bd727a912e25f734c0559527e84eff"
 
 react-modal@^3.1.10:
   version "3.1.11"
@@ -9336,6 +9363,10 @@ shallowequal@^0.2.2:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   dependencies:
     lodash.keys "^3.1.2"
+
+shallowequal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#857

This adds `react-hot-loader` as dependency, since new type checking is done via [areComponentsEqual](https://github.com/gaearon/react-hot-loader/blob/f3e1208878583136e9e14c0e2e6b7ffc7db94fea/src/utils.dev.js#L9-L11)
```javascript
export const areComponentsEqual = (a, b) =>
  getProxyOrType(a) === getProxyOrType(b)
``` 

#### Changelog

**New**

* react-hot-loader project dependency

**Changed**

* Updated childrenOf and childrenOfType type checking and tests
