### PR TITLE
feat(Icon): introduce pass-thru option

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
       "/cjs/"
     ],
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+      "[/\\\\]node_modules[/\\\\](?!(carbon-icons)).+\\.(js|jsx)$"
     ],
     "moduleFileExtensions": [
       "js",

--- a/src/components/Accordion/Accordion.Skeleton.js
+++ b/src/components/Accordion/Accordion.Skeleton.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import Icon from '../Icon';
 import SkeletonText from '../SkeletonText';
+import { iconChevronRight } from 'carbon-icons';
 
 export default class AccordionSkeleton extends React.Component {
   render() {
     const item = (
       <li className="bx--accordion__item">
         <button type="button" className="bx--accordion__heading">
-          <Icon className="bx--accordion__arrow" name="chevron--right" />
+          <Icon className="bx--accordion__arrow" icon={iconChevronRight} />
           <SkeletonText className="bx--accordion__title" />
         </button>
       </li>
@@ -16,7 +17,7 @@ export default class AccordionSkeleton extends React.Component {
       <ul className="bx--accordion bx--skeleton">
         <li className="bx--accordion__item bx--accordion__item--active">
           <button type="button" className="bx--accordion__heading">
-            <Icon className="bx--accordion__arrow" name="chevron--right" />
+            <Icon className="bx--accordion__arrow" icon={iconChevronRight} />
             <SkeletonText className="bx--accordion__title" />
           </button>
           <div className="bx--accordion__content">

--- a/src/components/AccordionItem/AccordionItem-test.js
+++ b/src/components/AccordionItem/AccordionItem-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconChevronRight } from 'carbon-icons';
 import AccordionItem from '../AccordionItem';
 import Icon from '../Icon';
 import { shallow, mount } from 'enzyme';
@@ -26,7 +27,7 @@ describe('AccordionItem', () => {
 
     it('should use correct icon', () => {
       const heading = wrapper.find('.bx--accordion__heading');
-      expect(heading.find(Icon).props().name).toEqual('chevron--right');
+      expect(heading.find(Icon).props().icon).toEqual(iconChevronRight);
     });
 
     it('has the expected classes', () => {

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import { iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 
 export default class AccordionItem extends Component {
@@ -80,7 +81,7 @@ export default class AccordionItem extends Component {
           onClick={this.handleHeadingClick}>
           <Icon
             className="bx--accordion__arrow"
-            name="chevron--right"
+            icon={iconChevronRight}
             description="Expand/Collapse"
           />
           <p className="bx--accordion__title">{title}</p>

--- a/src/components/Button/Button-story.js
+++ b/src/components/Button/Button-story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { iconAddSolid, iconSearch } from 'carbon-icons';
 import Button from '../Button';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 
@@ -83,7 +84,7 @@ storiesOf('Buttons', module)
           small
           {...buttonEvents}
           kind="ghost"
-          icon="add--solid"
+          icon={iconAddSolid}
           iconDescription="Add">
           Small ghost Button
         </Button>
@@ -119,13 +120,13 @@ storiesOf('Buttons', module)
     `,
     () => (
       <div>
-        <Button icon="search" iconDescription="Search" {...buttonEvents}>
+        <Button icon={iconSearch} iconDescription="Search" {...buttonEvents}>
           Primary with icon
         </Button>
         &nbsp;
         <Button
           kind="secondary"
-          icon="search"
+          icon={iconSearch}
           iconDescription="Search"
           {...buttonEvents}>
           Secondary with icon
@@ -134,7 +135,7 @@ storiesOf('Buttons', module)
         <Button
           small
           kind="primary"
-          icon="search"
+          icon={iconSearch}
           iconDescription="Search"
           {...buttonEvents}>
           Small primary with icon
@@ -143,7 +144,7 @@ storiesOf('Buttons', module)
         <Button
           small
           kind="secondary"
-          icon="search"
+          icon={iconSearch}
           iconDescription="Search"
           {...buttonEvents}>
           Small secondary with icon
@@ -164,7 +165,7 @@ storiesOf('Buttons', module)
         <Button
           kind="ghost"
           className="some-class"
-          icon="add--solid"
+          icon={iconAddSolid}
           iconDescription="Add"
           {...buttonEvents}>
           Ghost button
@@ -174,7 +175,7 @@ storiesOf('Buttons', module)
           kind="ghost"
           href="#"
           className="some-class"
-          icon="add--solid"
+          icon={iconAddSolid}
           iconDescription="Add"
           {...buttonEvents}>
           Ghost link

--- a/src/components/Button/Button-test.js
+++ b/src/components/Button/Button-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconSearch } from 'carbon-icons';
 import Button from '../Button';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 import { shallow, mount } from 'enzyme';
@@ -91,7 +92,7 @@ describe('Button', () => {
 
   describe('Renders icon buttons', () => {
     const iconButton = mount(
-      <Button icon="search" iconDescription="Search">
+      <Button icon={iconSearch} iconDescription="Search">
         Search
       </Button>
     );

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -34,7 +34,12 @@ const Button = ({
   };
 
   const buttonImage = icon ? (
-    <Icon name={icon} description={iconDescription} className="bx--btn__icon" />
+    <Icon
+      icon={Object(icon) === icon ? icon : undefined}
+      name={Object(icon) !== icon ? icon : undefined}
+      description={iconDescription}
+      className="bx--btn__icon"
+    />
   ) : null;
 
   const button = (
@@ -74,7 +79,15 @@ Button.propTypes = {
   tabIndex: PropTypes.number,
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
   role: PropTypes.string,
-  icon: PropTypes.string,
+  icon: PropTypes.oneOfType([
+    PropTypes.shape({
+      width: PropTypes.string,
+      height: PropTypes.string,
+      viewBox: PropTypes.string.isRequired,
+      svgData: PropTypes.object.isRequired,
+    }),
+    PropTypes.string,
+  ]),
   iconDescription: props => {
     if (props.icon && !props.iconDescription) {
       return new Error(

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { iconClose } from 'carbon-icons';
 import Button from '../Button';
 import Icon from '../Icon';
 import classNames from 'classnames';
@@ -165,7 +166,7 @@ export class ModalHeader extends Component {
           className={closeClass}
           type="button">
           <Icon
-            name="close"
+            icon={iconClose}
             className={closeIconClass}
             description={iconDescription}
           />

--- a/src/components/CopyButton/CopyButton-test.js
+++ b/src/components/CopyButton/CopyButton-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconCopy } from 'carbon-icons';
 import CopyButton from '../CopyButton';
 import Icon from '../Icon';
 import { shallow, mount } from 'enzyme';
@@ -29,7 +30,7 @@ describe('CopyButton', () => {
       expect(wrapper.hasClass('bx--snippet-button')).toBe(true);
       expect(wrapper.find('.bx--btn--copy__feedback').length).toBe(1);
       expect(wrapper.find(Icon).length).toBe(1);
-      expect(wrapper.find(Icon).props().name).toBe('copy');
+      expect(wrapper.find(Icon).props().icon).toBe(iconCopy);
     });
 
     it('Should be able to disable the button', () => {

--- a/src/components/CopyButton/CopyButton.js
+++ b/src/components/CopyButton/CopyButton.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import { iconCopy } from 'carbon-icons';
 import Icon from '../Icon';
 
 export default class CopyButton extends Component {
@@ -57,7 +58,7 @@ export default class CopyButton extends Component {
         {...other}>
         <Icon
           className="bx--snippet__icon"
-          name="copy"
+          icon={iconCopy}
           description={iconDescription}
         />
         <div className={feedbackClassNames} data-feedback={feedback} />

--- a/src/components/DangerButton/DangerButton-test.js
+++ b/src/components/DangerButton/DangerButton-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import DangerButton from '../DangerButton';
 import { shallow, mount } from 'enzyme';
+import { iconSearch } from 'carbon-icons';
 
 describe('DangerButton', () => {
   describe('Renders as expected', () => {
@@ -30,7 +31,7 @@ describe('DangerButton', () => {
 
     describe('Renders icon buttons', () => {
       const iconButton = mount(
-        <DangerButton icon="search" iconDescription="Search">
+        <DangerButton icon={iconSearch} iconDescription="Search">
           Search
         </DangerButton>
       );

--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -22,6 +22,7 @@ import DataTable, {
   TableToolbarSearch,
 } from '../DataTable';
 import Button from '../Button';
+import { iconDownload, iconEdit, iconSettings } from 'carbon-icons';
 
 const initialRows = [
   {
@@ -128,17 +129,17 @@ storiesOf('DataTable', module)
               <TableToolbarSearch onChange={onInputChange} />
               <TableToolbarContent>
                 <TableToolbarAction
-                  iconName="download"
+                  icon={iconDownload}
                   iconDescription="Download"
                   onClick={action('TableToolbarAction - Download')}
                 />
                 <TableToolbarAction
-                  iconName="edit"
+                  icon={iconEdit}
                   iconDescription="Edit"
                   onClick={action('TableToolbarAction - Edit')}
                 />
                 <TableToolbarAction
-                  iconName="settings"
+                  icon={iconSettings}
                   iconDescription="Settings"
                   onClick={action('TableToolbarAction - Settings')}
                 />
@@ -192,17 +193,17 @@ storiesOf('DataTable', module)
               <TableToolbarSearch onChange={onInputChange} />
               <TableToolbarContent>
                 <TableToolbarAction
-                  iconName="download"
+                  icon={iconDownload}
                   iconDescription="Download"
                   onClick={action('TableToolbarAction - Download')}
                 />
                 <TableToolbarAction
-                  iconName="edit"
+                  icon={iconEdit}
                   iconDescription="Edit"
                   onClick={action('TableToolbarAction - Edit')}
                 />
                 <TableToolbarAction
-                  iconName="settings"
+                  icon={iconSettings}
                   iconDescription="Settings"
                   onClick={action('TableToolbarAction - Settings')}
                 />
@@ -413,17 +414,17 @@ storiesOf('DataTable', module)
               <TableToolbarSearch onChange={onInputChange} />
               <TableToolbarContent>
                 <TableToolbarAction
-                  iconName="download"
+                  icon={iconDownload}
                   iconDescription="Download"
                   onClick={action('TableToolbarAction - Download')}
                 />
                 <TableToolbarAction
-                  iconName="edit"
+                  icon={iconEdit}
                   iconDescription="Edit"
                   onClick={action('TableToolbarAction - Edit')}
                 />
                 <TableToolbarAction
-                  iconName="settings"
+                  icon={iconSettings}
                   iconDescription="Settings"
                   onClick={action('TableToolbarAction - Settings')}
                 />
@@ -583,17 +584,17 @@ storiesOf('DataTable', module)
                     <TableToolbarSearch onChange={onInputChange} />
                     <TableToolbarContent>
                       <TableToolbarAction
-                        iconName="download"
+                        icon={iconDownload}
                         iconDescription="Download"
                         onClick={action('TableToolbarAction - Download')}
                       />
                       <TableToolbarAction
-                        iconName="edit"
+                        icon={iconEdit}
                         iconDescription="Edit"
                         onClick={action('TableToolbarAction - Edit')}
                       />
                       <TableToolbarAction
-                        iconName="settings"
+                        icon={iconSettings}
                         iconDescription="Settings"
                         onClick={action('TableToolbarAction - Settings')}
                       />

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -516,17 +516,17 @@ In practice, this looks like the following:
         <TableToolbarSearch onChange={onInputChange} />
         <TableToolbarContent>
           <TableToolbarAction
-            iconName="download"
+            icon={iconDownload}
             iconDescription="Download"
             onClick={action('TableToolbarAction - Download')}
           />
           <TableToolbarAction
-            iconName="edit"
+            icon={iconEdit}
             iconDescription="Edit"
             onClick={action('TableToolbarAction - Edit')}
           />
           <TableToolbarAction
-            iconName="settings"
+            icon={iconSettings}
             iconDescription="Settings"
             onClick={action('TableToolbarAction - Settings')}
           />
@@ -607,17 +607,17 @@ In practice, this looks like the following:
         <TableToolbarSearch onChange={onInputChange} />
         <TableToolbarContent>
           <TableToolbarAction
-            iconName="download"
+            icon={iconDownload}
             iconDescription="Download"
             onClick={action('TableToolbarAction - Download')}
           />
           <TableToolbarAction
-            iconName="edit"
+            icon={iconEdit}
             iconDescription="Edit"
             onClick={action('TableToolbarAction - Edit')}
           />
           <TableToolbarAction
-            iconName="settings"
+            icon={iconSettings}
             iconDescription="Settings"
             onClick={action('TableToolbarAction - Settings')}
           />

--- a/src/components/DataTable/TableBatchAction.js
+++ b/src/components/DataTable/TableBatchAction.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { iconAddSolid } from 'carbon-icons';
 import Button from '../Button';
 
 const TableBatchAction = props => (
-  <Button small kind="ghost" icon="add--solid" {...props} />
+  <Button small kind="ghost" icon={iconAddSolid} {...props} />
 );
 
 TableBatchAction.propTypes = {

--- a/src/components/DataTable/TableExpandRow.js
+++ b/src/components/DataTable/TableExpandRow.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 import TableCell from './TableCell';
 
@@ -33,7 +34,7 @@ const TableExpandRow = ({
           aria-label={ariaLabel}>
           <Icon
             className="bx--table-expand-v2__svg"
-            name="chevron--right"
+            icon={iconChevronRight}
             description={expandIconDescription}
           />
         </button>

--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import { sortStates } from './state/sorting';
 
@@ -54,7 +55,7 @@ const TableHeader = ({
         <span className="bx--table-header-label">{children}</span>
         <Icon
           className="bx--table-sort-v2__icon"
-          name="caret--down"
+          icon={iconCaretDown}
           description={t('carbon.table.header.icon.description', {
             header: children,
             sortDirection,

--- a/src/components/DataTable/TableToolbarAction.js
+++ b/src/components/DataTable/TableToolbarAction.js
@@ -5,6 +5,7 @@ import Icon from '../Icon';
 
 const TableToolbarAction = ({
   className,
+  icon,
   iconName,
   iconDescription,
   ...rest
@@ -14,6 +15,7 @@ const TableToolbarAction = ({
     <button className={toolbarActionClasses} {...rest}>
       <Icon
         className="bx--toolbar-action__icon"
+        icon={icon}
         name={iconName}
         description={iconDescription}
       />
@@ -26,9 +28,19 @@ TableToolbarAction.propTypes = {
   className: PropTypes.string,
 
   /**
+   * Specify the icon for the toolbar action
+   */
+  icon: PropTypes.shape({
+    width: PropTypes.string,
+    height: PropTypes.string,
+    viewBox: PropTypes.string.isRequired,
+    svgData: PropTypes.object.isRequired,
+  }).isRequired,
+
+  /**
    * Specify the name of the icon for the toolbar action
    */
-  iconName: PropTypes.string.isRequired,
+  iconName: PropTypes.string,
 
   /**
    * Specify the description of the icon for the toolbar action

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconDownload, iconEdit, iconSettings } from 'carbon-icons';
 import Button from '../../Button';
 import DataTable, {
   Table,
@@ -72,17 +73,17 @@ describe('DataTable', () => {
             <TableToolbarSearch onChange={onInputChange} id="custom-id" />
             <TableToolbarContent>
               <TableToolbarAction
-                iconName="download"
+                icon={iconDownload}
                 iconDescription="Download"
                 onClick={jest.fn()}
               />
               <TableToolbarAction
-                iconName="edit"
+                icon={iconEdit}
                 iconDescription="Edit"
                 onClick={jest.fn()}
               />
               <TableToolbarAction
-                iconName="settings"
+                icon={iconSettings}
                 iconDescription="Settings"
                 onClick={jest.fn()}
               />

--- a/src/components/DataTable/__tests__/TableToolbarAction-test.js
+++ b/src/components/DataTable/__tests__/TableToolbarAction-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { iconAddSolid } from 'carbon-icons';
 import { TableToolbarAction } from '../';
 
 describe('DataTable.TableToolbarAction', () => {
@@ -7,7 +8,7 @@ describe('DataTable.TableToolbarAction', () => {
     const wrapper = mount(
       <TableToolbarAction
         className="custom-class"
-        iconName="add--solid"
+        icon={iconAddSolid}
         iconDescription="Add"
       />
     );

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -130,7 +130,29 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                           className="bx--table-sort-v2__icon"
                           description="Sort rows by this header in descending order"
                           fillRule="evenodd"
-                          name="caret--down"
+                          icon={
+                            Object {
+                              "height": "5",
+                              "id": "icon--caret--down",
+                              "name": "icon--caret--down",
+                              "styles": "",
+                              "svgData": Object {
+                                "circles": "",
+                                "ellipses": "",
+                                "paths": Array [
+                                  Object {
+                                    "d": "M0 0l5 4.998L10 0z",
+                                  },
+                                ],
+                                "polygons": "",
+                                "polylines": "",
+                                "rects": "",
+                              },
+                              "tags": "icon--caret--down",
+                              "viewBox": "0 0 10 5",
+                              "width": "10",
+                            }
+                          }
                           role="img"
                         >
                           <svg
@@ -139,7 +161,6 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                             className="bx--table-sort-v2__icon"
                             fillRule="evenodd"
                             height="5"
-                            name="caret--down"
                             role="img"
                             viewBox="0 0 10 5"
                             width="10"
@@ -181,7 +202,29 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                           className="bx--table-sort-v2__icon"
                           description="Sort rows by this header in descending order"
                           fillRule="evenodd"
-                          name="caret--down"
+                          icon={
+                            Object {
+                              "height": "5",
+                              "id": "icon--caret--down",
+                              "name": "icon--caret--down",
+                              "styles": "",
+                              "svgData": Object {
+                                "circles": "",
+                                "ellipses": "",
+                                "paths": Array [
+                                  Object {
+                                    "d": "M0 0l5 4.998L10 0z",
+                                  },
+                                ],
+                                "polygons": "",
+                                "polylines": "",
+                                "rects": "",
+                              },
+                              "tags": "icon--caret--down",
+                              "viewBox": "0 0 10 5",
+                              "width": "10",
+                            }
+                          }
                           role="img"
                         >
                           <svg
@@ -190,7 +233,6 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                             className="bx--table-sort-v2__icon"
                             fillRule="evenodd"
                             height="5"
-                            name="caret--down"
                             role="img"
                             viewBox="0 0 10 5"
                             width="10"
@@ -457,7 +499,29 @@ exports[`DataTable selection should render 1`] = `
                           className="bx--table-sort-v2__icon"
                           description="Sort rows by this header in descending order"
                           fillRule="evenodd"
-                          name="caret--down"
+                          icon={
+                            Object {
+                              "height": "5",
+                              "id": "icon--caret--down",
+                              "name": "icon--caret--down",
+                              "styles": "",
+                              "svgData": Object {
+                                "circles": "",
+                                "ellipses": "",
+                                "paths": Array [
+                                  Object {
+                                    "d": "M0 0l5 4.998L10 0z",
+                                  },
+                                ],
+                                "polygons": "",
+                                "polylines": "",
+                                "rects": "",
+                              },
+                              "tags": "icon--caret--down",
+                              "viewBox": "0 0 10 5",
+                              "width": "10",
+                            }
+                          }
                           role="img"
                         >
                           <svg
@@ -466,7 +530,6 @@ exports[`DataTable selection should render 1`] = `
                             className="bx--table-sort-v2__icon"
                             fillRule="evenodd"
                             height="5"
-                            name="caret--down"
                             role="img"
                             viewBox="0 0 10 5"
                             width="10"
@@ -508,7 +571,29 @@ exports[`DataTable selection should render 1`] = `
                           className="bx--table-sort-v2__icon"
                           description="Sort rows by this header in descending order"
                           fillRule="evenodd"
-                          name="caret--down"
+                          icon={
+                            Object {
+                              "height": "5",
+                              "id": "icon--caret--down",
+                              "name": "icon--caret--down",
+                              "styles": "",
+                              "svgData": Object {
+                                "circles": "",
+                                "ellipses": "",
+                                "paths": Array [
+                                  Object {
+                                    "d": "M0 0l5 4.998L10 0z",
+                                  },
+                                ],
+                                "polygons": "",
+                                "polylines": "",
+                                "rects": "",
+                              },
+                              "tags": "icon--caret--down",
+                              "viewBox": "0 0 10 5",
+                              "width": "10",
+                            }
+                          }
                           role="img"
                         >
                           <svg
@@ -517,7 +602,6 @@ exports[`DataTable selection should render 1`] = `
                             className="bx--table-sort-v2__icon"
                             fillRule="evenodd"
                             height="5"
-                            name="caret--down"
                             role="img"
                             viewBox="0 0 10 5"
                             width="10"
@@ -899,7 +983,30 @@ exports[`DataTable should render 1`] = `
                     className="bx--search-magnifier"
                     description="Filter table"
                     fillRule="evenodd"
-                    name="search"
+                    icon={
+                      Object {
+                        "height": "16",
+                        "id": "icon--search",
+                        "name": "icon--search",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--search",
+                        "viewBox": "0 0 16 16",
+                        "width": "16",
+                      }
+                    }
                     role="img"
                   >
                     <svg
@@ -908,7 +1015,6 @@ exports[`DataTable should render 1`] = `
                       className="bx--search-magnifier"
                       fillRule="evenodd"
                       height="16"
-                      name="search"
                       role="img"
                       viewBox="0 0 16 16"
                       width="16"
@@ -943,7 +1049,29 @@ exports[`DataTable should render 1`] = `
                     <Icon
                       description="Provide a description that will be used as the title"
                       fillRule="evenodd"
-                      name="close--solid"
+                      icon={
+                        Object {
+                          "height": "16",
+                          "id": "icon--close--solid",
+                          "name": "icon--close--solid",
+                          "styles": "",
+                          "svgData": Object {
+                            "circles": "",
+                            "ellipses": "",
+                            "paths": Array [
+                              Object {
+                                "d": "M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z",
+                              },
+                            ],
+                            "polygons": "",
+                            "polylines": "",
+                            "rects": "",
+                          },
+                          "tags": "icon--close--solid",
+                          "viewBox": "0 0 16 16",
+                          "width": "16",
+                        }
+                      }
                       role="img"
                     >
                       <svg
@@ -951,7 +1079,6 @@ exports[`DataTable should render 1`] = `
                         aria-label="Provide a description that will be used as the title"
                         fillRule="evenodd"
                         height="16"
-                        name="close--solid"
                         role="img"
                         viewBox="0 0 16 16"
                         width="16"
@@ -975,8 +1102,30 @@ exports[`DataTable should render 1`] = `
               className="bx--toolbar-content"
             >
               <TableToolbarAction
+                icon={
+                  Object {
+                    "height": "16",
+                    "id": "icon--download",
+                    "name": "icon--download",
+                    "styles": "",
+                    "svgData": Object {
+                      "circles": "",
+                      "ellipses": "",
+                      "paths": Array [
+                        Object {
+                          "d": "M7.5 11l4.1-4.4.7.7L7 13 1.6 7.3l.7-.7L6.5 11V0h1v11zm5.5 4v-2h1v2c0 .6-.4 1-1 1H1c-.6 0-1-.4-1-1v-2h1v2h12z",
+                        },
+                      ],
+                      "polygons": "",
+                      "polylines": "",
+                      "rects": "",
+                    },
+                    "tags": "icon--download",
+                    "viewBox": "0 0 14 16",
+                    "width": "14",
+                  }
+                }
                 iconDescription="Download"
-                iconName="download"
                 onClick={[MockFunction]}
               >
                 <button
@@ -987,7 +1136,29 @@ exports[`DataTable should render 1`] = `
                     className="bx--toolbar-action__icon"
                     description="Download"
                     fillRule="evenodd"
-                    name="download"
+                    icon={
+                      Object {
+                        "height": "16",
+                        "id": "icon--download",
+                        "name": "icon--download",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M7.5 11l4.1-4.4.7.7L7 13 1.6 7.3l.7-.7L6.5 11V0h1v11zm5.5 4v-2h1v2c0 .6-.4 1-1 1H1c-.6 0-1-.4-1-1v-2h1v2h12z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--download",
+                        "viewBox": "0 0 14 16",
+                        "width": "14",
+                      }
+                    }
                     role="img"
                   >
                     <svg
@@ -996,7 +1167,6 @@ exports[`DataTable should render 1`] = `
                       className="bx--toolbar-action__icon"
                       fillRule="evenodd"
                       height="16"
-                      name="download"
                       role="img"
                       viewBox="0 0 14 16"
                       width="14"
@@ -1013,8 +1183,31 @@ exports[`DataTable should render 1`] = `
                 </button>
               </TableToolbarAction>
               <TableToolbarAction
+                icon={
+                  Object {
+                    "height": "16",
+                    "id": "icon--edit",
+                    "name": "icon--edit",
+                    "styles": "",
+                    "svgData": Object {
+                      "circles": "",
+                      "ellipses": "",
+                      "paths": Array [
+                        Object {
+                          "d": "M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z",
+                          "fill-rule": "nonzero",
+                        },
+                      ],
+                      "polygons": "",
+                      "polylines": "",
+                      "rects": "",
+                    },
+                    "tags": "icon--edit",
+                    "viewBox": "0 0 16 16",
+                    "width": "16",
+                  }
+                }
                 iconDescription="Edit"
-                iconName="edit"
                 onClick={[MockFunction]}
               >
                 <button
@@ -1025,7 +1218,30 @@ exports[`DataTable should render 1`] = `
                     className="bx--toolbar-action__icon"
                     description="Edit"
                     fillRule="evenodd"
-                    name="edit"
+                    icon={
+                      Object {
+                        "height": "16",
+                        "id": "icon--edit",
+                        "name": "icon--edit",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--edit",
+                        "viewBox": "0 0 16 16",
+                        "width": "16",
+                      }
+                    }
                     role="img"
                   >
                     <svg
@@ -1034,7 +1250,6 @@ exports[`DataTable should render 1`] = `
                       className="bx--toolbar-action__icon"
                       fillRule="evenodd"
                       height="16"
-                      name="edit"
                       role="img"
                       viewBox="0 0 16 16"
                       width="16"
@@ -1051,8 +1266,33 @@ exports[`DataTable should render 1`] = `
                 </button>
               </TableToolbarAction>
               <TableToolbarAction
+                icon={
+                  Object {
+                    "height": "16",
+                    "id": "icon--settings",
+                    "name": "icon--settings",
+                    "styles": "",
+                    "svgData": Object {
+                      "circles": "",
+                      "ellipses": "",
+                      "paths": Array [
+                        Object {
+                          "d": "M7.5 10.5C8.9 10.5 10 9.4 10 8S8.9 5.5 7.5 5.5 5 6.6 5 8s1.2 2.5 2.5 2.5zm0 1C5.6 11.5 4 9.9 4 8s1.6-3.5 3.5-3.5S11 6.1 11 8s-1.5 3.5-3.5 3.5z",
+                        },
+                        Object {
+                          "d": "M6.3 2.6l-.3.1c-.7.2-1.3.5-1.9 1l-.2.2-1.4-.8-1.3 1.8L2.4 6l-.1.2C2.1 6.8 2 7.4 2 8c0 .3 0 .7.1 1l.1.3-1.2 1L2.2 12l1.1-.6.3.3c.6.8 1.4 1.3 2.4 1.6l.3.1.2 1.6h2.1l.2-1.6.3-.1c.8-.2 1.6-.7 2.2-1.3l.3-.2 1.1.6 1.2-1.7-1.1-1 .1-.3c.1-.5.1-1 .1-1.4 0-.5-.1-1.1-.2-1.6l-.1-.3 1.2-1-1.2-1.7-1.4.6-.3-.2c-.6-.5-1.3-.9-2-1.1l-.2-.1L8.6 1H6.5l-.2 1.6zM5.5.9c0-.5.5-.9 1-.9h2.1c.5 0 .9.4 1 .9l.1 1c.6.2 1.2.5 1.8 1l.7-.4c.4-.2 1-.1 1.3.3l1.2 1.7c.3.4.2 1-.1 1.3l-.7.6c.1.5.1 1.1.1 1.6 0 .4 0 .8-.1 1.3l.6.6c.4.3.4.9.1 1.3l-1.2 1.7c-.3.4-.8.5-1.3.3l-.4-.2c-.6.5-1.3.9-2 1.2l-.1 1c-.1.5-.5.9-1 .9H6.5c-.5 0-.9-.4-1-.9l-.1-1c-.8-.3-1.6-.8-2.3-1.4l-.4.2c-.4.2-1 .1-1.3-.3L.2 11c-.3-.4-.2-1 .1-1.3l.8-.7c0-.4-.1-.7-.1-1 0-.6.1-1.2.2-1.8l-.6-.6C.2 5.3.1 4.7.4 4.3l1.2-1.7c.3-.5.9-.6 1.3-.4l.9.5c.5-.3 1-.6 1.6-.8l.1-1z",
+                        },
+                      ],
+                      "polygons": "",
+                      "polylines": "",
+                      "rects": "",
+                    },
+                    "tags": "icon--settings",
+                    "viewBox": "0 0 15 16",
+                    "width": "15",
+                  }
+                }
                 iconDescription="Settings"
-                iconName="settings"
                 onClick={[MockFunction]}
               >
                 <button
@@ -1063,7 +1303,32 @@ exports[`DataTable should render 1`] = `
                     className="bx--toolbar-action__icon"
                     description="Settings"
                     fillRule="evenodd"
-                    name="settings"
+                    icon={
+                      Object {
+                        "height": "16",
+                        "id": "icon--settings",
+                        "name": "icon--settings",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M7.5 10.5C8.9 10.5 10 9.4 10 8S8.9 5.5 7.5 5.5 5 6.6 5 8s1.2 2.5 2.5 2.5zm0 1C5.6 11.5 4 9.9 4 8s1.6-3.5 3.5-3.5S11 6.1 11 8s-1.5 3.5-3.5 3.5z",
+                            },
+                            Object {
+                              "d": "M6.3 2.6l-.3.1c-.7.2-1.3.5-1.9 1l-.2.2-1.4-.8-1.3 1.8L2.4 6l-.1.2C2.1 6.8 2 7.4 2 8c0 .3 0 .7.1 1l.1.3-1.2 1L2.2 12l1.1-.6.3.3c.6.8 1.4 1.3 2.4 1.6l.3.1.2 1.6h2.1l.2-1.6.3-.1c.8-.2 1.6-.7 2.2-1.3l.3-.2 1.1.6 1.2-1.7-1.1-1 .1-.3c.1-.5.1-1 .1-1.4 0-.5-.1-1.1-.2-1.6l-.1-.3 1.2-1-1.2-1.7-1.4.6-.3-.2c-.6-.5-1.3-.9-2-1.1l-.2-.1L8.6 1H6.5l-.2 1.6zM5.5.9c0-.5.5-.9 1-.9h2.1c.5 0 .9.4 1 .9l.1 1c.6.2 1.2.5 1.8 1l.7-.4c.4-.2 1-.1 1.3.3l1.2 1.7c.3.4.2 1-.1 1.3l-.7.6c.1.5.1 1.1.1 1.6 0 .4 0 .8-.1 1.3l.6.6c.4.3.4.9.1 1.3l-1.2 1.7c-.3.4-.8.5-1.3.3l-.4-.2c-.6.5-1.3.9-2 1.2l-.1 1c-.1.5-.5.9-1 .9H6.5c-.5 0-.9-.4-1-.9l-.1-1c-.8-.3-1.6-.8-2.3-1.4l-.4.2c-.4.2-1 .1-1.3-.3L.2 11c-.3-.4-.2-1 .1-1.3l.8-.7c0-.4-.1-.7-.1-1 0-.6.1-1.2.2-1.8l-.6-.6C.2 5.3.1 4.7.4 4.3l1.2-1.7c.3-.5.9-.6 1.3-.4l.9.5c.5-.3 1-.6 1.6-.8l.1-1z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--settings",
+                        "viewBox": "0 0 15 16",
+                        "width": "15",
+                      }
+                    }
                     role="img"
                   >
                     <svg
@@ -1072,7 +1337,6 @@ exports[`DataTable should render 1`] = `
                       className="bx--toolbar-action__icon"
                       fillRule="evenodd"
                       height="16"
-                      name="settings"
                       role="img"
                       viewBox="0 0 15 16"
                       width="15"
@@ -1148,7 +1412,29 @@ exports[`DataTable should render 1`] = `
                           className="bx--table-sort-v2__icon"
                           description="Sort rows by this header in descending order"
                           fillRule="evenodd"
-                          name="caret--down"
+                          icon={
+                            Object {
+                              "height": "5",
+                              "id": "icon--caret--down",
+                              "name": "icon--caret--down",
+                              "styles": "",
+                              "svgData": Object {
+                                "circles": "",
+                                "ellipses": "",
+                                "paths": Array [
+                                  Object {
+                                    "d": "M0 0l5 4.998L10 0z",
+                                  },
+                                ],
+                                "polygons": "",
+                                "polylines": "",
+                                "rects": "",
+                              },
+                              "tags": "icon--caret--down",
+                              "viewBox": "0 0 10 5",
+                              "width": "10",
+                            }
+                          }
                           role="img"
                         >
                           <svg
@@ -1157,7 +1443,6 @@ exports[`DataTable should render 1`] = `
                             className="bx--table-sort-v2__icon"
                             fillRule="evenodd"
                             height="5"
-                            name="caret--down"
                             role="img"
                             viewBox="0 0 10 5"
                             width="10"
@@ -1199,7 +1484,29 @@ exports[`DataTable should render 1`] = `
                           className="bx--table-sort-v2__icon"
                           description="Sort rows by this header in descending order"
                           fillRule="evenodd"
-                          name="caret--down"
+                          icon={
+                            Object {
+                              "height": "5",
+                              "id": "icon--caret--down",
+                              "name": "icon--caret--down",
+                              "styles": "",
+                              "svgData": Object {
+                                "circles": "",
+                                "ellipses": "",
+                                "paths": Array [
+                                  Object {
+                                    "d": "M0 0l5 4.998L10 0z",
+                                  },
+                                ],
+                                "polygons": "",
+                                "polylines": "",
+                                "rects": "",
+                              },
+                              "tags": "icon--caret--down",
+                              "viewBox": "0 0 10 5",
+                              "width": "10",
+                            }
+                          }
                           role="img"
                         >
                           <svg
@@ -1208,7 +1515,6 @@ exports[`DataTable should render 1`] = `
                             className="bx--table-sort-v2__icon"
                             fillRule="evenodd"
                             height="5"
-                            name="caret--down"
                             role="img"
                             viewBox="0 0 10 5"
                             width="10"

--- a/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
@@ -8,7 +8,29 @@ exports[`DataTable.TableBatchAction should render 1`] = `
   <Button
     className="custom-class"
     disabled={false}
-    icon="add--solid"
+    icon={
+      Object {
+        "height": "16",
+        "id": "icon--add--solid",
+        "name": "icon--add--solid",
+        "styles": "",
+        "svgData": Object {
+          "circles": "",
+          "ellipses": "",
+          "paths": Array [
+            Object {
+              "d": "M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z",
+            },
+          ],
+          "polygons": "",
+          "polylines": "",
+          "rects": "",
+        },
+        "tags": "icon--add--solid",
+        "viewBox": "0 0 16 16",
+        "width": "16",
+      }
+    }
     iconDescription="Add"
     kind="ghost"
     small={true}
@@ -25,7 +47,29 @@ exports[`DataTable.TableBatchAction should render 1`] = `
         className="bx--btn__icon"
         description="Add"
         fillRule="evenodd"
-        name="add--solid"
+        icon={
+          Object {
+            "height": "16",
+            "id": "icon--add--solid",
+            "name": "icon--add--solid",
+            "styles": "",
+            "svgData": Object {
+              "circles": "",
+              "ellipses": "",
+              "paths": Array [
+                Object {
+                  "d": "M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z",
+                },
+              ],
+              "polygons": "",
+              "polylines": "",
+              "rects": "",
+            },
+            "tags": "icon--add--solid",
+            "viewBox": "0 0 16 16",
+            "width": "16",
+          }
+        }
         role="img"
       >
         <svg
@@ -34,7 +78,6 @@ exports[`DataTable.TableBatchAction should render 1`] = `
           className="bx--btn__icon"
           fillRule="evenodd"
           height="16"
-          name="add--solid"
           role="img"
           viewBox="0 0 16 16"
           width="16"

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -32,7 +32,30 @@ exports[`DataTable.TableExpandRow should render 1`] = `
                     className="bx--table-expand-v2__svg"
                     description="Provide a description that will be used as the title"
                     fillRule="evenodd"
-                    name="chevron--right"
+                    icon={
+                      Object {
+                        "height": "12",
+                        "id": "icon--chevron--right",
+                        "name": "icon--chevron--right",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--chevron--right",
+                        "viewBox": "0 0 7 12",
+                        "width": "7",
+                      }
+                    }
                     role="img"
                   >
                     <svg
@@ -41,7 +64,6 @@ exports[`DataTable.TableExpandRow should render 1`] = `
                       className="bx--table-expand-v2__svg"
                       fillRule="evenodd"
                       height="12"
-                      name="chevron--right"
                       role="img"
                       viewBox="0 0 7 12"
                       width="7"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarAction-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarAction-test.js.snap
@@ -3,8 +3,30 @@
 exports[`DataTable.TableToolbarAction should render 1`] = `
 <TableToolbarAction
   className="custom-class"
+  icon={
+    Object {
+      "height": "16",
+      "id": "icon--add--solid",
+      "name": "icon--add--solid",
+      "styles": "",
+      "svgData": Object {
+        "circles": "",
+        "ellipses": "",
+        "paths": Array [
+          Object {
+            "d": "M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z",
+          },
+        ],
+        "polygons": "",
+        "polylines": "",
+        "rects": "",
+      },
+      "tags": "icon--add--solid",
+      "viewBox": "0 0 16 16",
+      "width": "16",
+    }
+  }
   iconDescription="Add"
-  iconName="add--solid"
 >
   <button
     className="custom-class bx--toolbar-action"
@@ -13,7 +35,29 @@ exports[`DataTable.TableToolbarAction should render 1`] = `
       className="bx--toolbar-action__icon"
       description="Add"
       fillRule="evenodd"
-      name="add--solid"
+      icon={
+        Object {
+          "height": "16",
+          "id": "icon--add--solid",
+          "name": "icon--add--solid",
+          "styles": "",
+          "svgData": Object {
+            "circles": "",
+            "ellipses": "",
+            "paths": Array [
+              Object {
+                "d": "M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z",
+              },
+            ],
+            "polygons": "",
+            "polylines": "",
+            "rects": "",
+          },
+          "tags": "icon--add--solid",
+          "viewBox": "0 0 16 16",
+          "width": "16",
+        }
+      }
       role="img"
     >
       <svg
@@ -22,7 +66,6 @@ exports[`DataTable.TableToolbarAction should render 1`] = `
         className="bx--toolbar-action__icon"
         fillRule="evenodd"
         height="16"
-        name="add--solid"
         role="img"
         viewBox="0 0 16 16"
         width="16"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -28,7 +28,30 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
           className="bx--search-magnifier"
           description="Filter table"
           fillRule="evenodd"
-          name="search"
+          icon={
+            Object {
+              "height": "16",
+              "id": "icon--search",
+              "name": "icon--search",
+              "styles": "",
+              "svgData": Object {
+                "circles": "",
+                "ellipses": "",
+                "paths": Array [
+                  Object {
+                    "d": "M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z",
+                    "fill-rule": "nonzero",
+                  },
+                ],
+                "polygons": "",
+                "polylines": "",
+                "rects": "",
+              },
+              "tags": "icon--search",
+              "viewBox": "0 0 16 16",
+              "width": "16",
+            }
+          }
           role="img"
         >
           <svg
@@ -37,7 +60,6 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
             className="bx--search-magnifier"
             fillRule="evenodd"
             height="16"
-            name="search"
             role="img"
             viewBox="0 0 16 16"
             width="16"
@@ -72,7 +94,29 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
           <Icon
             description="Provide a description that will be used as the title"
             fillRule="evenodd"
-            name="close--solid"
+            icon={
+              Object {
+                "height": "16",
+                "id": "icon--close--solid",
+                "name": "icon--close--solid",
+                "styles": "",
+                "svgData": Object {
+                  "circles": "",
+                  "ellipses": "",
+                  "paths": Array [
+                    Object {
+                      "d": "M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z",
+                    },
+                  ],
+                  "polygons": "",
+                  "polylines": "",
+                  "rects": "",
+                },
+                "tags": "icon--close--solid",
+                "viewBox": "0 0 16 16",
+                "width": "16",
+              }
+            }
             role="img"
           >
             <svg
@@ -80,7 +124,6 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
               aria-label="Provide a description that will be used as the title"
               fillRule="evenodd"
               height="16"
-              name="close--solid"
               role="img"
               viewBox="0 0 16 16"
               width="16"

--- a/src/components/Dropdown/Dropdown-test.js
+++ b/src/components/Dropdown/Dropdown-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconCaretDown } from 'carbon-icons';
 import Dropdown from '../Dropdown';
 import DropdownItem from '../DropdownItem';
 import Icon from '../Icon';
@@ -58,7 +59,7 @@ describe('Dropdown', () => {
 
     it('should use correct icon', () => {
       const icon = mounted.find(Icon);
-      expect(icon.props().name).toEqual('caret--down');
+      expect(icon.props().icon).toEqual(iconCaretDown);
     });
 
     it('has the expected default iconDescription', () => {

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import warning from 'warning';
+import { iconCaretDown } from 'carbon-icons';
 import ClickListener from '../../internal/ClickListener';
 import Icon from '../Icon';
 
@@ -172,7 +173,7 @@ export default class Dropdown extends PureComponent {
           <li className="bx--dropdown-text">{this.state.selectedText}</li>
           <li>
             <Icon
-              name="caret--down"
+              icon={iconCaretDown}
               className="bx--dropdown__arrow"
               description={iconDescription}
             />

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -110,7 +110,29 @@ exports[`DropdownV2 should render 1`] = `
                   alt="Open menu"
                   description="Open menu"
                   fillRule="evenodd"
-                  name="caret--down"
+                  icon={
+                    Object {
+                      "height": "5",
+                      "id": "icon--caret--down",
+                      "name": "icon--caret--down",
+                      "styles": "",
+                      "svgData": Object {
+                        "circles": "",
+                        "ellipses": "",
+                        "paths": Array [
+                          Object {
+                            "d": "M0 0l5 4.998L10 0z",
+                          },
+                        ],
+                        "polygons": "",
+                        "polylines": "",
+                        "rects": "",
+                      },
+                      "tags": "icon--caret--down",
+                      "viewBox": "0 0 10 5",
+                      "width": "10",
+                    }
+                  }
                   role="img"
                 >
                   <svg
@@ -118,7 +140,6 @@ exports[`DropdownV2 should render 1`] = `
                     aria-label="Open menu"
                     fillRule="evenodd"
                     height="5"
-                    name="caret--down"
                     role="img"
                     viewBox="0 0 10 5"
                     width="10"

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import Icon from '../Icon';
 import uid from '../../tools/uniqueId';
 import { ButtonTypes } from '../../prop-types/types';
+import { iconCloseSolid, iconCheckmarkSolid } from 'carbon-icons';
 
 export class FileUploaderButton extends Component {
   static propTypes = {
@@ -144,7 +145,7 @@ export class Filename extends Component {
         <Icon
           description={iconDescription}
           className="bx--file-close"
-          name="close--solid"
+          icon={iconCloseSolid}
           style={style}
           {...other}
         />
@@ -154,7 +155,7 @@ export class Filename extends Component {
         <Icon
           description={iconDescription}
           className="bx--file-complete"
-          name="checkmark--solid"
+          icon={iconCheckmarkSolid}
           style={style}
           {...other}
         />

--- a/src/components/Icon/Icon-story.js
+++ b/src/components/Icon/Icon-story.js
@@ -1,7 +1,11 @@
 import React from 'react';
+import { iconAdd, iconAddSolid, iconAddOutline } from 'carbon-icons';
+import iconsList from 'carbon-icons';
 import { storiesOf } from '@storybook/react';
-import Icon from '../Icon';
+import Icon, { setIconsList } from '../Icon';
 import IconSkeleton from '../Icon/Icon.Skeleton';
+
+setIconsList(iconsList);
 
 const props = {
   style: {
@@ -29,6 +33,19 @@ const propsSkeleton2 = {
 storiesOf('Icon', module)
   .addWithInfo(
     'Default',
+    `
+    Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see carbondesignsystem.com/style/iconography/library
+  `,
+    () => (
+      <div>
+        <Icon {...props} icon={iconAdd} />
+        <Icon {...props} icon={iconAddSolid} />
+        <Icon {...props} icon={iconAddOutline} />
+      </div>
+    )
+  )
+  .addWithInfo(
+    'Legacy',
     `
     Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see carbondesignsystem.com/style/iconography/library
   `,

--- a/src/components/Icon/Icon-test.js
+++ b/src/components/Icon/Icon-test.js
@@ -1,18 +1,13 @@
 import React from 'react';
-import Icon, {
-  findIcon,
-  svgShapes,
-  getSvgData,
-  icons,
-  isPrefixed,
-} from '../Icon';
+import { iconSearch } from 'carbon-icons';
+import Icon, { findIcon, svgShapes, getSvgData, isPrefixed } from '../Icon';
 import { mount } from 'enzyme';
 
 describe('Icon', () => {
   describe('Renders as expected', () => {
     const props = {
       className: 'extra-class',
-      name: 'search',
+      icon: iconSearch,
       width: '20',
       height: '20',
       description: 'close the thing',
@@ -49,6 +44,29 @@ describe('Icon', () => {
 
     it('should recieve style props', () => {
       expect(wrapper.props().style).toEqual({ transition: '2s' });
+    });
+  });
+
+  describe('Supports legacy icon', () => {
+    const props = {
+      className: 'extra-class',
+      name: 'search--glyph',
+      width: '20',
+      height: '20',
+      description: 'close the thing',
+      style: {
+        transition: '2s',
+      },
+    };
+
+    const wrapper = mount(<Icon {...props} />);
+
+    it('Renders `description` as expected', () => {
+      expect(wrapper.props().description).toEqual('close the thing');
+    });
+
+    it('should have expected viewBox on <svg>', () => {
+      expect(wrapper.find('svg').props().viewBox).not.toEqual('');
     });
   });
 
@@ -111,16 +129,6 @@ describe('Icon', () => {
     it('returns false when given a name without icon-- prefix', () => {
       const prefixed = isPrefixed('search');
       expect(prefixed).toBe(false);
-    });
-  });
-
-  describe('JSON file', () => {
-    it('should be defined', () => {
-      expect(typeof icons).toBeDefined();
-    });
-
-    it('should have length > 0', () => {
-      expect(icons.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,6 +3,12 @@ import React from 'react';
 import icons from 'carbon-icons';
 
 /**
+ * The icons list object from `carbon-icons`.
+ * @type {Object}
+ */
+let iconsList = icons;
+
+/**
  * Returns a single icon Object
  * @param {string} name - "name" property of icon
  * @param {Object} [iconsObj=icons] - JSON Array of Objects
@@ -10,7 +16,7 @@ import icons from 'carbon-icons';
  * // Returns a single icon Object
  * this.findIcon('copy-code', icons.json);
  */
-export function findIcon(name, iconsObj = icons) {
+export function findIcon(name, iconsObj = iconsList) {
   const icon = iconsObj.filter(obj => obj.name === name);
 
   if (icon.length === 0) {
@@ -20,6 +26,16 @@ export function findIcon(name, iconsObj = icons) {
   } else {
     return icon[0];
   }
+}
+
+/**
+ * Sets the icons list object from `carbon-icons`.
+ * Doing so instead of having this module directly import `carbon-icons`
+ * avoids the icons list being included in applications' bundles if only limited set of icons is in use.
+ * @param {Object} list The icons list from `carbon-icons`.
+ */
+export function setIconsList(list) {
+  iconsList = list;
 }
 
 /**
@@ -35,8 +51,8 @@ export function getSvgData(iconName) {
 }
 
 /**
- * Returns Elements/Nodes for SVG
  * @param {Object} svgData - JSON Object for an SVG icon
+ * @returns {ReactElement} Elements/Nodes for SVG
  * @example
  * // Returns SVG elements
  * const svgData = getSvgData('copy-code');
@@ -82,14 +98,13 @@ const Icon = ({
   fillRule,
   height,
   name,
+  icon = isPrefixed(name) ? findIcon(name) : findIcon(`icon--${name}`),
   role,
   style,
   width,
   iconRef,
   ...other
 }) => {
-  const icon = isPrefixed(name) ? findIcon(name) : findIcon(`icon--${name}`);
-
   const props = {
     className,
     fill,
@@ -141,9 +156,19 @@ Icon.propTypes = {
   height: PropTypes.string,
 
   /**
+   * The icon data.
+   */
+  icon: PropTypes.shape({
+    width: PropTypes.string,
+    height: PropTypes.string,
+    viewBox: PropTypes.string.isRequired,
+    svgData: PropTypes.object.isRequired,
+  }),
+
+  /**
    * The name in the sprite.
    */
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
 
   /**
    * The `role` attribute.

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,3 +1,3 @@
 export * from './Icon';
+export { default } from './Icon';
 export * from './Icon.Skeleton';
-export default from './Icon';

--- a/src/components/ListBox/ListBoxMenuIcon.js
+++ b/src/components/ListBox/ListBoxMenuIcon.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 
 export const translationIds = {
@@ -25,7 +26,7 @@ const ListBoxMenuIcon = ({ isOpen, translateWithId: t }) => {
   const description = isOpen ? t('close.menu') : t('open.menu');
   return (
     <div className={className}>
-      <Icon name="caret--down" description={description} alt={description} />
+      <Icon icon={iconCaretDown} description={description} alt={description} />
     </div>
   );
 };

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { iconClose } from 'carbon-icons';
 import Icon from '../Icon';
 
 /**
@@ -42,7 +43,7 @@ const ListBoxSelection = ({
       onKeyDown={handleOnKeyDown}
       title={description}>
       {selectionCount}
-      <Icon name="close" description={description} focusable="false" />
+      <Icon icon={iconClose} description={description} focusable="false" />
     </div>
   );
 };

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -23,7 +23,30 @@ exports[`ListBoxField should render 1`] = `
           description="Clear selected item"
           fillRule="evenodd"
           focusable="false"
-          name="close"
+          icon={
+            Object {
+              "height": "10",
+              "id": "icon--close",
+              "name": "icon--close",
+              "styles": "",
+              "svgData": Object {
+                "circles": "",
+                "ellipses": "",
+                "paths": Array [
+                  Object {
+                    "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                    "fill-rule": "nonzero",
+                  },
+                ],
+                "polygons": "",
+                "polylines": "",
+                "rects": "",
+              },
+              "tags": "icon--close",
+              "viewBox": "0 0 10 10",
+              "width": "10",
+            }
+          }
           role="img"
         >
           <svg
@@ -32,7 +55,6 @@ exports[`ListBoxField should render 1`] = `
             fillRule="evenodd"
             focusable="false"
             height="10"
-            name="close"
             role="img"
             viewBox="0 0 10 10"
             width="10"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
@@ -12,7 +12,29 @@ exports[`ListBoxMenuIcon should render 1`] = `
       alt="Close menu"
       description="Close menu"
       fillRule="evenodd"
-      name="caret--down"
+      icon={
+        Object {
+          "height": "5",
+          "id": "icon--caret--down",
+          "name": "icon--caret--down",
+          "styles": "",
+          "svgData": Object {
+            "circles": "",
+            "ellipses": "",
+            "paths": Array [
+              Object {
+                "d": "M0 0l5 4.998L10 0z",
+              },
+            ],
+            "polygons": "",
+            "polylines": "",
+            "rects": "",
+          },
+          "tags": "icon--caret--down",
+          "viewBox": "0 0 10 5",
+          "width": "10",
+        }
+      }
       role="img"
     >
       <svg
@@ -20,7 +42,6 @@ exports[`ListBoxMenuIcon should render 1`] = `
         aria-label="Close menu"
         fillRule="evenodd"
         height="5"
-        name="caret--down"
         role="img"
         viewBox="0 0 10 5"
         width="10"
@@ -50,7 +71,29 @@ exports[`ListBoxMenuIcon should render 2`] = `
       alt="Open menu"
       description="Open menu"
       fillRule="evenodd"
-      name="caret--down"
+      icon={
+        Object {
+          "height": "5",
+          "id": "icon--caret--down",
+          "name": "icon--caret--down",
+          "styles": "",
+          "svgData": Object {
+            "circles": "",
+            "ellipses": "",
+            "paths": Array [
+              Object {
+                "d": "M0 0l5 4.998L10 0z",
+              },
+            ],
+            "polygons": "",
+            "polylines": "",
+            "rects": "",
+          },
+          "tags": "icon--caret--down",
+          "viewBox": "0 0 10 5",
+          "width": "10",
+        }
+      }
       role="img"
     >
       <svg
@@ -58,7 +101,6 @@ exports[`ListBoxMenuIcon should render 2`] = `
         aria-label="Open menu"
         fillRule="evenodd"
         height="5"
-        name="caret--down"
         role="img"
         viewBox="0 0 10 5"
         width="10"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -28,7 +28,30 @@ exports[`ListBoxSelection should render 1`] = `
       description="translation"
       fillRule="evenodd"
       focusable="false"
-      name="close"
+      icon={
+        Object {
+          "height": "10",
+          "id": "icon--close",
+          "name": "icon--close",
+          "styles": "",
+          "svgData": Object {
+            "circles": "",
+            "ellipses": "",
+            "paths": Array [
+              Object {
+                "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                "fill-rule": "nonzero",
+              },
+            ],
+            "polygons": "",
+            "polylines": "",
+            "rects": "",
+          },
+          "tags": "icon--close",
+          "viewBox": "0 0 10 10",
+          "width": "10",
+        }
+      }
       role="img"
     >
       <svg
@@ -37,7 +60,6 @@ exports[`ListBoxSelection should render 1`] = `
         fillRule="evenodd"
         focusable="false"
         height="10"
-        name="close"
         role="img"
         viewBox="0 0 10 10"
         width="10"
@@ -85,7 +107,30 @@ exports[`ListBoxSelection should render 2`] = `
       description="translation"
       fillRule="evenodd"
       focusable="false"
-      name="close"
+      icon={
+        Object {
+          "height": "10",
+          "id": "icon--close",
+          "name": "icon--close",
+          "styles": "",
+          "svgData": Object {
+            "circles": "",
+            "ellipses": "",
+            "paths": Array [
+              Object {
+                "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                "fill-rule": "nonzero",
+              },
+            ],
+            "polygons": "",
+            "polylines": "",
+            "rects": "",
+          },
+          "tags": "icon--close",
+          "viewBox": "0 0 10 10",
+          "width": "10",
+        }
+      }
       role="img"
     >
       <svg
@@ -94,7 +139,6 @@ exports[`ListBoxSelection should render 2`] = `
         fillRule="evenodd"
         focusable="false"
         height="10"
-        name="close"
         role="img"
         viewBox="0 0 10 10"
         width="10"

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import { iconClose } from 'carbon-icons';
 import Icon from '../Icon';
 import Button from '../Button';
 
@@ -116,7 +117,7 @@ export default class Modal extends Component {
         onClick={onRequestClose}
         ref={this.button}>
         <Icon
-          name="close"
+          icon={iconClose}
           className="bx--modal-close__icon"
           description={iconDescription}
         />

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -87,7 +87,30 @@ exports[`ModalWrapper should render 1`] = `
                 className="bx--modal-close__icon"
                 description="close the modal"
                 fillRule="evenodd"
-                name="close"
+                icon={
+                  Object {
+                    "height": "10",
+                    "id": "icon--close",
+                    "name": "icon--close",
+                    "styles": "",
+                    "svgData": Object {
+                      "circles": "",
+                      "ellipses": "",
+                      "paths": Array [
+                        Object {
+                          "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                          "fill-rule": "nonzero",
+                        },
+                      ],
+                      "polygons": "",
+                      "polylines": "",
+                      "rects": "",
+                    },
+                    "tags": "icon--close",
+                    "viewBox": "0 0 10 10",
+                    "width": "10",
+                  }
+                }
                 role="img"
               >
                 <svg
@@ -96,7 +119,6 @@ exports[`ModalWrapper should render 1`] = `
                   className="bx--modal-close__icon"
                   fillRule="evenodd"
                   height="10"
-                  name="close"
                   role="img"
                   viewBox="0 0 10 10"
                   width="10"

--- a/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -132,7 +132,29 @@ exports[`MultiSelect.Filterable should render 1`] = `
                     alt="Open menu"
                     description="Open menu"
                     fillRule="evenodd"
-                    name="caret--down"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
                     role="img"
                   >
                     <svg
@@ -140,7 +162,6 @@ exports[`MultiSelect.Filterable should render 1`] = `
                       aria-label="Open menu"
                       fillRule="evenodd"
                       height="5"
-                      name="caret--down"
                       role="img"
                       viewBox="0 0 10 5"
                       width="10"

--- a/src/components/Notification/Notification-test.js
+++ b/src/components/Notification/Notification-test.js
@@ -1,4 +1,11 @@
 import React from 'react';
+import {
+  iconCheckmarkSolid,
+  iconInfoSolid,
+  iconErrorSolid,
+  iconWarningSolid,
+  iconClose,
+} from 'carbon-icons';
 import Icon from '../Icon';
 import Notification, {
   NotificationButton,
@@ -23,7 +30,7 @@ describe('NotificationButton', () => {
 
     it('renders correct Icon', () => {
       const icon = wrapper.find('Icon');
-      expect(icon.props().name).toEqual('close');
+      expect(icon.props().icon).toEqual(iconClose);
     });
 
     describe('When notificationType equals "toast"', () => {
@@ -183,22 +190,22 @@ describe('InlineNotification', () => {
 
     it('renders success notification with matching kind and <icon name=""> values', () => {
       inline.setProps({ kind: 'success' });
-      expect(inline.find(Icon).some('[name="checkmark--solid"]')).toBe(true);
+      expect(inline.find(Icon).some({ icon: iconCheckmarkSolid })).toBe(true);
     });
 
     it('renders error notification with matching kind and <icon name=""> values', () => {
       inline.setProps({ kind: 'error' });
-      expect(inline.find(Icon).some('[name="error--solid"]')).toBe(true);
+      expect(inline.find(Icon).some({ icon: iconErrorSolid })).toBe(true);
     });
 
     it('renders warning notification with matching kind and <icon name=""> values', () => {
       inline.setProps({ kind: 'warning' });
-      expect(inline.find(Icon).some('[name="warning--solid"]')).toBe(true);
+      expect(inline.find(Icon).some({ icon: iconWarningSolid })).toBe(true);
     });
 
     it('renders info notification with matching kind and <icon name=""> values', () => {
       inline.setProps({ kind: 'info' });
-      expect(inline.find(Icon).some('[name="info--solid"]')).toBe(true);
+      expect(inline.find(Icon).some({ icon: iconInfoSolid })).toBe(true);
     });
 
     it('renders HTML for inline notifications when caption does not exist', () => {
@@ -294,23 +301,23 @@ describe('[Deprecated]: Notification', () => {
       });
 
       it('renders checkmark--solid icon for success inline notification', () => {
-        const icon = inline.find('[name="checkmark--solid"]');
-        expect(icon.props().name).toEqual('checkmark--solid');
+        const icon = inline.find({ icon: iconCheckmarkSolid });
+        expect(icon.props().icon).toEqual(iconCheckmarkSolid);
       });
 
       it('renders error notification with matching kind and <icon name=""> values', () => {
         inline.setProps({ kind: 'error' });
-        expect(inline.find(Icon).some('[name="error--solid"]')).toBe(true);
+        expect(inline.find(Icon).some({ icon: iconErrorSolid })).toBe(true);
       });
 
       it('renders warning notification with matching kind and <icon name=""> values', () => {
         inline.setProps({ kind: 'warning' });
-        expect(inline.find(Icon).some('[name="warning--solid"]')).toBe(true);
+        expect(inline.find(Icon).some({ icon: iconWarningSolid })).toBe(true);
       });
 
       it('renders info notification with matching kind and <icon name=""> values', () => {
         inline.setProps({ kind: 'info' });
-        expect(inline.find(Icon).some('[name="info--solid"]')).toBe(true);
+        expect(inline.find(Icon).some({ icon: iconInfoSolid })).toBe(true);
       });
 
       it('renders HTML for toast notifications when caption exists', () => {

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import {
+  iconClose,
+  iconCheckmarkSolid,
+  iconErrorSolid,
+  iconInfoSolid,
+  iconWarningSolid,
+} from 'carbon-icons';
 import Icon from '../Icon';
 
 export class NotificationButton extends Component {
@@ -9,6 +16,12 @@ export class NotificationButton extends Component {
     ariaLabel: PropTypes.string,
     type: PropTypes.string,
     iconDescription: PropTypes.string,
+    icon: PropTypes.shape({
+      width: PropTypes.string,
+      height: PropTypes.string,
+      viewBox: PropTypes.string.isRequired,
+      svgData: PropTypes.object.isRequired,
+    }),
     name: PropTypes.string,
     notificationType: PropTypes.oneOf(['toast', 'inline']),
   };
@@ -17,7 +30,6 @@ export class NotificationButton extends Component {
     notificationType: 'toast',
     type: 'button',
     iconDescription: 'close icon',
-    name: 'close',
   };
   render() {
     const {
@@ -25,6 +37,7 @@ export class NotificationButton extends Component {
       className,
       iconDescription,
       type,
+      icon,
       name,
       notificationType,
       ...other
@@ -49,6 +62,7 @@ export class NotificationButton extends Component {
           description={iconDescription}
           className={iconClasses}
           aria-label={ariaLabel}
+          icon={!icon && !name ? iconClose : icon}
           name={name}
         />
       </button>
@@ -141,10 +155,13 @@ export class ToastNotification extends Component {
     this.props.onCloseButtonClick(evt);
   };
 
-  useIconName = kindProp => {
-    const isSuccess = kindProp === 'success';
-    return isSuccess ? 'checkmark--solid' : `${kindProp}--solid`;
-  };
+  useIcon = kindProp =>
+    ({
+      error: iconErrorSolid,
+      info: iconInfoSolid,
+      success: iconCheckmarkSolid,
+      warning: iconWarningSolid,
+    }[kindProp]);
 
   render() {
     if (!this.state.open) {
@@ -222,10 +239,13 @@ export class InlineNotification extends Component {
     this.props.onCloseButtonClick(evt);
   };
 
-  useIconName = kindProp => {
-    const isSuccess = kindProp === 'success';
-    return isSuccess ? 'checkmark--solid' : `${kindProp}--solid`;
-  };
+  useIcon = kindProp =>
+    ({
+      error: iconErrorSolid,
+      info: iconInfoSolid,
+      success: iconCheckmarkSolid,
+      warning: iconWarningSolid,
+    }[kindProp]);
 
   render() {
     if (!this.state.open) {
@@ -258,7 +278,7 @@ export class InlineNotification extends Component {
             description={this.props.iconDescription}
             className="bx--inline-notification__icon"
             aria-label="close"
-            name={this.useIconName(kind)}
+            icon={this.useIcon(kind)}
           />
           <NotificationTextDetails
             title={title}
@@ -309,10 +329,13 @@ export default class Notification extends Component {
     this.props.onCloseButtonClick(evt);
   };
 
-  useIconName = kindProp => {
-    const isSuccess = kindProp === 'success';
-    return isSuccess ? 'checkmark--solid' : `${kindProp}--solid`;
-  };
+  useIcon = kindProp =>
+    ({
+      error: iconErrorSolid,
+      info: iconInfoSolid,
+      success: iconCheckmarkSolid,
+      warning: iconWarningSolid,
+    }[kindProp]);
 
   render() {
     if (!this.state.open) {
@@ -376,7 +399,7 @@ export default class Notification extends Component {
             description={this.props.iconDescription}
             className="bx--inline-notification__icon"
             aria-label="close"
-            name={this.useIconName(kind)}
+            icon={this.useIcon(kind)}
           />
           <NotificationTextDetails
             title={title}

--- a/src/components/NumberInput/NumberInput-test.js
+++ b/src/components/NumberInput/NumberInput-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { iconCaretUp, iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import NumberInput from '../NumberInput';
 import NumberInputSkeleton from '../NumberInput/NumberInput.Skeleton';
@@ -150,8 +151,8 @@ describe('NumberInput', () => {
       });
 
       it('should use correct icons', () => {
-        expect(icons.at(0).prop('name')).toEqual('caret--up');
-        expect(icons.at(1).prop('name')).toEqual('caret--down');
+        expect(icons.at(0).prop('icon')).toEqual(iconCaretUp);
+        expect(icons.at(1).prop('icon')).toEqual(iconCaretDown);
       });
 
       it('adds new iconDescription when passed via props', () => {

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { iconCaretUp, iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import classNames from 'classnames';
 
@@ -168,7 +169,7 @@ export default class NumberInput extends Component {
               onClick={evt => this.handleArrowClick(evt, 'up')}>
               <Icon
                 className="up-icon"
-                name="caret--up"
+                icon={iconCaretUp}
                 description={this.props.iconDescription}
                 viewBox="0 0 10 5"
               />
@@ -179,7 +180,7 @@ export default class NumberInput extends Component {
               onClick={evt => this.handleArrowClick(evt, 'down')}>
               <Icon
                 className="down-icon"
-                name="caret--down"
+                icon={iconCaretDown}
                 viewBox="0 0 10 5"
                 description={this.props.iconDescription}
               />

--- a/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/src/components/OverflowMenu/OverflowMenu-story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { iconAdd } from 'carbon-icons';
 import OverflowMenu from '../OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
 import Icon from '../Icon';
@@ -44,7 +45,7 @@ storiesOf('OverflowMenu', module)
                 display: 'flex',
                 justifyContent: 'space-between',
               }}>
-              Add <Icon name="icon--add" style={{ height: '12px' }} />
+              Add <Icon icon={iconAdd} style={{ height: '12px' }} />
             </div>
           }
         />

--- a/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/src/components/OverflowMenu/OverflowMenu-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconOverflowMenu } from 'carbon-icons';
 import OverflowMenu from '../OverflowMenu';
 import Icon from '../Icon';
 import { shallow, mount } from 'enzyme';
@@ -20,7 +21,7 @@ describe('OverflowMenu', () => {
     });
 
     it('should use correct overflow-menu icon', () => {
-      expect(icon.props().name).toEqual('overflow-menu');
+      expect(icon.props().icon).toEqual(iconOverflowMenu);
     });
 
     it('has the expected classes', () => {

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import { iconOverflowMenu } from 'carbon-icons';
 import ClickListener from '../../internal/ClickListener';
 import FloatingMenu from '../../internal/FloatingMenu';
 import OptimizedResize from '../../internal/OptimizedResize';
@@ -153,6 +154,16 @@ export default class OverflowMenu extends Component {
     iconDescription: PropTypes.string.isRequired,
 
     /**
+     * The icon.
+     */
+    icon: PropTypes.shape({
+      width: PropTypes.string,
+      height: PropTypes.string,
+      viewBox: PropTypes.string.isRequired,
+      svgData: PropTypes.object.isRequired,
+    }),
+
+    /**
      * The icon name.
      */
     iconName: PropTypes.string,
@@ -203,7 +214,6 @@ export default class OverflowMenu extends Component {
   static defaultProps = {
     ariaLabel: 'list of options',
     iconDescription: 'open and close list of options',
-    iconName: 'overflow-menu',
     open: false,
     flipped: false,
     floatingMenu: false,
@@ -386,6 +396,7 @@ export default class OverflowMenu extends Component {
       ariaLabel,
       children,
       iconDescription,
+      icon,
       iconName,
       flipped,
       floatingMenu,
@@ -473,7 +484,12 @@ export default class OverflowMenu extends Component {
           {renderIcon ? (
             renderIcon(iconProps)
           ) : (
-            <Icon {...iconProps} name={iconName} style={{ width: '100%' }} />
+            <Icon
+              {...iconProps}
+              icon={!icon && !iconName ? iconOverflowMenu : icon}
+              name={iconName}
+              style={{ width: '100%' }}
+            />
           )}
           {open && wrappedMenuBody}
         </div>

--- a/src/components/Pagination/Pagination-test.js
+++ b/src/components/Pagination/Pagination-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconChevronLeft, iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 import Pagination from '../Pagination';
 import Select from '../Select';
@@ -21,11 +22,11 @@ describe('Pagination', () => {
       });
 
       it('should use correct "backward" icon', () => {
-        expect(icons.first().props().name).toEqual('chevron--left');
+        expect(icons.first().props().icon).toEqual(iconChevronLeft);
       });
 
       it('should use correct "forward" icon', () => {
-        expect(icons.last().props().name).toEqual('chevron--right');
+        expect(icons.last().props().icon).toEqual(iconChevronRight);
       });
     });
 

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 import warning from 'warning';
+import { iconChevronLeft, iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
@@ -238,7 +239,7 @@ export default class Pagination extends Component {
             disabled={this.props.disabled || statePage === 1}>
             <Icon
               className="bx--pagination__button-icon"
-              name="chevron--left"
+              icon={iconChevronLeft}
               description={backwardText}
             />
           </button>
@@ -261,7 +262,7 @@ export default class Pagination extends Component {
             }>
             <Icon
               className="bx--pagination__button-icon"
-              name="chevron--right"
+              icon={iconChevronRight}
               description={forwardText}
             />
           </button>

--- a/src/components/PaginationV2/PaginationV2-test.js
+++ b/src/components/PaginationV2/PaginationV2-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconChevronLeft, iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 import PaginationV2 from '../PaginationV2';
 import Select from '../Select';
@@ -29,11 +30,11 @@ describe('Pagination', () => {
       });
 
       it('should use correct "backward" icon', () => {
-        expect(icons.first().props().name).toEqual('chevron--left');
+        expect(icons.first().props().icon).toEqual(iconChevronLeft);
       });
 
       it('should use correct "forward" icon', () => {
-        expect(icons.last().props().name).toEqual('chevron--right');
+        expect(icons.last().props().icon).toEqual(iconChevronRight);
       });
     });
 

--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import { iconChevronLeft, iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
@@ -279,7 +280,7 @@ export default class PaginationV2 extends Component {
             disabled={this.props.disabled || statePage === 1}>
             <Icon
               className="bx--pagination__button-icon"
-              name="chevron--left"
+              icon={iconChevronLeft}
               description={backwardText}
             />
           </button>
@@ -302,7 +303,7 @@ export default class PaginationV2 extends Component {
             }>
             <Icon
               className="bx--pagination__button-icon"
-              name="chevron--right"
+              icon={iconChevronRight}
               description={forwardText}
             />
           </button>

--- a/src/components/PrimaryButton/PrimaryButton-test.js
+++ b/src/components/PrimaryButton/PrimaryButton-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PrimaryButton from '../PrimaryButton';
 import { shallow, mount } from 'enzyme';
+import { iconSearch } from 'carbon-icons';
 
 describe('PrimaryButton', () => {
   describe('Renders as expected', () => {
@@ -30,7 +31,7 @@ describe('PrimaryButton', () => {
 
     describe('Renders icon buttons', () => {
       const iconButton = mount(
-        <PrimaryButton icon="search" iconDescription="Search">
+        <PrimaryButton icon={iconSearch} iconDescription="Search">
           Search
         </PrimaryButton>
       );

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import uid from '../../tools/uniqueId';
 import Icon from '../Icon';
+import { iconCheckmarkSolid } from 'carbon-icons';
 import classNames from 'classnames';
 
 export default class RadioTile extends React.Component {
@@ -45,7 +46,7 @@ export default class RadioTile extends React.Component {
         />
 
         <div className="bx--tile__checkmark">
-          <Icon name="checkmark--solid" description="Tile checkmark" />
+          <Icon icon={iconCheckmarkSolid} description="Tile checkmark" />
         </div>
         <div className="bx--tile-content">{children}</div>
       </label>

--- a/src/components/Search/Search-test.js
+++ b/src/components/Search/Search-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconSearch } from 'carbon-icons';
 import Icon from '../Icon';
 import Search from '../Search';
 import SearchSkeleton from '../Search/Search.Skeleton';
@@ -104,7 +105,7 @@ describe('Search', () => {
       describe('icons', () => {
         it('renders "search" icon', () => {
           const icons = wrapper.find(Icon);
-          expect(icons.at(0).props().name).toEqual('search');
+          expect(icons.at(0).props().icon).toEqual(iconSearch);
         });
 
         it('renders two Icons', () => {
@@ -130,7 +131,7 @@ describe('Search', () => {
 
       it('renders correct search icon', () => {
         const icons = small.find(Icon);
-        expect(icons.at(0).props().name).toEqual('search');
+        expect(icons.at(0).props().icon).toEqual(iconSearch);
       });
 
       it('should have the expected small class', () => {

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import { iconSearch, iconCloseSolid } from 'carbon-icons';
 import Icon from '../Icon';
 
 export default class Search extends Component {
@@ -89,7 +90,7 @@ export default class Search extends Component {
     return (
       <div className={searchClasses} role="search">
         <Icon
-          name="search"
+          icon={iconSearch}
           description={labelText}
           className="bx--search-magnifier"
         />
@@ -112,7 +113,7 @@ export default class Search extends Component {
           onClick={this.clearInput}
           type="button"
           aria-label={closeButtonLabelText}>
-          <Icon name="close--solid" description={closeButtonLabelText} />
+          <Icon icon={iconCloseSolid} description={closeButtonLabelText} />
         </button>
       </div>
     );

--- a/src/components/SearchFilterButton/SearchFilterButton-test.js
+++ b/src/components/SearchFilterButton/SearchFilterButton-test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Icon from '../Icon';
 import SearchFilterButton from '../SearchFilterButton';
 import { mount } from 'enzyme';
+import { iconFilter } from 'carbon-icons';
 
 describe('SearchFilterButton', () => {
   const wrapper = mount(<SearchFilterButton labelText="testlabel" />);
@@ -22,7 +23,7 @@ describe('SearchFilterButton', () => {
   describe('icons', () => {
     it('should use "filter" icon', () => {
       const icon = wrapper.find(Icon);
-      expect(icon.props().name).toEqual('filter');
+      expect(icon.props().icon).toEqual(iconFilter);
     });
   });
 });

--- a/src/components/SearchFilterButton/SearchFilterButton.js
+++ b/src/components/SearchFilterButton/SearchFilterButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { iconFilter } from 'carbon-icons';
 import Icon from '../Icon';
 
 /**
@@ -11,7 +12,11 @@ const SearchFilterButton = ({ labelText, ...other }) => (
     type="button"
     aria-label={labelText}
     {...other}>
-    <Icon name="filter" description="filter" className="bx--search-filter" />
+    <Icon
+      icon={iconFilter}
+      description="filter"
+      className="bx--search-filter"
+    />
   </button>
 );
 

--- a/src/components/SearchLayoutButton/SearchLayoutButton-test.js
+++ b/src/components/SearchLayoutButton/SearchLayoutButton-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconList, iconGrid } from 'carbon-icons';
 import Icon from '../Icon';
 import SearchLayoutButton from '../SearchLayoutButton';
 import { mount } from 'enzyme';
@@ -22,22 +23,22 @@ describe('SearchLayoutButton', () => {
   describe('icons', () => {
     it('should use "list" icon for toggle button', () => {
       const icon = wrapper.find(Icon);
-      expect(icon.props().name).toEqual('list');
+      expect(icon.props().icon).toEqual(iconList);
     });
 
     it('should use "grid" icon when format state is not "list"', () => {
       wrapper.setState({ format: 'not-list' });
       const icon = wrapper.find(Icon);
-      expect(icon.props().name).toEqual('grid');
+      expect(icon.props().icon).toEqual(iconGrid);
     });
 
     it('should support specifying the layout via props', () => {
       const wrapperWithFormatProps = mount(
         <SearchLayoutButton format="grid" />
       );
-      expect(wrapperWithFormatProps.find(Icon).props().name).toEqual('grid');
+      expect(wrapperWithFormatProps.find(Icon).props().icon).toEqual(iconGrid);
       wrapperWithFormatProps.setProps({ format: 'list' });
-      expect(wrapperWithFormatProps.find(Icon).props().name).toEqual('list');
+      expect(wrapperWithFormatProps.find(Icon).props().icon).toEqual(iconList);
     });
 
     it('should support being notified of change in layout', () => {

--- a/src/components/SearchLayoutButton/SearchLayoutButton.js
+++ b/src/components/SearchLayoutButton/SearchLayoutButton.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { iconList, iconGrid } from 'carbon-icons';
 import Icon from '../Icon';
 
 /**
@@ -65,12 +66,16 @@ class SearchLayoutButton extends Component {
         aria-label={labelText}>
         {this.state.format === 'list' ? (
           <div className="bx--search__toggle-layout__container">
-            <Icon name="list" description="list" className="bx--search-view" />
+            <Icon
+              icon={iconList}
+              description="list"
+              className="bx--search-view"
+            />
           </div>
         ) : (
           <div className="bx--search__toggle-layout__container">
             <Icon
-              name="grid"
+              icon={iconGrid}
               description="toggle-layout"
               className="bx--search-view"
             />

--- a/src/components/SecondaryButton/SecondaryButton-test.js
+++ b/src/components/SecondaryButton/SecondaryButton-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconSearch } from 'carbon-icons';
 import SecondaryButton from '../SecondaryButton';
 import { shallow, mount } from 'enzyme';
 
@@ -30,7 +31,7 @@ describe('SecondaryButton', () => {
 
     describe('Renders icon buttons', () => {
       const iconButton = mount(
-        <SecondaryButton icon="search" iconDescription="Search">
+        <SecondaryButton icon={iconSearch} iconDescription="Search">
           Search
         </SecondaryButton>
       );

--- a/src/components/Select/Select-test.js
+++ b/src/components/Select/Select-test.js
@@ -4,6 +4,7 @@ import Select from '../Select';
 import SelectItem from '../SelectItem';
 import SelectSkeleton from '../Select/Select.Skeleton';
 import { mount, shallow } from 'enzyme';
+import { iconCaretDown } from 'carbon-icons';
 
 describe('Select', () => {
   describe('Renders as expected', () => {
@@ -29,7 +30,7 @@ describe('Select', () => {
 
       it('should use correct icon', () => {
         const icon = wrapper.find(Icon);
-        expect(icon.props().name).toEqual('caret--down');
+        expect(icon.props().icon).toEqual(iconCaretDown);
       });
 
       it('has the expected classes', () => {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 
 const Select = ({
@@ -46,7 +47,7 @@ const Select = ({
           {children}
         </select>
         <Icon
-          name="caret--down"
+          icon={iconCaretDown}
           className="bx--select__arrow"
           description={iconDescription}
         />

--- a/src/components/StructuredList/StructuredList-story.js
+++ b/src/components/StructuredList/StructuredList-story.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { iconCheckmarkSolid } from 'carbon-icons';
 import Icon from '../Icon';
 import {
   StructuredListWrapper,
@@ -78,7 +79,7 @@ storiesOf('StructuredList', module)
             <StructuredListCell>
               <Icon
                 className="bx--structured-list-svg"
-                name="checkmark--solid"
+                icon={iconCheckmarkSolid}
                 description="select an option"
               />
             </StructuredListCell>
@@ -101,7 +102,7 @@ storiesOf('StructuredList', module)
             <StructuredListCell>
               <Icon
                 className="bx--structured-list-svg"
-                name="checkmark--solid"
+                icon={iconCheckmarkSolid}
                 description="select an option"
               />
             </StructuredListCell>

--- a/src/components/TableData/TableData.js
+++ b/src/components/TableData/TableData.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { iconChevronRight } from 'carbon-icons';
 import Icon from '../Icon';
 
 const TableData = props => {
@@ -23,7 +24,7 @@ const TableData = props => {
       ) : (
         <Icon
           className={iconClasses}
-          name="chevron--right"
+          icon={iconChevronRight}
           description="expand row"
           style={style}
           tabIndex={0}

--- a/src/components/TableHeader/TableHeader-test.js
+++ b/src/components/TableHeader/TableHeader-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconCaretDown } from 'carbon-icons';
 import TableHeader from '../TableHeader';
 import Icon from '../Icon';
 import { shallow } from 'enzyme';
@@ -30,7 +31,7 @@ describe('TableHeader', () => {
       const icon = theader.find(Icon);
       expect(icon.length).toEqual(1);
       expect(icon.hasClass('bx--table-sort__svg')).toEqual(true);
-      expect(icon.props().name).toEqual('caret--down');
+      expect(icon.props().icon).toEqual(iconCaretDown);
     });
   });
 });

--- a/src/components/TableHeader/TableHeader.js
+++ b/src/components/TableHeader/TableHeader.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { iconCaretDown, iconCaretUp } from 'carbon-icons';
 import Icon from '../Icon';
 
 const TableHeader = props => {
@@ -15,13 +16,13 @@ const TableHeader = props => {
     sortContent =
       sortDir === 'DESC' ? (
         <Icon
-          name="caret--down"
+          icon={iconCaretDown}
           description="descending sort"
           className={iconClasses}
         />
       ) : (
         <Icon
-          name="caret--up"
+          icon={iconCaretUp}
           description="ascending sort"
           className={iconClasses}
         />

--- a/src/components/Tabs/Tabs-test.js
+++ b/src/components/Tabs/Tabs-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import Tabs from '../Tabs';
 import Tab from '../Tab';
@@ -56,7 +57,7 @@ describe('Tabs', () => {
       });
 
       it('renders <Icon>', () => {
-        expect(trigger.find(Icon).props().name).toEqual('caret--down');
+        expect(trigger.find(Icon).props().icon).toEqual(iconCaretDown);
       });
     });
 

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import TabContent from '../TabContent';
 
@@ -183,7 +184,7 @@ export default class Tabs extends React.Component {
               onClick={this.handleDropdownClick}>
               {selectedLabel}
             </a>
-            <Icon description={iconDescription} name="caret--down" />
+            <Icon description={iconDescription} icon={iconCaretDown} />
           </div>
           <ul role="tablist" className={classes.tablist}>
             {tabsWithProps}

--- a/src/components/Tile/Tile-test.js
+++ b/src/components/Tile/Tile-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { iconChevronDown } from 'carbon-icons';
 import {
   Tile,
   ClickableTile,
@@ -168,7 +169,7 @@ describe('Tile', () => {
       // Force the expanded tile to be collapsed.
       wrapper.setState({ expanded: false });
       const collapsedDescription = wrapper
-        .find('[name="chevron--down"]')
+        .find({ icon: iconChevronDown })
         .getElements()[0].props.description;
       expect(collapsedDescription).toEqual(defaultCollapsedIconText);
 
@@ -177,7 +178,7 @@ describe('Tile', () => {
 
       // Validate the description change
       const expandedDescription = wrapper
-        .find('[name="chevron--down"]')
+        .find({ icon: iconChevronDown })
         .getElements()[0].props.description;
       expect(expandedDescription).toEqual(defaultExpandedIconText);
     });
@@ -192,7 +193,7 @@ describe('Tile', () => {
       // Force the expanded tile to be collapsed.
       wrapper.setState({ expanded: false });
       const collapsedDescription = wrapper
-        .find('[name="chevron--down"]')
+        .find({ icon: iconChevronDown })
         .getElements()[0].props.description;
       expect(collapsedDescription).toEqual(tileCollapsedIconText);
 
@@ -201,7 +202,7 @@ describe('Tile', () => {
 
       // Validate the description change
       const expandedDescription = wrapper
-        .find('[name="chevron--down"]')
+        .find({ icon: iconChevronDown })
         .getElements()[0].props.description;
       expect(expandedDescription).toEqual(tileExpandedIconText);
     });

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { iconCheckmarkSolid, iconChevronDown } from 'carbon-icons';
 import Icon from '../Icon';
 
 export class Tile extends Component {
@@ -205,7 +206,7 @@ export class SelectableTile extends Component {
           checked={this.state.selected}
         />
         <div className="bx--tile__checkmark">
-          <Icon name="checkmark--solid" description="Tile checkmark" />
+          <Icon icon={iconCheckmarkSolid} description="Tile checkmark" />
         </div>
         <div className="bx--tile-content">{children}</div>
       </label>
@@ -333,7 +334,7 @@ export class ExpandableTile extends Component {
         tabIndex={tabIndex}>
         <button className="bx--tile__chevron">
           <Icon
-            name="chevron--down"
+            icon={iconChevronDown}
             description={
               this.state.expanded ? tileExpandedIconText : tileCollapsedIconText
             }

--- a/src/components/TimePickerSelect/TimePickerSelect.js
+++ b/src/components/TimePickerSelect/TimePickerSelect.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
+import { iconCaretDown } from 'carbon-icons';
 
 export default class TimePickerSelect extends Component {
   static propTypes = {
@@ -64,7 +65,7 @@ export default class TimePickerSelect extends Component {
           {children}
         </select>
         <Icon
-          name="caret--down"
+          icon={iconCaretDown}
           className="bx--select__arrow"
           description={iconDescription}
         />

--- a/src/components/Toolbar/Toolbar-story.js
+++ b/src/components/Toolbar/Toolbar-story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { iconFilter } from 'carbon-icons';
 import Toolbar, {
   ToolbarItem,
   ToolbarTitle,
@@ -30,7 +31,7 @@ storiesOf('Toolbar', module).addWithInfo(
     <Toolbar {...toolbarProps} className="some-class">
       <ToolbarItem type="search" placeHolderText="Search" />
       <ToolbarItem>
-        <OverflowMenu iconName="filter" floatingMenu>
+        <OverflowMenu icon={iconFilter} floatingMenu>
           <ToolbarTitle title="FILTER BY" />
           <ToolbarOption>
             <Checkbox

--- a/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/src/components/ToolbarSearch/ToolbarSearch.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { iconSearch } from 'carbon-icons';
 import Icon from '../Icon';
 import ClickListener from '../../internal/ClickListener';
 
@@ -77,7 +78,7 @@ export default class ToolbarSearch extends Component {
             className="bx--toolbar-search__btn"
             onClick={this.expandSearch}>
             <Icon
-              name="search"
+              icon={iconSearch}
               description="search"
               className="bx--search-magnifier"
             />

--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import debounce from 'lodash.debounce';
+import { iconInfoGlyph } from 'carbon-icons';
 import Icon from '../Icon';
 import FloatingMenu from '../../internal/FloatingMenu';
 import Tooltip from '../Tooltip';
@@ -28,7 +29,7 @@ describe('Tooltip', () => {
       it('renders the info icon', () => {
         const icon = trigger.find(Icon);
         expect(icon.length).toBe(1);
-        expect(icon.props().name).toBe('info--glyph');
+        expect(icon.props().icon).toBe(iconInfoGlyph);
       });
     });
   });

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import Icon from '../Icon';
 import classNames from 'classnames';
+import { iconInfoGlyph } from 'carbon-icons';
 import FloatingMenu, {
   DIRECTION_LEFT,
   DIRECTION_TOP,
@@ -137,6 +138,16 @@ export default class Tooltip extends Component {
     showIcon: PropTypes.bool,
 
     /**
+     * The the default tooltip icon.
+     */
+    icon: PropTypes.shape({
+      width: PropTypes.string,
+      height: PropTypes.string,
+      viewBox: PropTypes.string.isRequired,
+      svgData: PropTypes.object.isRequired,
+    }),
+
+    /**
      * The name of the default tooltip icon.
      */
     iconName: PropTypes.string,
@@ -156,7 +167,6 @@ export default class Tooltip extends Component {
     open: false,
     direction: DIRECTION_BOTTOM,
     showIcon: true,
-    iconName: 'info--glyph',
     iconDescription: 'tooltip',
     triggerText: 'Provide triggerText',
     menuOffset: getMenuOffset,
@@ -301,6 +311,7 @@ export default class Tooltip extends Component {
       direction,
       triggerText,
       showIcon,
+      icon,
       iconName,
       iconDescription,
       menuOffset,
@@ -345,6 +356,7 @@ export default class Tooltip extends Component {
                 <Icon
                   onKeyDown={this.handleKeyPress}
                   onClick={() => this.handleMouse('click')}
+                  icon={!icon && !iconName ? iconInfoGlyph : icon}
                   name={iconName}
                   description={iconDescription}
                   iconRef={node => {

--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { iconInfoGlyph } from 'carbon-icons';
 import classNames from 'classnames';
 import warning from 'warning';
 import Icon from '../Icon';
@@ -12,6 +13,7 @@ const TooltipSimple = ({
   position,
   text,
   showIcon,
+  icon,
   iconName,
   iconDescription,
   ...other
@@ -39,7 +41,12 @@ const TooltipSimple = ({
             tabIndex="0"
             role="button"
             {...other}>
-            <Icon role="img" name={iconName} description={iconDescription} />
+            <Icon
+              role="img"
+              icon={!icon && !iconName ? iconInfoGlyph : icon}
+              name={iconName}
+              description={iconDescription}
+            />
           </div>
         </React.Fragment>
       ) : (
@@ -62,6 +69,12 @@ TooltipSimple.propTypes = {
   position: PropTypes.oneOf(['bottom', 'top']),
   text: PropTypes.string.isRequired,
   showIcon: PropTypes.bool,
+  icon: PropTypes.shape({
+    width: PropTypes.string,
+    height: PropTypes.string,
+    viewBox: PropTypes.string.isRequired,
+    svgData: PropTypes.object.isRequired,
+  }),
   iconName: PropTypes.string,
   iconDescription: PropTypes.string,
 };
@@ -69,7 +82,6 @@ TooltipSimple.propTypes = {
 TooltipSimple.defaultProps = {
   position: 'top',
   showIcon: true,
-  iconName: 'info--glyph',
   iconDescription: 'tooltip',
   text: 'Provide text',
 };


### PR DESCRIPTION
Continuation of https://github.com/carbon-design-system/carbon-components-react/pull/588 - With a bit of breaking change for the sake of `v9` major version.

The breaking change is that app needs to call `setIconsList()` API for older usage to work, like below:

```javascript
import iconsList from 'carbon-icons';
import Icon, { setIconsList } from '../Icon';

setIconsList(iconsList);

...

<Icon name="icon--add" ... />
```

Wrt the newer pattern - The new `icon` prop allows icon data directly passed, and using it along with specific icon data from tree-shakable ESM module of `carbon-icons` beginning `6.3.0` release, app can optimize the bundle size.

The change also allows you to use an icon that is not in `carbon-icons`.

#### Changelog

**New**

* `<IconV2>` component, as mentioned above.