### PR TITLE
feat(data-table): allow isSortable to be defined in getHeaderProps

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -139,13 +139,13 @@ export default class DataTable extends React.Component {
    * @param {Function} config.onClick a custom click handler for the header
    * @returns {Object}
    */
-  getHeaderProps = ({ header, onClick, ...rest }) => {
+  getHeaderProps = ({ header, onClick, isSortable = true, ...rest }) => {
     const { sortDirection, sortHeaderKey } = this.state;
     return {
       ...rest,
       key: header.key,
       sortDirection,
-      isSortable: true,
+      isSortable,
       isSortHeader: sortHeaderKey === header.key,
       // Compose the event handlers so we don't overwrite a consumer's `onClick`
       // handler


### PR DESCRIPTION
Small QOL fix to allow folks to pass in `isSortable` to `getHeaderProps` and have that pass through to the underlying `TableHeader` component.

#### Changelog

**New**

**Changed**

* `getHeaderProps` now reads `isSortable` from arguments passed in, defaulting to true

**Removed**
