### PR TITLE
fix(structured-list): add storybook addon-info

### DIFF
--- a/src/components/StructuredList/StructuredList-story.js
+++ b/src/components/StructuredList/StructuredList-story.js
@@ -35,9 +35,9 @@ storiesOf('StructuredList', module)
             <StructuredListCell>Row 1</StructuredListCell>
             <StructuredListCell>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-              vulputate nisl a porttitor interdum.
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
             </StructuredListCell>
           </StructuredListRow>
           <StructuredListRow>
@@ -45,9 +45,9 @@ storiesOf('StructuredList', module)
             <StructuredListCell>Row 2</StructuredListCell>
             <StructuredListCell>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-              vulputate nisl a porttitor interdum.
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
             </StructuredListCell>
           </StructuredListRow>
         </StructuredListBody>
@@ -90,9 +90,9 @@ storiesOf('StructuredList', module)
             <StructuredListCell>Row 1</StructuredListCell>
             <StructuredListCell>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-              vulputate nisl a porttitor interdum.
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
             </StructuredListCell>
           </StructuredListRow>
           <StructuredListRow label htmlFor="row-2">
@@ -113,9 +113,9 @@ storiesOf('StructuredList', module)
             <StructuredListCell>Row 2</StructuredListCell>
             <StructuredListCell>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-              vulputate nisl a porttitor interdum.
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
             </StructuredListCell>
           </StructuredListRow>
         </StructuredListBody>

--- a/src/components/StructuredList/StructuredList-story.js
+++ b/src/components/StructuredList/StructuredList-story.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
 import { iconCheckmarkSolid } from 'carbon-icons';
 import Icon from '../Icon';
 import {
@@ -13,103 +14,124 @@ import {
 import StructuredListSkeleton from '../StructuredList/StructuredList.Skeleton';
 
 storiesOf('StructuredList', module)
-  .add('Simple', () => (
-    <StructuredListWrapper>
-      <StructuredListHead>
-        <StructuredListRow head>
-          <StructuredListCell head>ColumnA</StructuredListCell>
-          <StructuredListCell head>ColumnB</StructuredListCell>
-          <StructuredListCell head>ColumnC</StructuredListCell>
-        </StructuredListRow>
-      </StructuredListHead>
-      <StructuredListBody>
-        <StructuredListRow>
-          <StructuredListCell noWrap>Row 1</StructuredListCell>
-          <StructuredListCell>Row 1</StructuredListCell>
-          <StructuredListCell>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-            magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-            sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-            vulputate nisl a porttitor interdum.
-          </StructuredListCell>
-        </StructuredListRow>
-        <StructuredListRow>
-          <StructuredListCell noWrap>Row 2</StructuredListCell>
-          <StructuredListCell>Row 2</StructuredListCell>
-          <StructuredListCell>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-            magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-            sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-            vulputate nisl a porttitor interdum.
-          </StructuredListCell>
-        </StructuredListRow>
-      </StructuredListBody>
-    </StructuredListWrapper>
-  ))
-  .add('Selection', () => (
-    <StructuredListWrapper selection border>
-      <StructuredListHead>
-        <StructuredListRow head>
-          <StructuredListCell head>{''}</StructuredListCell>
-          <StructuredListCell head>ColumnA</StructuredListCell>
-          <StructuredListCell head>ColumnB</StructuredListCell>
-          <StructuredListCell head>ColumnC</StructuredListCell>
-        </StructuredListRow>
-      </StructuredListHead>
-      <StructuredListBody>
-        <StructuredListRow label htmlFor="row-1">
-          <StructuredListInput
-            id="row-1"
-            value="row-1"
-            title="row-1"
-            name="row-1"
-            defaultChecked
-          />
-          <StructuredListCell>
-            <Icon
-              className="bx--structured-list-svg"
-              icon={iconCheckmarkSolid}
-              description="select an option"
+  .add(
+    'Simple',
+    withInfo({
+      text: `
+        Structured Lists group content that is similar or related, such as terms or definitions.
+      `,
+    })(() => (
+      <StructuredListWrapper>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>ColumnA</StructuredListCell>
+            <StructuredListCell head>ColumnB</StructuredListCell>
+            <StructuredListCell head>ColumnC</StructuredListCell>
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          <StructuredListRow>
+            <StructuredListCell noWrap>Row 1</StructuredListCell>
+            <StructuredListCell>Row 1</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+              vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+          <StructuredListRow>
+            <StructuredListCell noWrap>Row 2</StructuredListCell>
+            <StructuredListCell>Row 2</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+              vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+        </StructuredListBody>
+      </StructuredListWrapper>
+    ))
+  )
+  .add(
+    'Selection',
+    withInfo({
+      text: `
+        Structured Lists with selection allow a row of list content to be selected.
+      `,
+    })(() => (
+      <StructuredListWrapper selection border>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>{''}</StructuredListCell>
+            <StructuredListCell head>ColumnA</StructuredListCell>
+            <StructuredListCell head>ColumnB</StructuredListCell>
+            <StructuredListCell head>ColumnC</StructuredListCell>
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          <StructuredListRow label htmlFor="row-1">
+            <StructuredListInput
+              id="row-1"
+              value="row-1"
+              title="row-1"
+              name="row-1"
+              defaultChecked
             />
-          </StructuredListCell>
-          <StructuredListCell>Row 1</StructuredListCell>
-          <StructuredListCell>Row 1</StructuredListCell>
-          <StructuredListCell>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-            magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-            sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-            vulputate nisl a porttitor interdum.
-          </StructuredListCell>
-        </StructuredListRow>
-        <StructuredListRow label htmlFor="row-2">
-          <StructuredListInput
-            id="row-2"
-            value="row-2"
-            title="row-2"
-            name="row-1"
-          />
-          <StructuredListCell>
-            <Icon
-              className="bx--structured-list-svg"
-              icon={iconCheckmarkSolid}
-              description="select an option"
+            <StructuredListCell>
+              <Icon
+                className="bx--structured-list-svg"
+                icon={iconCheckmarkSolid}
+                description="select an option"
+              />
+            </StructuredListCell>
+            <StructuredListCell>Row 1</StructuredListCell>
+            <StructuredListCell>Row 1</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+              vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+          <StructuredListRow label htmlFor="row-2">
+            <StructuredListInput
+              id="row-2"
+              value="row-2"
+              title="row-2"
+              name="row-1"
             />
-          </StructuredListCell>
-          <StructuredListCell>Row 2</StructuredListCell>
-          <StructuredListCell>Row 2</StructuredListCell>
-          <StructuredListCell>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
-            magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
-            sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
-            vulputate nisl a porttitor interdum.
-          </StructuredListCell>
-        </StructuredListRow>
-      </StructuredListBody>
-    </StructuredListWrapper>
-  ))
-  .add('skeleton', () => (
-    <div style={{ width: '800px' }}>
-      <StructuredListSkeleton />
-      <StructuredListSkeleton border />
-    </div>
-  ));
+            <StructuredListCell>
+              <Icon
+                className="bx--structured-list-svg"
+                icon={iconCheckmarkSolid}
+                description="select an option"
+              />
+            </StructuredListCell>
+            <StructuredListCell>Row 2</StructuredListCell>
+            <StructuredListCell>Row 2</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean posuere
+              sem vel euismod dignissim. Nulla ut cursus dolor. Pellentesque
+              vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+        </StructuredListBody>
+      </StructuredListWrapper>
+    ))
+  )
+  .add(
+    'skeleton',
+    withInfo({
+      text: `
+        Placeholder skeleton state to use when content is loading.
+      `,
+    })(() => (
+      <div style={{ width: '800px' }}>
+        <StructuredListSkeleton />
+        <StructuredListSkeleton border />
+      </div>
+    ))
+  );


### PR DESCRIPTION
Adds addon-info storybook implementation with text descriptions.

Closes IBM/carbon-components-react#1229

#### Changelog

**New**
* Add `@storybook/addon-info` implementation to the `StructuredList` stories
* Add `... withInfo` with text descriptions, similar to what's done in other components in this repo

**Changed**
* Indentation to accommodate `addons-info` implementation