### PR TITLE
feat(breadcrumbs): provide ability to disable trailing slash as a prop

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb-story.js
+++ b/src/components/Breadcrumb/Breadcrumb-story.js
@@ -30,6 +30,21 @@ storiesOf('Breadcrumb', module)
     )
   )
   .addWithInfo(
+    'No Trailing Slash',
+    `
+      Use prop noTrailingSlash to disable the trailing slash.
+    `,
+    () => (
+      <Breadcrumb noTrailingSlash {...additionalProps}>
+        <BreadcrumbItem>
+          <a href="/#">Breadcrumb 1</a>
+        </BreadcrumbItem>
+        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+        <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
+      </Breadcrumb>
+    )
+  )
+  .addWithInfo(
     'skeleton',
     `
     Placeholder skeleton state to use when content is loading.

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -2,8 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Breadcrumb = ({ children, className, ...other }) => {
-  const classNames = classnames('bx--breadcrumb', className);
+const Breadcrumb = ({ children, className, noTrailingSlash, ...other }) => {
+  const classNames = classnames(className, {
+    'bx--breadcrumb': true,
+    'bx--breadcrumb--no-trailing-slash': noTrailingSlash,
+  });
   return (
     <div className={classNames} {...other}>
       {children}
@@ -14,6 +17,7 @@ const Breadcrumb = ({ children, className, ...other }) => {
 Breadcrumb.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  noTrailingSlash: PropTypes.bool,
 };
 
 export default Breadcrumb;


### PR DESCRIPTION
Closes #1073 

This adds an optional prop for `Breadcrumbs` called `noTrailingSlash` which conditionally adds the `bx--breadcrumb--no-trailing-slash` class. It also adds a new story for the breadcrumbs component, showcasing this new behavior.

#### Changelog

**New**

* `noTrailingSlash` optional prop
