### PR TITLE
fix(Drodown): adds light support

### DIFF
--- a/src/components/Dropdown/Dropdown-story.js
+++ b/src/components/Dropdown/Dropdown-story.js
@@ -79,6 +79,28 @@ storiesOf('Dropdown', module)
     )
   )
   .addWithInfo(
+    'light',
+    `
+      The Dropdown component is used for navigating or filtering existing content.
+      You can also have an option preselected in the dropdown.
+    `,
+    () => (
+      <Dropdown
+        {...dropdownEvents}
+        onChange={selectedItemInfo => console.log(selectedItemInfo)}
+        onOpen={action('onOpen')}
+        onClose={action('onClose')}
+        defaultText="Dropdown label"
+        light>
+        <DropdownItem itemText="Option 1" value="option1" />
+        <DropdownItem itemText="Option 2" value="option2" />
+        <DropdownItem itemText="Option 3" value="option3" />
+        <DropdownItem itemText="Option 4" value="option4" />
+        <DropdownItem itemText="Option 5" value="option5" />
+      </Dropdown>
+    )
+  )
+  .addWithInfo(
     'with pre-selected value',
     `
         The Dropdown component is used for navigating or filtering existing content.

--- a/src/components/Dropdown/Dropdown-test.js
+++ b/src/components/Dropdown/Dropdown-test.js
@@ -32,6 +32,14 @@ describe('Dropdown', () => {
       expect(wrapper.hasClass('bx--dropdown--disabled')).toEqual(true);
     });
 
+    it('has the expected classes when light is true', () => {
+      const wrapper = shallow(
+        <Dropdown defaultText="Choose something.." light />
+      ).childAt(0);
+
+      expect(wrapper.hasClass('bx--dropdown--light')).toEqual(true);
+    });
+
     it('should add extra classes that are passed via className', () => {
       expect(dropdownWrapper.hasClass('extra-class')).toEqual(true);
     });

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -24,12 +24,14 @@ export default class Dropdown extends PureComponent {
     open: PropTypes.bool,
     iconDescription: PropTypes.string,
     disabled: PropTypes.bool,
+    light: PropTypes.bool,
   };
 
   static defaultProps = {
     tabIndex: 0,
     open: false,
     disabled: false,
+    light: false,
     iconDescription: 'open list of options',
     onChange: () => {},
     onOpen: () => {},
@@ -134,6 +136,7 @@ export default class Dropdown extends PureComponent {
       defaultText, // eslint-disable-line no-unused-vars
       iconDescription,
       disabled,
+      light,
       selectedText, // eslint-disable-line no-unused-vars
       onOpen, // eslint-disable-line no-unused-vars
       onClose, // eslint-disable-line no-unused-vars
@@ -156,6 +159,7 @@ export default class Dropdown extends PureComponent {
       'bx--dropdown': true,
       'bx--dropdown--open': this.state.open,
       'bx--dropdown--disabled': disabled,
+      'bx--dropdown--light': light,
       [this.props.className]: this.props.className,
     });
 


### PR DESCRIPTION
Closes IBM/carbon-components-react#1137

Implements light option for older Dropdown component

#### Changelog

**New**

* Added light option in src/Dropdown component, tests, storybook

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/carbon-components-react/1138)
<!-- Reviewable:end -->
