### PR TITLE
fix(FileUploader): limit `multiple="false"` to a single upload

### DIFF
--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -207,11 +207,12 @@ export default class FileUploader extends Component {
   }
   handleChange = evt => {
     evt.stopPropagation();
-    this.setState({
-      filenames: this.state.filenames.concat(
-        [...evt.target.files].map(file => file.name)
-      ),
-    });
+    const filenames = !this.props.multiple
+      ? [evt.target.files[0].name]
+      : this.state.filenames.concat(
+          [...evt.target.files].map(file => file.name)
+        );
+    this.setState({ filenames });
     this.props.onChange(evt);
   };
 


### PR DESCRIPTION
This PR will limit `FileUploader` to a single upload when the `multiple` prop is `false`. Closes IBM/carbon-components-react#1166

#### Changelog

**Changed**

* behavior of `onChange` handler in `FileUploader` when `multiple` prop is false