### PR TITLE
fix(TableHeader): apply className to outer th node

### DIFF
--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -50,7 +50,7 @@ const TableHeader = ({
   });
 
   return (
-    <th scope={scope}>
+    <th scope={scope} className={headerClassName}>
       <button className={className} onClick={onClick} {...rest}>
         <span className="bx--table-header-label">{children}</span>
         <Icon


### PR DESCRIPTION
Closes IBM/carbon-components-react#1026

#### Changelog

**New**

**Changed**

* `TableHeader` now passes `className` to underlying `th`

**Removed**
