### PR TITLE
feat(DataTable): loosen prop-type definition to include nodes

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -64,7 +64,7 @@ export default class DataTable extends React.Component {
     headers: PropTypes.arrayOf(
       PropTypes.shape({
         key: PropTypes.string.isRequired,
-        header: PropTypes.string.isRequired,
+        header: PropTypes.node.isRequired,
       })
     ).isRequired,
 


### PR DESCRIPTION
Closes IBM/carbon-components-react#878

#### Changelog

**New**

**Changed**

* DataTable prop types for headers now matches the `TableHeader` prop type.

**Removed**
