### PR TITLE
RFC: chore(components): use named exports from React

### DIFF
--- a/src/components/Accordion/Accordion.Skeleton.js
+++ b/src/components/Accordion/Accordion.Skeleton.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Icon from '../Icon';
 import SkeletonText from '../SkeletonText';
 import { iconChevronRight } from 'carbon-icons';
 
-export default class AccordionSkeleton extends React.Component {
+export default class AccordionSkeleton extends Component {
   render() {
     const item = (
       <li className="bx--accordion__item">

--- a/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class BreadcrumbSkeleton extends React.Component {
+export default class BreadcrumbSkeleton extends Component {
   render() {
     const item = (
       <div className="bx--breadcrumb-item">

--- a/src/components/BreadcrumbItem/BreadcrumbItem.js
+++ b/src/components/BreadcrumbItem/BreadcrumbItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import classnames from 'classnames';
 import Link from '../Link';
 
@@ -7,7 +7,7 @@ const newChild = (children, href) => {
   if (typeof children === 'string' && !(href === undefined)) {
     return <Link href={href}>{children}</Link>;
   } else {
-    return React.cloneElement(React.Children.only(children), {
+    return cloneElement(Children.only(children), {
       className: 'bx--link',
     });
   }

--- a/src/components/Checkbox/Checkbox.Skeleton.js
+++ b/src/components/Checkbox/Checkbox.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class CheckboxSkeleton extends React.Component {
+export default class CheckboxSkeleton extends Component {
   render() {
     const { id } = this.props;
     return (

--- a/src/components/ComboBox/ComboBox.js
+++ b/src/components/ComboBox/ComboBox.js
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import Downshift from 'downshift';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
 
 const defaultItemToString = item => {
@@ -26,7 +26,7 @@ const getInputValue = (props, state) => {
   return state.inputValue || '';
 };
 
-export default class ComboBox extends React.Component {
+export default class ComboBox extends Component {
   static propTypes = {
     /**
      * An optional className to add to the container node

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { iconClose } from 'carbon-icons';
 import Button from '../Button';
@@ -75,9 +75,9 @@ export default class ComposedModal extends Component {
       [containerClassName]: containerClassName,
     });
 
-    const childrenWithProps = React.Children.toArray(children).map(child => {
+    const childrenWithProps = Children.toArray(children).map(child => {
       if (child.type === ModalHeader || child.type === ModalFooter) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           closeModal: this.closeModal,
         });
       }

--- a/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/src/components/ContentSwitcher/ContentSwitcher.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import { composeEventHandlers } from '../../tools/events';
 
-export default class ContentSwitcher extends React.Component {
+export default class ContentSwitcher extends Component {
   state = {};
 
   static propTypes = {
@@ -44,8 +44,8 @@ export default class ContentSwitcher extends React.Component {
   }
 
   getChildren(children) {
-    return React.Children.map(children, (child, index) =>
-      React.cloneElement(child, {
+    return Children.map(children, (child, index) =>
+      cloneElement(child, {
         index,
         onClick: composeEventHandlers([
           this.handleChildChange,

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import isEqual from 'lodash.isequal';
 import getDerivedStateFromProps from './state/getDerivedStateFromProps';
 import { getNextSortState } from './state/sorting';
@@ -41,7 +41,7 @@ const translateWithId = id => defaultTranslations[id];
  * and updating the state of the single entity will cascade updates to the
  * consumer.
  */
-export default class DataTable extends React.Component {
+export default class DataTable extends Component {
   static propTypes = {
     /**
      * The `rows` prop is where you provide us with a list of all the rows that

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { iconDownload, iconEdit, iconSettings } from 'carbon-icons';
 import Button from '../../Button';
 import DataTable, {
@@ -374,7 +374,7 @@ describe('DataTable', () => {
                 </TableHead>
                 <TableBody>
                   {rows.map(row => (
-                    <React.Fragment key={row.id}>
+                    <Fragment key={row.id}>
                       <TableExpandRow {...getRowProps({ row })}>
                         <TableSelectRow {...getSelectionProps({ row })} />
                         {row.cells.map(cell => (
@@ -389,7 +389,7 @@ describe('DataTable', () => {
                           </TableCell>
                         </TableExpandedRow>
                       )}
-                    </React.Fragment>
+                    </Fragment>
                   ))}
                 </TableBody>
               </Table>

--- a/src/components/DataTable/stories/with-dynamic-content.js
+++ b/src/components/DataTable/stories/with-dynamic-content.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, Fragment } from 'react';
 import { action } from '@storybook/addon-actions';
 import { iconDownload, iconEdit, iconSettings } from 'carbon-icons';
 import DataTable, {
@@ -30,7 +30,7 @@ export default () => {
     return [...array.slice(0, index), element, ...array.slice(index)];
   };
 
-  class DynamicRows extends React.Component {
+  class DynamicRows extends Component {
     state = {
       rows: initialRows,
       headers: headers,
@@ -152,7 +152,7 @@ export default () => {
                 </TableHead>
                 <TableBody>
                   {rows.map(row => (
-                    <React.Fragment key={row.id}>
+                    <Fragment key={row.id}>
                       <TableExpandRow {...getRowProps({ row })}>
                         <TableSelectRow {...getSelectionProps({ row })} />
                         {row.cells.map(cell => (
@@ -167,7 +167,7 @@ export default () => {
                           </TableCell>
                         </TableExpandedRow>
                       )}
-                    </React.Fragment>
+                    </Fragment>
                   ))}
                 </TableBody>
               </Table>

--- a/src/components/DataTable/stories/with-expansion.js
+++ b/src/components/DataTable/stories/with-expansion.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import DataTable, {
   Table,
   TableBody,
@@ -32,7 +32,7 @@ export default () => (
           </TableHead>
           <TableBody>
             {rows.map(row => (
-              <React.Fragment key={row.id}>
+              <Fragment key={row.id}>
                 <TableExpandRow {...getRowProps({ row })}>
                   {row.cells.map(cell => (
                     <TableCell key={cell.id}>{cell.value}</TableCell>
@@ -46,7 +46,7 @@ export default () => (
                     </TableCell>
                   </TableExpandedRow>
                 )}
-              </React.Fragment>
+              </Fragment>
             ))}
           </TableBody>
         </Table>

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import flatpickr from 'flatpickr';
 import l10n from 'flatpickr/dist/l10n/index';
@@ -438,25 +438,25 @@ export default class DatePicker extends Component {
         ''
       );
 
-    const childArray = React.Children.toArray(children);
+    const childArray = Children.toArray(children);
     const childrenWithProps = childArray.map((child, index) => {
       if (index === 0 && child.type === DatePickerInput) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           datePickerType,
           ref: this.assignInputFieldRef,
           openCalendar: this.openCalendar,
         });
       } else if (index === 1 && child.type === DatePickerInput) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           datePickerType,
           ref: this.assignToInputFieldRef,
         });
       } else if (index === 0) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           ref: this.assignInputFieldRef,
         });
       } else if (index === 1) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           ref: this.assignToInputFieldRef,
         });
       }

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import warning from 'warning';
 import { iconCaretDown } from 'carbon-icons';
@@ -76,7 +76,7 @@ export default class Dropdown extends PureComponent {
     const { children, selectedText, value, defaultText, open } = props;
 
     let matchingChild;
-    React.Children.forEach(children, child => {
+    Children.forEach(children, child => {
       if (
         child &&
         (child.props.itemText === selectedText || child.props.value === value)
@@ -143,10 +143,10 @@ export default class Dropdown extends PureComponent {
       ...other
     } = this.props;
 
-    const children = React.Children.toArray(this.props.children)
+    const children = Children.toArray(this.props.children)
       .filter(Boolean)
       .map(child =>
-        React.cloneElement(child, {
+        cloneElement(child, {
           onClick: (...args) => {
             child.props.onClick && child.props.onClick(...args);
             this.handleItemClick(...args);

--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import Downshift from 'downshift';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
 
 const defaultItemToString = item => {
@@ -12,7 +12,7 @@ const defaultItemToString = item => {
   return item ? item.label : '';
 };
 
-export default class DropdownV2 extends React.Component {
+export default class DropdownV2 extends Component {
   static propTypes = {
     /**
      * Disable the control

--- a/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/src/components/FileUploader/FileUploader.Skeleton.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { Component } from 'react';
 import SkeletonText from '../SkeletonText';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 
-export default class FileUploaderSkeleton extends React.Component {
+export default class FileUploaderSkeleton extends Component {
   render() {
     return (
       <div className="bx--form-item">

--- a/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/src/components/InlineCheckbox/InlineCheckbox.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class InlineCheckbox extends React.Component {
+export default class InlineCheckbox extends Component {
   static propTypes = {
     /**
      * Specify the label for the control

--- a/src/components/InlineLoading/InlineLoading.js
+++ b/src/components/InlineLoading/InlineLoading.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Loading from '../Loading';
 
-export default class InlineLoading extends React.Component {
+export default class InlineLoading extends Component {
   static propTypes = {
     /**
      * Specify a custom className to be applied to the container node

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
-export default class Loading extends React.Component {
+export default class Loading extends Component {
   static propTypes = {
     /**
      * Specify whether you want the loading indicator to be spinning or not

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import classNames from 'classnames';
 import { iconClose } from 'carbon-icons';
 import Icon from '../Icon';
@@ -52,9 +52,9 @@ export default class Modal extends Component {
     selectorPrimaryFocus: '[data-modal-primary-focus]',
   };
 
-  button = React.createRef();
-  outerModal = React.createRef();
-  innerModal = React.createRef();
+  button = createRef();
+  outerModal = createRef();
+  innerModal = createRef();
 
   elementOrParentIsFloatingMenu = target => {
     if (target && typeof target.closest === 'function') {

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
 import { ButtonTypes } from '../../prop-types/types';
 
-export default class ModalWrapper extends React.Component {
+export default class ModalWrapper extends Component {
   static propTypes = {
     status: PropTypes.string,
     handleOpen: PropTypes.func,

--- a/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/src/components/MultiSelect/FilterableMultiSelect.js
@@ -1,6 +1,6 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import Downshift from 'downshift';
 import isEqual from 'lodash.isequal';
 import ListBox from '../ListBox';
@@ -11,7 +11,7 @@ import { defaultItemToString } from './tools/itemToString';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 import { defaultFilterItems } from '../ComboBox/tools/filter';
 
-export default class FilterableMultiSelect extends React.Component {
+export default class FilterableMultiSelect extends Component {
   static propTypes = {
     ...sortingPropTypes,
 

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Downshift from 'downshift';
 import isEqual from 'lodash.isequal';
@@ -10,7 +10,7 @@ import { sortingPropTypes } from './MultiSelectPropTypes';
 import { defaultItemToString } from './tools/itemToString';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 
-export default class MultiSelect extends React.Component {
+export default class MultiSelect extends Component {
   static propTypes = {
     ...sortingPropTypes,
 

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import warning from 'warning';
 import { iconOverflowMenu } from 'carbon-icons';
@@ -481,8 +481,8 @@ export default class OverflowMenu extends Component {
       iconClass
     );
 
-    const childrenWithProps = React.Children.toArray(children).map(child =>
-      React.cloneElement(child, {
+    const childrenWithProps = Children.toArray(children).map(child =>
+      cloneElement(child, {
         closeMenu: this.closeMenu,
         floatingMenu: floatingMenu || undefined,
       })
@@ -508,7 +508,7 @@ export default class OverflowMenu extends Component {
           menuRef={this._bindMenuBody}
           target={this._getTarget}
           onPlace={this._handlePlace}>
-          {React.cloneElement(menuBody, {
+          {cloneElement(menuBody, {
             'data-floating-menu-direction': direction,
           })}
         </FloatingMenu>

--- a/src/components/PaginationV2/Pagination.Skeleton.js
+++ b/src/components/PaginationV2/Pagination.Skeleton.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { Component } from 'react';
 import SkeletonText from '../SkeletonText';
 
-export default class PaginationSkeleton extends React.Component {
+export default class PaginationSkeleton extends Component {
   render() {
     return (
       <div className="bx--pagination bx--skeleton">

--- a/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class ProgressIndicatorSkeleton extends React.Component {
+export default class ProgressIndicatorSkeleton extends Component {
   render() {
     const step = (
       <li className="bx--progress-step bx--progress-step--incomplete">

--- a/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import classnames from 'classnames';
 
 export const ProgressStep = ({ ...props }) => {
@@ -110,17 +110,17 @@ export class ProgressIndicator extends Component {
   }
 
   renderSteps = () =>
-    React.Children.map(this.props.children, (child, index) => {
+    Children.map(this.props.children, (child, index) => {
       if (index === this.state.currentIndex) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           current: true,
         });
       } else if (index < this.state.currentIndex) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           complete: true,
         });
       } else if (index > this.state.currentIndex) {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           complete: false,
         });
       }

--- a/src/components/RadioButton/RadioButton.Skeleton.js
+++ b/src/components/RadioButton/RadioButton.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class RadioButtonSkeleton extends React.Component {
+export default class RadioButtonSkeleton extends Component {
   render() {
     const { id } = this.props;
     return (

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import uid from '../../tools/uniqueId';
 
-export default class RadioButton extends React.Component {
+export default class RadioButton extends Component {
   static propTypes = {
     /**
      * Specify whether the <RadioButton> is currently checked

--- a/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component, Children } from 'react';
 import RadioButton from '../RadioButton';
 import warning from 'warning';
 
-export default class RadioButtonGroup extends React.Component {
+export default class RadioButtonGroup extends Component {
   state = { selected: this.props.valueSelected || this.props.defaultSelected };
 
   static propTypes = {
@@ -60,7 +60,7 @@ export default class RadioButtonGroup extends React.Component {
   }
 
   getRadioButtons = () => {
-    const children = React.Children.map(this.props.children, radioButton => {
+    const children = Children.map(this.props.children, radioButton => {
       const { value, ...other } = radioButton.props;
       /* istanbul ignore if */
       if (radioButton.props.hasOwnProperty('checked')) {

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import uid from '../../tools/uniqueId';
 import Icon from '../Icon';
 import { iconCheckmarkSolid } from 'carbon-icons';
 import classNames from 'classnames';
 
-export default class RadioTile extends React.Component {
+export default class RadioTile extends Component {
   static propTypes = {
     /**
      * `true` if this tile should be selected.

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
 const Switch = props => {
@@ -41,7 +41,7 @@ const Switch = props => {
   };
 
   const btnIcon = icon
-    ? React.cloneElement(icon, {
+    ? cloneElement(icon, {
         className: classNames(
           icon.props.className,
           ' bx--content-switcher__icon'

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
-export default class Tab extends React.Component {
+export default class Tab extends Component {
   static propTypes = {
     className: PropTypes.string,
     handleTabClick: PropTypes.func,

--- a/src/components/TableBody/TableBody.js
+++ b/src/components/TableBody/TableBody.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import TableRow from '../TableRow';
 
@@ -21,7 +21,7 @@ const handleRowStriping = rows => {
       const even = 'even' in child.props ? child.props.even : count % 2 === 1;
 
       // Return a clone of the element with the `even` prop set.
-      return React.cloneElement(child, { even });
+      return cloneElement(child, { even });
     }
 
     return child;
@@ -33,7 +33,7 @@ const TableBody = props => {
 
   const tableBodyClasses = classNames(className, 'bx--table-body');
 
-  const childArray = React.Children.toArray(children);
+  const childArray = Children.toArray(children);
   const childrenWithProps = handleRowStriping(childArray);
 
   return (

--- a/src/components/Tabs/Tabs.Skeleton.js
+++ b/src/components/Tabs/Tabs.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class TabsSkeleton extends React.Component {
+export default class TabsSkeleton extends Component {
   render() {
     const tab = (
       <li className="bx--tabs__nav-item">

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import classNames from 'classnames';
 import { iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import TabContent from '../TabContent';
 
-export default class Tabs extends React.Component {
+export default class Tabs extends Component {
   static propTypes = {
     /**
      * Specify the text to be read by screen-readers when visiting the <Tabs>
@@ -95,13 +95,11 @@ export default class Tabs extends React.Component {
   }
 
   getTabs() {
-    return React.Children.map(this.props.children, tab => tab);
+    return Children.map(this.props.children, tab => tab);
   }
 
   getTabAt = index => {
-    return (
-      this[`tab${index}`] || React.Children.toArray(this.props.children)[index]
-    );
+    return this[`tab${index}`] || Children.toArray(this.props.children)[index];
   };
 
   setTabAt = (index, tabRef) => {
@@ -134,7 +132,7 @@ export default class Tabs extends React.Component {
 
   handleTabAnchorFocus = onSelectionChange => {
     return index => {
-      const tabCount = React.Children.count(this.props.children) - 1;
+      const tabCount = Children.count(this.props.children) - 1;
       let tabIndex = index;
 
       if (index < 0) {
@@ -183,7 +181,7 @@ export default class Tabs extends React.Component {
     } = this.props;
 
     const tabsWithProps = this.getTabs().map((tab, index) => {
-      const newTab = React.cloneElement(tab, {
+      const newTab = cloneElement(tab, {
         index,
         selected: index === this.state.selected,
         handleTabClick: this.handleTabClick(onSelectionChange),
@@ -197,7 +195,7 @@ export default class Tabs extends React.Component {
       return newTab;
     });
 
-    const tabContentWithProps = React.Children.map(tabsWithProps, tab => {
+    const tabContentWithProps = Children.map(tabsWithProps, tab => {
       const { children, selected } = tab.props;
 
       return (

--- a/src/components/Tag/Tag.Skeleton.js
+++ b/src/components/Tag/Tag.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class TagSkeleton extends React.Component {
+export default class TagSkeleton extends Component {
   render() {
     return <span className="bx--tag bx--skeleton" />;
   }

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import React, { Component, Children, cloneElement } from 'react';
+import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { iconCheckmarkSolid, iconChevronDown } from 'carbon-icons';
@@ -324,7 +324,7 @@ export class ExpandableTile extends Component {
 
   componentDidMount = () => {
     if (this.refs[0]) {
-      this.aboveTheFold = ReactDOM.findDOMNode(this.refs[0]); // eslint-disable-line
+      this.aboveTheFold = findDOMNode(this.refs[0]); // eslint-disable-line
     }
     const getStyle = window.getComputedStyle(this.tile, null);
     this.setState({
@@ -360,7 +360,7 @@ export class ExpandableTile extends Component {
   };
 
   getChildren = () => {
-    return React.Children.map(this.props.children, child => child);
+    return Children.map(this.props.children, child => child);
   };
 
   render() {
@@ -389,7 +389,7 @@ export class ExpandableTile extends Component {
       maxHeight: this.state.tileMaxHeight + this.state.tilePadding,
     };
     const content = this.getChildren().map((child, index) => {
-      return React.cloneElement(child, { ref: index });
+      return cloneElement(child, { ref: index });
     });
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component, Children } from 'react';
 import RadioTile from '../RadioTile';
 import warning from 'warning';
 
-export default class TileGroup extends React.Component {
+export default class TileGroup extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -30,7 +30,7 @@ export default class TileGroup extends React.Component {
   }
 
   getRadioTiles = () => {
-    const childrenArray = React.Children.toArray(this.props.children);
+    const childrenArray = Children.toArray(this.props.children);
     const children = childrenArray.map(tileRadio => {
       const { value, ...other } = tileRadio.props;
       /* istanbul ignore if */

--- a/src/components/Toggle/Toggle.Skeleton.js
+++ b/src/components/Toggle/Toggle.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class ToggleSkeleton extends React.Component {
+export default class ToggleSkeleton extends Component {
   render() {
     const { id } = this.props;
     return (

--- a/src/components/ToggleSmall/ToggleSmall.Skeleton.js
+++ b/src/components/ToggleSmall/ToggleSmall.Skeleton.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default class ToggleSmallSkeleton extends React.Component {
+export default class ToggleSmallSkeleton extends Component {
   render() {
     const { id } = this.props;
     return (

--- a/src/internal/ClickListener.js
+++ b/src/internal/ClickListener.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component, cloneElement } from 'react';
 
 /**
  * Generic component used for reacting to a click event happening outside of a
  * given `children` element.
  */
-export default class ClickListener extends React.Component {
+export default class ClickListener extends Component {
   static propTypes = {
     children: PropTypes.element.isRequired,
     onClickOutside: PropTypes.func.isRequired,
@@ -55,7 +55,7 @@ export default class ClickListener extends React.Component {
   }
 
   render() {
-    return React.cloneElement(this.props.children, {
+    return cloneElement(this.props.children, {
       ref: this.handleRef,
     });
   }

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -1,7 +1,7 @@
 import warning from 'warning';
 import PropTypes from 'prop-types';
-import React, { createRef } from 'react';
-import ReactDOM from 'react-dom';
+import { Component, cloneElement, createRef } from 'react';
+import { createPortal } from 'react-dom';
 import window from 'window-or-global';
 
 /**
@@ -108,7 +108,7 @@ const getFloatingPosition = ({
  * A menu that is detached from the triggering element.
  * Useful when the container of the triggering element cannot have `overflow:visible` style, etc.
  */
-class FloatingMenu extends React.Component {
+class FloatingMenu extends Component {
   static propTypes = {
     /**
      * Contents to put into the floating menu.
@@ -306,7 +306,7 @@ class FloatingMenu extends React.Component {
           visibility: 'hidden',
           top: '0px',
         };
-    return React.cloneElement(children, {
+    return cloneElement(children, {
       ref: this._menuBody,
       style: {
         ...styles,
@@ -321,7 +321,7 @@ class FloatingMenu extends React.Component {
   render() {
     if (typeof document !== 'undefined') {
       const { target } = this.props;
-      return ReactDOM.createPortal(
+      return createPortal(
         this._getChildrenWithProps(),
         !target ? document.body : target()
       );

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component, cloneElement } from 'react';
 
 /**
  * Generic component used for reacting to a click event happening outside of a
  * given child component that used the forwarded `handleRef` function through
  * the `refKey` prop.
  */
-export default class InnerClickListener extends React.Component {
+export default class InnerClickListener extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     refKey: PropTypes.string.isRequired,
@@ -44,7 +44,7 @@ export default class InnerClickListener extends React.Component {
 
   render() {
     const { refKey, children } = this.props;
-    return React.cloneElement(children, {
+    return cloneElement(children, {
       [refKey]: this.handleRef,
     });
   }

--- a/src/internal/Selection.js
+++ b/src/internal/Selection.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 
-export default class Selection extends React.Component {
+export default class Selection extends Component {
   static propTypes = {
     initialSelectedItems: PropTypes.array.isRequired,
   };

--- a/src/internal/__tests__/ClickListener-test.js
+++ b/src/internal/__tests__/ClickListener-test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import ClickListener from '../ClickListener';
 import { shallow, mount } from 'enzyme';
 
@@ -70,7 +70,7 @@ describe('ClickListener', () => {
 
   it('should not overwrite any children function refs', () => {
     const mockRef = jest.fn();
-    class Child extends React.Component {
+    class Child extends Component {
       render() {
         return <div />;
       }
@@ -85,7 +85,7 @@ describe('ClickListener', () => {
   });
 
   it('should not call any string refs on children', () => {
-    class Child extends React.Component {
+    class Child extends Component {
       render() {
         return <div />;
       }

--- a/src/internal/__tests__/InnerClickListener-test.js
+++ b/src/internal/__tests__/InnerClickListener-test.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import { mount } from 'enzyme';
 import InnerClickListener from '../InnerClickListener';
 
@@ -11,7 +11,7 @@ describe('InnerClickListener', () => {
   beforeEach(() => {
     onClickOutside = jest.fn();
     handleRefSpy = jest.spyOn(InnerClickListener.prototype, 'handleRef');
-    InnerChild = class InnerChild extends React.Component {
+    InnerChild = class InnerChild extends Component {
       static propTypes = {
         innerRef: PropTypes.func.isRequired,
       };

--- a/src/prop-types/__tests__/childrenOf-test.js
+++ b/src/prop-types/__tests__/childrenOf-test.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { Component } from 'react';
 import childrenOf from '../childrenOf';
 
 const StatelessComponent = () => <div />;
-class ClassComponent extends React.Component {
+class ClassComponent extends Component {
   render() {
     return <div />;
   }

--- a/src/prop-types/__tests__/childrenOfType-test.js
+++ b/src/prop-types/__tests__/childrenOfType-test.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import childrenOfType from '../childrenOfType';
 
 const Element = <span />;
 const StatelessComponent = () => <div />;
-class ClassComponent extends React.Component {
+class ClassComponent extends Component {
   render() {
     return <div />;
   }
@@ -109,7 +109,7 @@ describe('childrenOfType', () => {
   });
 
   it('should warn with an invalid prop type for an invalid class component child type', () => {
-    class BadClassComponent extends React.Component {
+    class BadClassComponent extends Component {
       render() {
         return <div />;
       }

--- a/src/prop-types/tools/__tests__/getDisplayName-test.js
+++ b/src/prop-types/tools/__tests__/getDisplayName-test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, createElement } from 'react';
 import getDisplayName from '../getDisplayName';
 
 describe('getDisplayName', () => {
@@ -9,18 +9,16 @@ describe('getDisplayName', () => {
 
   it('should get the name from a Stateless Functional Component', () => {
     const Child = () => <div />;
-    expect(getDisplayName(React.createElement(Child).type)).toBe('Child');
+    expect(getDisplayName(createElement(Child).type)).toBe('Child');
   });
 
   it('should get the displayName from a class Component', () => {
-    class Child extends React.Component {
+    class Child extends Component {
       static displayName = 'ChildDisplayName';
       render() {
         return null;
       }
     }
-    expect(getDisplayName(React.createElement(Child).type)).toBe(
-      Child.displayName
-    );
+    expect(getDisplayName(createElement(Child).type)).toBe(Child.displayName);
   });
 });

--- a/src/tools/withState.js
+++ b/src/tools/withState.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-export default class WithState extends React.PureComponent {
+export default class WithState extends PureComponent {
   static propTypes = {
     initialState: PropTypes.object,
   };

--- a/src/tools/wrapComponent.js
+++ b/src/tools/wrapComponent.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import { createElement } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 const wrapComponent = ({ name, className, type }) => {
   const Component = props => {
     const componentClass = cx(className, props.className);
-    return React.createElement(type, {
+    return createElement(type, {
       ...props,
       // Prevent Weird quirk where `cx` will evaluate to an empty string, '',
       // and so we have empty `class` attributes in the resulting markup


### PR DESCRIPTION
This change goes away from `React.*` and `ReactDOM.*` and uses named exports from `react` and `react-dom` instead. The merits are:

* Ability of static analysis (e.g. ESLint will catch typo which cannot be done with object properties)
* Slightly better minification (Minifier cannot shorten object property names)

I understand above merits are minor and up to team’s taste. Anybody feel free to bring up your preference - The goal is code consistency rather than the specific choice this PR has.

#### Changelog

**Changed**

* From `React.*` and `ReactDOM.*` to named exports from `react` and `react-dom`