### PR TITLE
fix(DropdownV2): fix tabIndex warning

### DIFF
--- a/.storybook/Container.js
+++ b/.storybook/Container.js
@@ -20,9 +20,9 @@ export default class Container extends Component {
           {story()}
         </div>
         <input
-          aria-label="inpute-text-offleft"
+          aria-label="input-text-offleft"
           type="text"
-          class="bx--visually-hidden"
+          className="bx--visually-hidden"
         />
       </React.StrictMode>
     );

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -67,7 +67,7 @@ exports[`DropdownV2 should render 1`] = `
         className="bx--dropdown bx--list-box"
         onKeyDown={[Function]}
         role="listbox"
-        tabindex="0"
+        tabIndex="0"
       >
         <ListBoxField
           aria-expanded={false}

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -34,7 +34,7 @@ const ListBox = ({
     <div
       {...rest}
       role="listbox"
-      tabindex="0"
+      tabIndex="0"
       className={className}
       ref={innerRef}
       onKeyDown={handleOnKeyDown}>

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -29,7 +29,7 @@ exports[`ListBox should render 1`] = `
     className="bx--list-box__container bx--list-box"
     onKeyDown={[Function]}
     role="listbox"
-    tabindex="0"
+    tabIndex="0"
   >
     <ListBoxField>
       <div

--- a/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -80,7 +80,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
           className="bx--multi-select bx--combo-box bx--list-box"
           onKeyDown={[Function]}
           role="listbox"
-          tabindex="0"
+          tabIndex="0"
         >
           <ListBoxField
             aria-expanded={false}


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-react/issues/1086

#### Changelog

**Changed**

- `tabindex` to `tabIndex`
- `class` to `className`
