### PR TITLE
fix: Update stories to reflect required label property

### DIFF
--- a/src/components/ComboBox/ComboBox-story.js
+++ b/src/components/ComboBox/ComboBox-story.js
@@ -6,19 +6,19 @@ import WithState from '../../tools/withState';
 const items = [
   {
     id: 'option-1',
-    text: 'Option 1',
+    label: 'Option 1',
   },
   {
     id: 'option-2',
-    text: 'Option 2',
+    label: 'Option 2',
   },
   {
     id: 'option-3',
-    text: 'Option 3',
+    label: 'Option 3',
   },
   {
     id: 'option-4',
-    text: 'Option 4',
+    label: 'Option 4',
   },
 ];
 
@@ -32,7 +32,7 @@ storiesOf('ComboBox', module)
       <div style={{ width: 300 }}>
         <ComboBox
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange - ComboBox')}
           placeholder="Filter..."
         />
@@ -48,7 +48,7 @@ storiesOf('ComboBox', module)
       <div style={{ width: 300 }}>
         <ComboBox
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange - ComboBox')}
           placeholder="Filter..."
           disabled
@@ -57,21 +57,21 @@ storiesOf('ComboBox', module)
     )
   )
   .addWithInfo(
-    'custom text input handling',
+    'custom label input handling',
     `Sometimes you want to perform an async action to trigger a backend call on input change.`,
     () => (
-      <WithState initialState={{ inputText: '' }}>
+      <WithState initialState={{ inputlabel: '' }}>
         {({ state, setState }) => (
           <div style={{ width: 300 }}>
             <ComboBox
               items={items}
               itemToString={item =>
-                item ? `${item.text} queried with ${state.inputText}` : ''
+                item ? `${item.label} queried with ${state.inputlabel}` : ''
               }
               onChange={action('onChange - ComboBox')}
               placeholder="Filter..."
               shouldFilterItem={() => true}
-              onInputChange={text => setState({ inputText: text })}
+              onInputChange={label => setState({ inputlabel: label })}
             />
           </div>
         )}

--- a/src/components/DropdownV2/DropdownV2-story.js
+++ b/src/components/DropdownV2/DropdownV2-story.js
@@ -7,19 +7,19 @@ import WithState from '../../tools/withState';
 const items = [
   {
     id: 'option-1',
-    text: 'Option 1',
+    label: 'Option 1',
   },
   {
     id: 'option-2',
-    text: 'Option 2',
+    label: 'Option 2',
   },
   {
     id: 'option-3',
-    text: 'Option 3',
+    label: 'Option 3',
   },
   {
     id: 'option-4',
-    text: 'Option 4',
+    label: 'Option 4',
   },
 ];
 
@@ -34,7 +34,7 @@ storiesOf('DropdownV2', module)
         <DropdownV2
           label="Label"
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
         />
       </div>
@@ -51,7 +51,7 @@ storiesOf('DropdownV2', module)
           type="inline"
           label="Label"
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
         />
       </div>
@@ -67,7 +67,7 @@ storiesOf('DropdownV2', module)
         <DropdownV2
           label="Label"
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
           disabled
         />
@@ -85,7 +85,7 @@ storiesOf('DropdownV2', module)
           type="inline"
           label="Label"
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
           disabled
         />
@@ -105,7 +105,7 @@ storiesOf('DropdownV2', module)
               type="inline"
               label="Label"
               items={items}
-              itemToString={item => (item ? item.text : '')}
+              itemToString={item => (item ? item.label : '')}
               onChange={({ selectedItem }) =>
                 setTimeout(() => setState({ selectedItem }), 1000)
               }
@@ -127,7 +127,7 @@ storiesOf('DropdownV2', module)
           light
           label="Label"
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
         />
       </div>

--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -5,19 +5,19 @@ import MultiSelect from '../MultiSelect';
 const items = [
   {
     id: 'item-1',
-    text: 'Item 1',
+    label: 'Item 1',
   },
   {
     id: 'item-2',
-    text: 'Item 2',
+    label: 'Item 2',
   },
   {
     id: 'item-3',
-    text: 'Item 3',
+    label: 'Item 3',
   },
   {
     id: 'item-4',
-    text: 'Item 4',
+    label: 'Item 4',
   },
 ];
 
@@ -35,7 +35,7 @@ storiesOf('MultiSelect', module)
         <MultiSelect
           label={defaultLabel}
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
         />
       </div>
@@ -52,7 +52,7 @@ storiesOf('MultiSelect', module)
           light
           label={defaultLabel}
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
         />
       </div>
@@ -68,7 +68,7 @@ storiesOf('MultiSelect', module)
         type="inline"
         label={defaultLabel}
         items={items}
-        itemToString={item => (item ? item.text : '')}
+        itemToString={item => (item ? item.label : '')}
         onChange={action('onChange')}
       />
     )
@@ -83,7 +83,7 @@ storiesOf('MultiSelect', module)
         <MultiSelect
           label={defaultLabel}
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
           disabled
         />
@@ -100,7 +100,7 @@ storiesOf('MultiSelect', module)
         type="inline"
         label={defaultLabel}
         items={items}
-        itemToString={item => (item ? item.text : '')}
+        itemToString={item => (item ? item.label : '')}
         onChange={action('onChange')}
         disabled
       />
@@ -116,7 +116,7 @@ storiesOf('MultiSelect', module)
         <MultiSelect
           label={defaultLabel}
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           initialSelectedItems={[items[0], items[1]]}
           onChange={action('onChange - Inline MultiSelect')}
         />
@@ -132,7 +132,7 @@ storiesOf('MultiSelect', module)
       <div style={{ width: 300 }}>
         <MultiSelect.Filterable
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
           placeholder={defaultPlaceholder}
         />
@@ -149,7 +149,7 @@ storiesOf('MultiSelect', module)
         <MultiSelect.Filterable
           light
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
           placeholder={defaultPlaceholder}
         />
@@ -165,7 +165,7 @@ storiesOf('MultiSelect', module)
       <div style={{ width: 300 }}>
         <MultiSelect.Filterable
           items={items}
-          itemToString={item => (item ? item.text : '')}
+          itemToString={item => (item ? item.label : '')}
           onChange={action('onChange')}
           placeholder={defaultPlaceholder}
           disabled


### PR DESCRIPTION
Closes IBM/carbon-components-react#

The storybooks don't make it clear that the required property for defaultItemToString to function is 'label' not 'text'. This is especially confusing since storybook hides the custom itemToString supplied in the stories as itemToString={itemToString()}.

#### Changelog

**Changed**

* Switched item property from 'text' to 'label' to prevent confusion when relying on the defaultItemToString method.