### PR TITLE
docs(Checkbox): Add description to checkbox onChange function

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -60,6 +60,10 @@ Checkbox.propTypes = {
   id: PropTypes.string.isRequired,
   labelText: PropTypes.node.isRequired,
   hideLabel: PropTypes.bool,
+  /**
+   * Receives three arguments: true/false, the checkbox's id, and the dom event.
+   * `(value, id, event) => console.log({value, id, event})`
+   */
   onChange: PropTypes.func,
   title: PropTypes.string,
   /**


### PR DESCRIPTION
The signature for the onChange function of the Checkbox component doesn't really jive with the rest of the inputs. Having the true/false value as the first parameter is confusing when other components pass in events or descriptive objects as the first parameter. Without diving into the source or observing the action log in the Storybook, the 2nd and 3rd parameters aren't obvious. This PR adds a description to the docs to make the method signature more apparent.

A future fix might update the component to coalesce the three parameters into a single one to make more obvious the parameters that are being passed in. This might also be the standard signature for checkbox components and I'm just not hip on it haha.

#### Changelog

**New**

* Checkbox onChange description
