### PR TITLE
fix(DropdownV2) defaultItemToString

### DIFF
--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -9,7 +9,7 @@ const defaultItemToString = item => {
     return item;
   }
 
-  return item ? item.label : '';
+  return item ? item.text : '';
 };
 
 export default class DropdownV2 extends React.Component {


### PR DESCRIPTION
Super confused when all my items wouldn't show up!

Closes IBM/carbon-components-react#

{{short description}}

defaultItemToString in the dropdownV2 references a 'label' property on item when the examples and documentation use a text property.

#### Changelog

**Changed**

* Changed defauItemToString to use item.text instead of item.label
