### PR TITLE
Missed Table Header Import in readme

### DIFF
--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -81,6 +81,7 @@ const {
   TableRow,
   TableBody,
   TableCell,
+  TableHeader
 } = DataTable;
 
 // Inside of your component's `render` method

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -81,7 +81,7 @@ const {
   TableRow,
   TableBody,
   TableCell,
-  TableHeader
+  TableHeader,
 } = DataTable;
 
 // Inside of your component's `render` method


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#

DataTable Example docs missed an import 

#### Changelog

**Changed**
Added missed TableHeader import to Readme.md