### PR TITLE
fix(tooltipIcon): show text on hover

### DIFF
--- a/src/components/TooltipIcon/TooltipIcon.js
+++ b/src/components/TooltipIcon/TooltipIcon.js
@@ -20,7 +20,7 @@ const TooltipIcon = ({
   });
   return (
     <div {...rest} className={tooltipClassName}>
-      <button className={triggerClassName} title={tooltipText}>
+      <button className={triggerClassName} aria-label={tooltipText}>
         {children}
       </button>
     </div>


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-react/issues/1078

`TooltipIcon` uses `aria-label` to show the text. We were placing the text inside the `title` attribute.

#### Changelog

**Changed**

- Use `aria-label` instead of `title`
