### PR TITLE
feat(DataTable): allow users to pass placeholder text into table tool…

### DIFF
--- a/src/components/DataTable/TableToolbarSearch.js
+++ b/src/components/DataTable/TableToolbarSearch.js
@@ -5,22 +5,14 @@ import Search from '../Search';
 import setupGetInstanceId from './tools/instanceId';
 
 const getInstanceId = setupGetInstanceId();
-const translationKeys = {
-  'carbon.table.toolbar.search.label': 'Filter table',
-  'carbon.table.toolbar.search.placeholder': 'Search',
-};
-
-const translateWithId = id => {
-  return translationKeys[id];
-};
 
 const TableToolbarSearch = ({
   className,
   searchContainerClass,
   onChange,
-  translateWithId: t,
   id = `data-table-search-${getInstanceId()}`,
   placeHolderText,
+  labelText,
   ...rest
 }) => {
   const searchContainerClasses = cx(
@@ -35,10 +27,8 @@ const TableToolbarSearch = ({
         {...rest}
         small
         id={id}
-        labelText={t('carbon.table.toolbar.search.label')}
-        placeHolderText={
-          placeHolderText || t('carbon.table.toolbar.search.placeholder')
-        }
+        labelText={labelText || 'Filter table'}
+        placeHolderText={placeHolderText || 'Search'}
         onChange={onChange}
       />
     </div>
@@ -69,18 +59,16 @@ TableToolbarSearch.propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * Provide custom text for the component for each translation id
-   */
-  translateWithId: PropTypes.func.isRequired,
-
-  /**
    * Provide custom text for the searchbar's placeholder
    */
   placeHolderText: PropTypes.string,
+
+  /**
+   * Provide custom text for the searchbar's label
+   */
+  labelText: PropTypes.string,
 };
 
-TableToolbarSearch.defaultProps = {
-  translateWithId,
-};
+TableToolbarSearch.defaultProps = {};
 
 export default TableToolbarSearch;

--- a/src/components/DataTable/TableToolbarSearch.js
+++ b/src/components/DataTable/TableToolbarSearch.js
@@ -20,6 +20,7 @@ const TableToolbarSearch = ({
   onChange,
   translateWithId: t,
   id = `data-table-search-${getInstanceId()}`,
+  placeHolderText,
   ...rest
 }) => {
   const searchContainerClasses = cx(
@@ -35,7 +36,9 @@ const TableToolbarSearch = ({
         small
         id={id}
         labelText={t('carbon.table.toolbar.search.label')}
-        placeHolderText={t('carbon.table.toolbar.search.placeholder')}
+        placeHolderText={
+          placeHolderText || t('carbon.table.toolbar.search.placeholder')
+        }
         onChange={onChange}
       />
     </div>
@@ -69,6 +72,11 @@ TableToolbarSearch.propTypes = {
    * Provide custom text for the component for each translation id
    */
   translateWithId: PropTypes.func.isRequired,
+
+  /**
+   * Provide custom text for the searchbar's placeholder
+   */
+  placeHolderText: PropTypes.string,
 };
 
 TableToolbarSearch.defaultProps = {

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -877,7 +877,6 @@ exports[`DataTable should render 1`] = `
           <TableToolbarSearch
             id="custom-id"
             onChange={[Function]}
-            translateWithId={[Function]}
           >
             <div
               className="bx--toolbar-search-container"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -5,7 +5,6 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
   className="custom-class"
   id="custom-id"
   onChange={[MockFunction]}
-  translateWithId={[Function]}
 >
   <div
     className="bx--toolbar-search-container"

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -380,6 +380,7 @@ export default class DatePicker extends Component {
 
   render() {
     const {
+      appendTo, // eslint-disable-line
       children,
       className,
       short,
@@ -389,6 +390,8 @@ export default class DatePicker extends Component {
       maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
       onChange, // eslint-disable-line
+      locale, // eslint-disable-line
+      value, // eslint-disable-line
       ...other
     } = this.props;
 


### PR DESCRIPTION
…bar search

Closes #999 

This adds an optional prop for `TableToolbarSearch`, controlling the placeholder text of the search bar. If the prop is not present, then the placeholder text falls back to the previous implementation, which was relying on a translate function as such: `t('carbon.table.toolbar.search.placeholder')` (which I did not fully understand, but would be curious to know more about)

#### Changelog

**New**

* `placeHolderText` optional prop

**Changed**

* `Search` prop `placeHolderText` now points to a custom prop first