### PR TITLE
Export Tag & TagSkeleton

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ export TableHeader from './components/TableHeader';
 export TableRow from './components/TableRow';
 export TableRowExpanded from './components/TableRowExpanded';
 export Tabs from './components/Tabs';
+export Tag from './components/Tag';
 export TextArea from './components/TextArea';
 export TextInput from './components/TextInput';
 export {
@@ -128,6 +129,7 @@ export SearchSkeleton from './components/Search/Search.Skeleton';
 export SelectSkeleton from './components/Select/Select.Skeleton';
 export SliderSkeleton from './components/Slider/Slider.Skeleton';
 export TabsSkeleton from './components/Tabs/Tabs.Skeleton';
+export TagSkeleton from './components/Tag/Tag.Skeleton';
 export TextAreaSkeleton from './components/TextArea/TextArea.Skeleton';
 export TextInputSkeleton from './components/TextInput/TextInput.Skeleton';
 export ToggleSkeleton from './components/Toggle/Toggle.Skeleton';


### PR DESCRIPTION
Exports the Tag component. It was removed in a prior PR, but I don't (think) it was actually supposed to be deprecated since it's still in the Storybook and included in the component

#### Changelog

**New**

* Exports `<Tag />` and `<TagSkeleton />`

