### PR TITLE
fix(pagination): remove string concatenation that will break localization for languages other than English

### DIFF
--- a/src/components/Pagination/Pagination-test.js
+++ b/src/components/Pagination/Pagination-test.js
@@ -54,7 +54,7 @@ describe('Pagination', () => {
 
       it('should label the dropdown', () => {
         const label = left.find('.bx--pagination__text').first();
-        expect(label.text()).toBe('items per page\u00a0\u00a0|\u00a0\u00a0');
+        expect(label.text()).toBe('items per page | ');
       });
 
       it('should show the item range out of the total', () => {
@@ -83,7 +83,7 @@ describe('Pagination', () => {
 
         it('should label the dropdown', () => {
           const label = left.find('.bx--pagination__text').first();
-          expect(label.text()).toBe('items per page\u00a0\u00a0|\u00a0\u00a0');
+          expect(label.text()).toBe('items per page | ');
         });
 
         it('should show the item range without the total', () => {

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -41,7 +41,7 @@ export default class Pagination extends Component {
     backwardText: 'Backward',
     itemRangeText: (min, max, total) => `${min}-${max} of ${total} items`,
     forwardText: 'Forward',
-    itemsPerPageText: 'items per page',
+    itemsPerPageText: 'items per page | ',
     onChange: () => {},
     pageNumberText: 'Page Number',
     pageRangeText: (current, total) => `${current} of ${total} pages`,
@@ -225,9 +225,7 @@ export default class Pagination extends Component {
               <SelectItem key={size} value={size} text={String(size)} />
             ))}
           </Select>
-          <span className="bx--pagination__text">
-            {itemsPerPageText}&nbsp;&nbsp;|&nbsp;&nbsp;
-          </span>
+          <span className="bx--pagination__text">{itemsPerPageText}</span>
           <span className="bx--pagination__text">{this.getItemsText()}</span>
         </div>
         <div className="bx--pagination__right">

--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -113,7 +113,7 @@ export default class PaginationV2 extends Component {
     backwardText: 'Backward',
     itemRangeText: (min, max, total) => `${min}-${max} of ${total} items`,
     forwardText: 'Forward',
-    itemsPerPageText: 'Items per page',
+    itemsPerPageText: 'Items per page:',
     pageNumberText: 'Page Number',
     pageRangeText: (current, total) => `${current} of ${total} pages`,
     disabled: false,
@@ -239,7 +239,7 @@ export default class PaginationV2 extends Component {
       <div className={classNames} {...other}>
         <div className="bx--pagination__left">
           <span className="bx--pagination__text">
-            {itemsPerPageFollowsText || `${itemsPerPageText}:`}
+            {itemsPerPageFollowsText || itemsPerPageText}
           </span>
 
           <Select


### PR DESCRIPTION
…age label, resolves #1067

This PR fixes issue #1067.  This makes sure that we aren't doing string concatenation that will break localization for languages other than English.