### PR TITLE
fix(Icon): handle undefined name

### DIFF
--- a/src/components/Icon/Icon-test.js
+++ b/src/components/Icon/Icon-test.js
@@ -45,6 +45,10 @@ describe('Icon', () => {
     it('should recieve style props', () => {
       expect(wrapper.props().style).toEqual({ transition: '2s' });
     });
+
+    it('should not crash when there is no name prop', () => {
+      mount(<Icon />);
+    });
   });
 
   describe('Supports legacy icon', () => {

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -88,7 +88,7 @@ export function svgShapes(svgData) {
 }
 
 export function isPrefixed(name) {
-  return name.split('--')[0] === 'icon';
+  return !!name && name.split('--')[0] === 'icon';
 }
 
 const Icon = ({


### PR DESCRIPTION
Fixes https://github.com/IBM/carbon-components-react/issues/1128

Handles an Icon being created without a "name" prop