### PR TITLE
docs(FileUploader): restore 'none' `buttonKind` knob

### DIFF
--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -17,6 +17,7 @@ import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
 import Button from '../Button';
 
 const buttonKinds = {
+  none: 'None ()',
   primary: 'Primary (primary)',
   secondary: 'Secondary (secondary)',
   danger: 'Danger (danger)',
@@ -33,13 +34,13 @@ const filenameStatuses = {
 
 const props = {
   fileUploaderButton: () => {
-    const buttonKind = select('Button kind (buttonKind)', buttonKinds, '');
+    const buttonKind = select('Button kind (buttonKind)', buttonKinds, 'none');
     return {
       className: 'bob',
       labelText: text('Label text (labelText)', 'Add files'),
       name: text('Form item name: (name)', ''),
       multiple: boolean('Supports multiple files (multiple)', true),
-      buttonKind: buttonKind || 'primary',
+      buttonKind: buttonKind === 'none' ? '' : buttonKind,
       disableLabelChanges: boolean(
         'Prevent the label from being replaced with file selected file (disableLabelChanges)',
         false


### PR DESCRIPTION
Restore 'none' `buttonKind` knob which was mistakenly replaced by defaulting to `buttonKind="primary"` in #1200 

Related: #1199