### PR TITLE
feat(DataTable): support disabling zebra stripe

### DIFF
--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -1,9 +1,32 @@
-import wrapComponent from '../../tools/wrapComponent';
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
 
-export const Table = wrapComponent({
-  name: 'Table',
-  className: ['bx--data-table-v2', 'bx--data-table-v2--zebra'],
-  type: 'table',
-});
+export const Table = ({ zebra, className, children, ...other }) => {
+  const componentClass = cx('bx--data-table-v2', className, {
+    'bx--data-table-v2--zebra': zebra,
+  });
+  return (
+    <table {...other} className={componentClass}>
+      {children}
+    </table>
+  );
+};
+
+Table.propTypes = {
+  /**
+   * The CSS class names.
+   */
+  className: PropTypes.string,
+
+  /**
+   * `true` to add zebra striping.
+   */
+  zebra: PropTypes.bool,
+};
+
+Table.defaultProps = {
+  zebra: true,
+};
 
 export default Table;

--- a/src/components/DataTable/__tests__/Table-test.js
+++ b/src/components/DataTable/__tests__/Table-test.js
@@ -1,10 +1,16 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Table } from '../';
 
 describe('DataTable.Table', () => {
   it('should render', () => {
     const wrapper = mount(<Table className="custom-class" />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should support disable zebra stripe', () => {
+    const wrapper = shallow(<Table zebra={false} />);
+    expect(wrapper.hasClass('bx--data-table-v2')).toBe(true);
+    expect(wrapper.hasClass('bx--data-table-v2--zebra')).toBe(false);
   });
 });

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -62,7 +62,9 @@ exports[`DataTable selection should have select-all default to un-checked if no 
       >
         DataTable with selection
       </h4>
-      <Table>
+      <Table
+        zebra={true}
+      >
         <table
           className="bx--data-table-v2 bx--data-table-v2--zebra"
         >
@@ -431,7 +433,9 @@ exports[`DataTable selection should render 1`] = `
       >
         DataTable with selection
       </h4>
-      <Table>
+      <Table
+        zebra={true}
+      >
         <table
           className="bx--data-table-v2 bx--data-table-v2--zebra"
         >
@@ -1379,7 +1383,9 @@ exports[`DataTable should render 1`] = `
           </TableToolbarContent>
         </section>
       </TableToolbar>
-      <Table>
+      <Table
+        zebra={true}
+      >
         <table
           className="bx--data-table-v2 bx--data-table-v2--zebra"
         >

--- a/src/components/DataTable/__tests__/__snapshots__/Table-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/Table-test.js.snap
@@ -3,9 +3,10 @@
 exports[`DataTable.Table should render 1`] = `
 <Table
   className="custom-class"
+  zebra={true}
 >
   <table
-    className="bx--data-table-v2 bx--data-table-v2--zebra custom-class"
+    className="bx--data-table-v2 custom-class bx--data-table-v2--zebra"
   />
 </Table>
 `;

--- a/src/components/DataTable/__tests__/__snapshots__/TableBody-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableBody-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableBody should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableCell-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableCell-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableCell should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandHeader-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableExpandHeader should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableExpandRow should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableHead-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHead-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableHead should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableHeader should have an active and ascending class if sorting by ASC 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
@@ -32,7 +34,9 @@ exports[`DataTable.TableHeader should have an active and ascending class if sort
 `;
 
 exports[`DataTable.TableHeader should have an active class if it is the sort header and the sort state is not NONE 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
@@ -63,7 +67,9 @@ exports[`DataTable.TableHeader should have an active class if it is the sort hea
 `;
 
 exports[`DataTable.TableHeader should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
@@ -94,7 +100,9 @@ exports[`DataTable.TableHeader should render 1`] = `
 `;
 
 exports[`DataTable.TableHeader should render 2`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableRow-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableRow should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableSelectAll should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >

--- a/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable.TableSelectRow should render 1`] = `
-<Table>
+<Table
+  zebra={true}
+>
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >


### PR DESCRIPTION
Fixes #1205.

#### Changelog

**New**

* `zebra` prop to `<Table>`, whose default is `true`. Setting `false` there disables zebra striping.
* Support for dynamic CSS class names in Data table's `wrapComponents` internal helper.
