### PR TITLE
fix(Modal): remove console warning for `selectorPrimaryFocus` prop

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -161,6 +161,7 @@ export default class Modal extends Component {
       iconDescription,
       primaryButtonDisabled,
       danger,
+      selectorPrimaryFocus, // eslint-disable-line
       selectorsFloatingMenus, // eslint-disable-line
       ...other
     } = this.props;

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -68,7 +68,6 @@ exports[`ModalWrapper should render 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         role="presentation"
-        selectorPrimaryFocus="[data-modal-primary-focus]"
         tabIndex={-1}
       >
         <div


### PR DESCRIPTION
Closes IBM/carbon-components-react#1180 

#### Changelog

**Changed**

* destructure `selectorPrimaryFocus` prop to prevent it from being spread in child elements