### PR TITLE
fix(code-snippet): add aria label to textbox

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.js
+++ b/src/components/CodeSnippet/CodeSnippet.js
@@ -97,7 +97,11 @@ export default class CodeSnippet extends Component {
     );
 
     const code = (
-      <div role="textbox" tabIndex={0} className="bx--snippet-container">
+      <div
+        role="textbox"
+        tabIndex={0}
+        className="bx--snippet-container"
+        aria-label="code-snippet">
         <code>
           <pre
             ref={codeContent => {

--- a/src/components/CodeSnippet/CodeSnippet.js
+++ b/src/components/CodeSnippet/CodeSnippet.js
@@ -17,6 +17,7 @@ export default class CodeSnippet extends Component {
     feedback: PropTypes.string,
     copyLabel: PropTypes.string,
     onClick: PropTypes.func,
+    ariaLabel: PropTypes.string,
     /**
      * Used with multi snippet only
      * when text is more than 15 lines
@@ -60,6 +61,7 @@ export default class CodeSnippet extends Component {
       children,
       feedback,
       onClick,
+      ariaLabel,
       copyLabel,
       light,
       showMoreText,
@@ -101,7 +103,7 @@ export default class CodeSnippet extends Component {
         role="textbox"
         tabIndex={0}
         className="bx--snippet-container"
-        aria-label="code-snippet">
+        aria-label={ariaLabel ? ariaLabel : 'code-snippet'}>
         <code>
           <pre
             ref={codeContent => {


### PR DESCRIPTION
Closes IBM/carbon-components-react #1050 

Adds aria label to codesnippet text box  div. Cannot reproduce issue using DAP or AI but should fix it.

#### Changelog

**New**

* add aria label
