### PR TITLE
fix(Modal): add support for primary focus selector prop

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -25,6 +25,7 @@ export default class Modal extends Component {
     onSecondarySubmit: PropTypes.func,
     danger: PropTypes.bool,
     shouldSubmitOnEnter: PropTypes.bool,
+    selectorPrimaryFocus: PropTypes.string,
   };
 
   static defaultProps = {
@@ -36,6 +37,7 @@ export default class Modal extends Component {
     iconDescription: 'close the modal',
     modalHeading: '',
     modalLabel: '',
+    selectorPrimaryFocus: '[data-modal-primary-focus]',
   };
 
   button = React.createRef();
@@ -63,19 +65,26 @@ export default class Modal extends Component {
     }
   }
 
-  focusButton = () => {
+  focusButton = e => {
+    const primaryFocusElement = e.currentTarget.querySelector(
+      this.props.selectorPrimaryFocus
+    );
+    if (primaryFocusElement) {
+      primaryFocusElement.focus();
+      return;
+    }
     if (this.button) {
       this.button.current.focus();
     }
   };
 
-  handleTransitionEnd = () => {
+  handleTransitionEnd = e => {
     if (
       this.outerModal.offsetWidth &&
       this.outerModal.offsetHeight &&
       this.beingOpen
     ) {
-      this.focusButton();
+      this.focusButton(e);
       this.beingOpen = false;
     }
   };

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -65,8 +65,8 @@ export default class Modal extends Component {
     }
   }
 
-  focusButton = e => {
-    const primaryFocusElement = e.currentTarget.querySelector(
+  focusButton = evt => {
+    const primaryFocusElement = evt.currentTarget.querySelector(
       this.props.selectorPrimaryFocus
     );
     if (primaryFocusElement) {
@@ -78,13 +78,13 @@ export default class Modal extends Component {
     }
   };
 
-  handleTransitionEnd = e => {
+  handleTransitionEnd = evt => {
     if (
       this.outerModal.offsetWidth &&
       this.outerModal.offsetHeight &&
       this.beingOpen
     ) {
-      this.focusButton(e);
+      this.focusButton(evt);
       this.beingOpen = false;
     }
   };

--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -152,4 +152,60 @@ storiesOf('ModalWrapper', module)
         </RadioButtonGroup>
       </ModalWrapper>
     )
+  )
+  .addWithInfo(
+    'selectorPrimaryFocus',
+    `
+      The 'selectorPrimaryFocus' prop can be used to focus on any single element when the modal is opened. The example shows an input field being focused on modal open, rather than the default behavior of focusing on the 'Save' button.
+    `,
+    () => (
+      <ModalWrapper
+        id="input-modal"
+        buttonTriggerText="Input Modal"
+        modalHeading="Modal with inputs and custom focus selector"
+        handleSubmit={action('onSubmit')}>
+        <TextInput
+          id="test2"
+          placeholder="Hint text here"
+          label="Text Input:"
+          data-modal-primary-focus
+        />
+        <br />
+        <Select id="select-1" labelText="Select">
+          <SelectItem
+            disabled
+            hidden
+            value="placeholder-item"
+            text="Pick an option"
+          />
+          <SelectItem value="option-1" text="Option 1" />
+          <SelectItem value="option-2" text="Option 2" />
+          <SelectItem value="option-3" text="Option 3" />
+        </Select>
+        <br />
+        <RadioButtonGroup
+          name="radio-button-group"
+          defaultSelected="default-selected">
+          <RadioButton
+            value="default-selected"
+            id="radio-1"
+            labelText="Radio Button label 1"
+            className="some-class"
+          />
+          <RadioButton
+            value="standard"
+            labelText="Radio Button label 2"
+            id="radio-2"
+            className="some-class"
+          />
+          <RadioButton
+            value="standard"
+            labelText="Radio Button label 3"
+            id="radio-3"
+            className="some-class"
+            disabled
+          />
+        </RadioButtonGroup>
+      </ModalWrapper>
+    )
   );

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -52,6 +52,7 @@ exports[`ModalWrapper should render 1`] = `
       primaryButtonDisabled={false}
       primaryButtonText="Save"
       secondaryButtonText="Cancel"
+      selectorPrimaryFocus="[data-modal-primary-focus]"
     >
       <div
         className="bx--modal bx--modal-tall"
@@ -59,6 +60,7 @@ exports[`ModalWrapper should render 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         role="presentation"
+        selectorPrimaryFocus="[data-modal-primary-focus]"
         tabIndex={-1}
       >
         <div


### PR DESCRIPTION
Closes IBM/carbon-components-react#1123

This PR will allow users to provide a selector that will be focused when the modal is opened. This behavior will be in line with the vanilla component's capabilities.

#### Changelog

**New**

* add `selectorPrimaryFocus` prop on `<Modal>`
* include `<ModalWrapper>` Storybook example showing `selectorPrimaryFocus` prop behavior

**Changed**

* modify auto focus behavior based on `selectorPrimaryFocus` value, or use default primary actionable item