### PR TITLE
feat(TextInput): add support for helper text

### DIFF
--- a/src/components/NumberInput/NumberInput-story.js
+++ b/src/components/NumberInput/NumberInput-story.js
@@ -20,6 +20,7 @@ const props = () => ({
     'Form validation UI content (invalidText)',
     'Number is not valid'
   ),
+  helperText: text('Helper text (helperText)', 'Optional helper text.'),
   light: boolean('Light variant (light)', false),
   onChange: action('onChange'),
   onClick: action('onClick'),

--- a/src/components/NumberInput/NumberInput-test.js
+++ b/src/components/NumberInput/NumberInput-test.js
@@ -13,6 +13,7 @@ describe('NumberInput', () => {
     let container;
     let formItem;
     let icons;
+    let helper;
 
     beforeEach(() => {
       wrapper = mount(
@@ -23,6 +24,7 @@ describe('NumberInput', () => {
           label="Number Input"
           className="extra-class"
           invalidText="invalid text"
+          helperText="testHelper"
         />
       );
 
@@ -31,6 +33,7 @@ describe('NumberInput', () => {
       container = wrapper.find('.bx--number');
       formItem = wrapper.find('.bx--form-item');
       icons = wrapper.find(Icon);
+      helper = wrapper.find('.bx--form__helper-text');
     });
 
     describe('input', () => {
@@ -192,6 +195,33 @@ describe('NumberInput', () => {
 
       it('has the expected classes', () => {
         expect(label.hasClass('bx--label')).toEqual(true);
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        expect(helper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
+            <span>
+              This helper text has <a href="#">a link</a>.
+            </span>
+          ),
+        });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="#">a link</a>.
+          </span>
+        );
+      });
+
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        expect(helper.text()).toEqual('Helper text');
       });
     });
   });

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -23,6 +23,7 @@ export default class NumberInput extends Component {
     value: PropTypes.number,
     invalid: PropTypes.bool,
     invalidText: PropTypes.string,
+    helperText: PropTypes.node,
     /**
      * `true` to use the light version.
      */
@@ -39,6 +40,7 @@ export default class NumberInput extends Component {
     value: 0,
     invalid: false,
     invalidText: 'Provide invalidText',
+    helperText: '',
     light: false,
   };
 
@@ -120,6 +122,7 @@ export default class NumberInput extends Component {
       step,
       invalid,
       invalidText,
+      helperText,
       light,
       ...other
     } = this.props;
@@ -149,6 +152,10 @@ export default class NumberInput extends Component {
       inputWrapperProps['data-invalid'] = true;
       error = <div className="bx--form-requirement">{invalidText}</div>;
     }
+
+    const helper = helperText ? (
+      <div className="bx--form__helper-text">{helperText}</div>
+    ) : null;
 
     return (
       <div className="bx--form-item">
@@ -188,6 +195,7 @@ export default class NumberInput extends Component {
             ref={this._handleInputRef}
           />
           {error}
+          {helper}
         </div>
       </div>
     );

--- a/src/components/Select/Select-story.js
+++ b/src/components/Select/Select-story.js
@@ -23,6 +23,7 @@ const props = {
       'Form validation UI content (invalidText in <Select>)',
       'A valid value is required'
     ),
+    helperText: text('Helper text (helperText)', 'Optional helper text.'),
     onChange: action('onChange'),
   }),
   group: () => ({

--- a/src/components/Select/Select-test.js
+++ b/src/components/Select/Select-test.js
@@ -9,7 +9,11 @@ import { iconCaretDown } from 'carbon-icons';
 describe('Select', () => {
   describe('Renders as expected', () => {
     const wrapper = mount(
-      <Select id="testing" labelText="Select" className="extra-class">
+      <Select
+        id="testing"
+        labelText="Select"
+        className="extra-class"
+        helperText="Helper text">
         <SelectItem />
         <SelectItem />
       </Select>
@@ -18,6 +22,7 @@ describe('Select', () => {
     const selectContainer = wrapper.find('.bx--form-item > div');
     const label = wrapper.find('label');
     const select = wrapper.find('select');
+    const helper = wrapper.find('.bx--form__helper-text');
 
     describe('selectContainer', () => {
       it('renders a container', () => {
@@ -108,6 +113,33 @@ describe('Select', () => {
 
       it('renders children as expected', () => {
         expect(label.props().children).toEqual('Select');
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        expect(helper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
+            <span>
+              This helper text has <a href="#">a link</a>.
+            </span>
+          ),
+        });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="#">a link</a>.
+          </span>
+        );
+      });
+
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        expect(helper.text()).toEqual('Helper text');
       });
     });
   });

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -15,6 +15,7 @@ const Select = ({
   hideLabel,
   invalid,
   invalidText,
+  helperText,
   light,
   ...other
 }) => {
@@ -33,6 +34,9 @@ const Select = ({
       {invalidText}
     </div>
   ) : null;
+  const helper = helperText ? (
+    <div className="bx--form__helper-text">{helperText}</div>
+  ) : null;
   return (
     <div className="bx--form-item">
       <div className={selectClasses}>
@@ -46,7 +50,7 @@ const Select = ({
           disabled={disabled || undefined}
           data-invalid={invalid || undefined}
           aria-invalid={invalid || undefined}
-          aria-describedby={errorId}>
+          aria-describedby={invalid && errorId}>
           {children}
         </select>
         <Icon
@@ -54,6 +58,7 @@ const Select = ({
           className="bx--select__arrow"
           description={iconDescription}
         />
+        {helper}
         {error}
       </div>
     </div>
@@ -73,6 +78,7 @@ Select.propTypes = {
   hideLabel: PropTypes.bool,
   invalid: PropTypes.bool,
   invalidText: PropTypes.string,
+  helperText: PropTypes.node,
   light: PropTypes.bool,
 };
 
@@ -83,6 +89,7 @@ Select.defaultProps = {
   iconDescription: 'open list of options',
   invalid: false,
   invalidText: '',
+  helperText: '',
   light: false,
 };
 

--- a/src/components/TextArea/TextArea-test.js
+++ b/src/components/TextArea/TextArea-test.js
@@ -5,7 +5,12 @@ import TextArea from '../TextArea';
 describe('TextArea', () => {
   describe('should render as expected', () => {
     const wrapper = mount(
-      <TextArea id="testing" labelText="testlabel" className="extra-class" />
+      <TextArea
+        id="testing"
+        labelText="testlabel"
+        className="extra-class"
+        helperText="testHelper"
+      />
     );
 
     const textarea = () => wrapper.find('textarea');
@@ -77,6 +82,35 @@ describe('TextArea', () => {
 
       it('has the expected classes', () => {
         expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
+            <span>
+              This helper text has <a href="#">a link</a>.
+            </span>
+          ),
+        });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="#">a link</a>.
+          </span>
+        );
+      });
+
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.text()).toEqual('Helper text');
       });
     });
   });

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -11,6 +11,7 @@ const TextArea = ({
   onClick,
   invalid,
   invalidText,
+  helperText,
   light,
   ...other
 }) => {
@@ -56,10 +57,15 @@ const TextArea = ({
     <textarea {...other} {...textareaProps} className={textareaClasses} />
   );
 
+  const helper = helperText ? (
+    <div className="bx--form__helper-text">{helperText}</div>
+  ) : null;
+
   return (
     <div className="bx--form-item">
       {label}
       {input}
+      {helper}
       {error}
     </div>
   );
@@ -79,6 +85,7 @@ TextArea.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   invalid: PropTypes.bool,
   invalidText: PropTypes.string,
+  helperText: PropTypes.node,
   hideLabel: PropTypes.bool,
   /**
    * `true` to use the light version.
@@ -95,6 +102,7 @@ TextArea.defaultProps = {
   cols: 50,
   invalid: false,
   invalidText: '',
+  helperText: '',
   light: false,
 };
 

--- a/src/components/TextArea/Textarea-story.js
+++ b/src/components/TextArea/Textarea-story.js
@@ -17,6 +17,7 @@ const TextAreaProps = () => ({
     'Content of form validation UI (invalidText)',
     'A valid value is required'
   ),
+  helperText: text('Helper text (helperText)', 'Optional helper text.'),
   placeholder: text('Placeholder text (placeholder)', 'Placeholder text.'),
   id: 'test2',
   cols: number('Columns (columns)', 50),

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -26,6 +26,7 @@ const TextInputProps = () => ({
     'Form validation UI content (invalidText)',
     'A valid value is required'
   ),
+  helperText: text('Helper text (helperText)', 'Optional helper text.'),
   onClick: action('onClick'),
   onChange: action('onChange'),
 });

--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -9,6 +9,7 @@ describe('TextInput', () => {
         id="test"
         className="extra-class"
         labelText="testlabel"
+        helperText="testHelper"
         light
       />
     );
@@ -72,6 +73,35 @@ describe('TextInput', () => {
 
       it('should set label as expected', () => {
         expect(renderedLabel.text()).toEqual('Email Input');
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
+            <span>
+              This helper text has <a href="#">a link</a>.
+            </span>
+          ),
+        });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="#">a link</a>.
+          </span>
+        );
+      });
+
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.text()).toEqual('Helper text');
       });
     });
   });

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -13,6 +13,7 @@ const TextInput = ({
   hideLabel,
   invalid,
   invalidText,
+  helperText,
   light,
   ...other
 }) => {
@@ -65,10 +66,15 @@ const TextInput = ({
     <input {...other} {...textInputProps} className={textInputClasses} />
   );
 
+  const helper = helperText ? (
+    <div className="bx--form__helper-text">{helperText}</div>
+  ) : null;
+
   return (
     <div className="bx--form-item">
       {label}
       {input}
+      {helper}
       {error}
     </div>
   );
@@ -88,6 +94,7 @@ TextInput.propTypes = {
   hideLabel: PropTypes.bool,
   invalid: PropTypes.bool,
   invalidText: PropTypes.string,
+  helperText: PropTypes.node,
   /**
    * `true` to use the light version.
    */
@@ -102,6 +109,7 @@ TextInput.defaultProps = {
   onClick: () => {},
   invalid: false,
   invalidText: '',
+  helperText: '',
   light: false,
 };
 


### PR DESCRIPTION
Adds support for helper text element in TextInput, Select and NumberInput components. See [Carbon Design System](http://www.carbondesignsystem.com/components/text-input/code) for reference.

#### Changelog

**Changed**

* {{TextInput}}: new {{helperText}} property
* {{NumberInput}}: new {{helperText}} property
* {{Select}}: new {{helperText}} property

