### PR TITLE
feat(components): allow React node in labels

### DIFF
--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -10,7 +10,7 @@ export default class RadioButton extends React.Component {
     defaultChecked: PropTypes.bool,
     disabled: PropTypes.bool,
     id: PropTypes.string,
-    labelText: PropTypes.string.isRequired,
+    labelText: PropTypes.node.isRequired,
     name: PropTypes.string,
     onChange: PropTypes.func,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -63,7 +63,7 @@ export default class Slider extends PureComponent {
     /**
      * The label for the slider.
      */
-    labelText: PropTypes.string,
+    labelText: PropTypes.node,
 
     /**
      * A value determining how much the value should increase/decrease by moving the thumb by mouse.

--- a/src/components/TimePicker/TimePicker.js
+++ b/src/components/TimePicker/TimePicker.js
@@ -7,7 +7,7 @@ export default class TimePicker extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     id: PropTypes.string.isRequired,
-    labelText: PropTypes.string,
+    labelText: PropTypes.node,
     onClick: PropTypes.func,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,

--- a/src/components/TimePickerSelect/TimePickerSelect.js
+++ b/src/components/TimePickerSelect/TimePickerSelect.js
@@ -14,7 +14,7 @@ export default class TimePickerSelect extends Component {
     defaultValue: PropTypes.any,
     iconDescription: PropTypes.string.isRequired,
     hideLabel: PropTypes.bool,
-    labelText: PropTypes.string.isRequired,
+    labelText: PropTypes.node.isRequired,
   };
 
   static defaultProps = {

--- a/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/src/components/ToolbarSearch/ToolbarSearch.js
@@ -40,7 +40,7 @@ export default class ToolbarSearch extends Component {
     /**
      * The text in the `<label>`.
      */
-    labelText: PropTypes.string,
+    labelText: PropTypes.node,
 
     /**
      * The ID of the `<input>`.


### PR DESCRIPTION
Fixes #1206.

#### Changelog

**Changed**

* `labelText` properties of several components from `PropType.string` to `PropType.node`.