### PR TITLE
chore(spelling): put space in time zone picker

### DIFF
--- a/src/components/TimePicker/TimePicker-story.js
+++ b/src/components/TimePicker/TimePicker-story.js
@@ -62,8 +62,8 @@ storiesOf('TimePicker', module)
             <SelectItem value="PM" text="PM" />
           </TimePickerSelect>
           <TimePickerSelect id="time-picker-select-2" {...selectProps}>
-            <SelectItem value="Timezone 1" text="Timezone 1" />
-            <SelectItem value="Timezone 2" text="Timezone 2" />
+            <SelectItem value="Time zone 1" text="Time zone 1" />
+            <SelectItem value="Time zone 2" text="Time zone 2" />
           </TimePickerSelect>
         </TimePicker>
       );


### PR DESCRIPTION
Closes IBM/carbon-components-react#

fix for https://github.com/IBM/carbon-components-react/issues/1170 , placing space in "Time zone" in the time zone picker

#### Changelog

**Changed**

* the space in in the time zone picker dropdown 

![bitmoji](https://render.bitstrips.com/v2/cpanel/fbf70eb2-c012-465e-9c1e-7b092675dfd8-98edfe88-38e8-4a6b-bd23-6f7757eac54b-v1.png?transparent=1&palette=1&width=246)
