### PR TITLE
feat(ModalWrapper): prop -> state sync for open state

### DIFF
--- a/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -33,10 +33,15 @@ describe('ContentSwitcher', () => {
   });
 
   describe('Allow initial state to draw from props', () => {
-    const wrapper = shallow(
+    const onChange = jest.fn();
+    const mockData = {
+      index: 0,
+    };
+
+    const wrapper = mount(
       <ContentSwitcher
         selectedIndex={1}
-        onChange={() => {}}
+        onChange={onChange}
         className="extra-class">
         <Switch kind="anchor" text="one" />
         <Switch kind="anchor" text="two" />
@@ -48,6 +53,31 @@ describe('ContentSwitcher', () => {
     it('Should apply the selected property on the selected child', () => {
       expect(children.first().props().selected).toEqual(false);
       expect(children.last().props().selected).toEqual(true);
+    });
+
+    it('should avoid change the selected index upon setting props, unless there the value actually changes', () => {
+      wrapper.setProps({ selectedIndex: 1 });
+      // Turns `state.selectedIndex` to `0`
+      children
+        .first()
+        .props()
+        .onClick(mockData);
+      wrapper.setProps({ selectedIndex: 1 }); // No change in `selectedIndex` prop
+      const clonedChildren = wrapper.find(Switch);
+      expect(clonedChildren.first().props().selected).toEqual(true);
+      expect(clonedChildren.last().props().selected).toEqual(false);
+    });
+
+    it('should change the selected index upon change in props', () => {
+      wrapper.setProps({ selectedIndex: 0 });
+      children
+        .first()
+        .props()
+        .onClick(mockData);
+      wrapper.setProps({ selectedIndex: 1 });
+      const clonedChildren = wrapper.find(Switch);
+      expect(clonedChildren.first().props().selected).toEqual(false);
+      expect(clonedChildren.last().props().selected).toEqual(true);
     });
   });
 

--- a/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -55,7 +55,7 @@ describe('ContentSwitcher', () => {
       expect(children.last().props().selected).toEqual(true);
     });
 
-    it('should avoid change the selected index upon setting props, unless there the value actually changes', () => {
+    it('should avoid changing the selected index when receiving new props unless the value has changed', () => {
       wrapper.setProps({ selectedIndex: 1 });
       // Turns `state.selectedIndex` to `0`
       children

--- a/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/src/components/ContentSwitcher/ContentSwitcher.js
@@ -39,6 +39,12 @@ export default class ContentSwitcher extends React.Component {
     }
   };
 
+  componentWillReceiveProps({ selectedIndex }) {
+    if (selectedIndex !== this.props.selectedIndex) {
+      this.setState({ selectedIndex });
+    }
+  }
+
   render() {
     const {
       children,

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
@@ -129,4 +129,28 @@ describe('InteriorLeftNavList', () => {
       expect(list.state().open).toEqual(false);
     });
   });
+
+  describe('props -> state sync', () => {
+    const list = mount(
+      <InteriorLeftNavList title="test-title" open={false}>
+        <InteriorLeftNavItem href="">
+          <a href="http://www.carbondesignsystem.com">test-title</a>
+        </InteriorLeftNavItem>
+      </InteriorLeftNavList>
+    );
+
+    it('should change the open state upon change in props', () => {
+      list.setProps({ open: false });
+      list.setState({ open: false });
+      list.setProps({ open: true });
+      expect(list.state().open).toEqual(true);
+    });
+
+    it('should avoid change the open state upon setting props, unless there the value actually changes', () => {
+      list.setProps({ open: false });
+      list.setState({ open: true });
+      list.setProps({ open: false });
+      expect(list.state().open).toEqual(true);
+    });
+  });
 });

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
@@ -146,7 +146,7 @@ describe('InteriorLeftNavList', () => {
       expect(list.state().open).toEqual(true);
     });
 
-    it('should avoid change the open state upon setting props, unless there the value actually changes', () => {
+    it('should avoid changing the open state when receiving new props unless the value has changed', () => {
       list.setProps({ open: false });
       list.setState({ open: true });
       list.setProps({ open: false });

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -60,6 +60,12 @@ export default class InteriorLeftNavList extends Component {
     );
   };
 
+  componentWillReceiveProps({ open }) {
+    if (open !== this.props.open) {
+      this.setState({ open });
+    }
+  }
+
   render() {
     const {
       tabIndex,

--- a/src/components/ModalWrapper/ModalWrapper-test.js
+++ b/src/components/ModalWrapper/ModalWrapper-test.js
@@ -27,6 +27,32 @@ describe('ModalWrapper', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should change the open state upon change in props', () => {
+    const wrapper = mount(
+      <ModalWrapper {...mockProps}>
+        <p className="bx--modal-content__text">Text</p>
+      </ModalWrapper>
+    );
+
+    wrapper.setProps({ open: true });
+    expect(wrapper.state('isOpen')).toBe(true);
+
+    wrapper.setProps({ open: false });
+    expect(wrapper.state('isOpen')).toBe(false);
+  });
+
+  it('should avoid change the open state upon setting props, unless there the value actually changes', () => {
+    const wrapper = mount(
+      <ModalWrapper {...mockProps} open={true}>
+        <p className="bx--modal-content__text">Text</p>
+      </ModalWrapper>
+    );
+
+    wrapper.find({ children: mockProps.primaryButtonText }).simulate('click'); // Turns `state.open` to `false`
+    wrapper.setProps({ open: true }); // No change in `open` prop
+    expect(wrapper.state('isOpen')).toBe(false);
+  });
+
   it('should close after a successful submit action', () => {
     const wrapper = mount(
       <ModalWrapper {...mockProps}>

--- a/src/components/ModalWrapper/ModalWrapper-test.js
+++ b/src/components/ModalWrapper/ModalWrapper-test.js
@@ -41,7 +41,7 @@ describe('ModalWrapper', () => {
     expect(wrapper.state('isOpen')).toBe(false);
   });
 
-  it('should avoid change the open state upon setting props, unless there the value actually changes', () => {
+  it('should avoid changing the open state when receiving new props unless the value has changed', () => {
     const wrapper = mount(
       <ModalWrapper {...mockProps} open={true}>
         <p className="bx--modal-content__text">Text</p>

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -62,6 +62,12 @@ export default class ModalWrapper extends React.Component {
     }
   };
 
+  componentWillReceiveProps({ open }) {
+    if (open !== this.props.open) {
+      this.setState({ isOpen: open });
+    }
+  }
+
   render() {
     const {
       id,

--- a/src/components/TileGroup/TileGroup-test.js
+++ b/src/components/TileGroup/TileGroup-test.js
@@ -121,7 +121,7 @@ describe('TileGroup', () => {
       expect(wrapper.state().selected).toEqual('female');
     });
 
-    it('should avoid change the selected item upon setting props, unless there the value actually changes', () => {
+    it('should avoid changing the selected item when receiving new props unless the value has changed', () => {
       wrapper.setProps({ valueSelected: 'male' });
       wrapper.setState({ selected: 'female' });
       wrapper.setProps({ valueSelected: 'male' });

--- a/src/components/TileGroup/TileGroup-test.js
+++ b/src/components/TileGroup/TileGroup-test.js
@@ -105,4 +105,27 @@ describe('TileGroup', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
   });
+
+  describe('prop -> state sync', () => {
+    const wrapper = mount(
+      <TileGroup name="gender">
+        <RadioTile labelText="Male" value="male" />
+        <RadioTile labelText="Female" value="female" />
+      </TileGroup>
+    );
+
+    it('should change the selected item upon change in props', () => {
+      wrapper.setProps({ valueSelected: 'male' });
+      wrapper.setState({ selected: 'male' });
+      wrapper.setProps({ valueSelected: 'female' });
+      expect(wrapper.state().selected).toEqual('female');
+    });
+
+    it('should avoid change the selected item upon setting props, unless there the value actually changes', () => {
+      wrapper.setProps({ valueSelected: 'male' });
+      wrapper.setState({ selected: 'female' });
+      wrapper.setProps({ valueSelected: 'male' });
+      expect(wrapper.state().selected).toEqual('female');
+    });
+  });
 });

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -29,10 +29,10 @@ export default class TileGroup extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.hasOwnProperty('valueSelected')) {
+  componentWillReceiveProps({ valueSelected }) {
+    if (this.props.valueSelected !== valueSelected) {
       this.setState({
-        selected: nextProps.valueSelected,
+        selected: valueSelected,
       });
     }
   }


### PR DESCRIPTION
Fixes #343.

#### Changelog

**New**

* prop -> state sync for `open` state, for `<ModalWrapper>`
* Similar sync mechanism to:
  * `<ContentSwitcher>`
  * `<InteriorLeftNavList>`
  * `<TileGroup>`