### PR TITLE
docs: update meta tags on root html

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,19 @@
+<meta name="keywords" content="IBM, design, system, Carbon, design system, Bluemix, styleguide, style, guide, components, library, pattern, kit, component, cloud, React, React.js">
+<meta name="description" content="This is the React implementation of the Carbon Design System. Carbon is a series of individual styles and components, that when combined make beautiful, intuitive designs.">
+
+<!-- Open Graph -->
+<meta property="og:title" content="Carbon Components React">
+<meta property="og:site_name" content="Carbon Components React">
+<meta property="og:description" content="This is the React implementation of the Carbon Design System. Carbon is a series of individual styles and components, that when combined make beautiful, intuitive designs.">
+<meta property="og:image" content="https://media.github.ibm.com/user/525/files/59e3bfde-b990-11e7-87ef-072e89a87719">
+<meta property="og:url" content="http://react.carbondesignsystem.com">
+
+<!-- Social -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image:alt" content="Carbon Design System">
+<meta name="twitter:site" content="@_carbondesign">
+
+<!-- Storybook override -->
+<script>
+    document.title = 'Carbon Components React'
+</script>

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -15,5 +15,5 @@
 
 <!-- Storybook override -->
 <script>
-    document.title = 'Carbon Components React'
+  document.title = 'Carbon Components React';
 </script>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1236

This adds some meta tags to improve search results/sharing of Carbon Components React. At this time, Storybook doesn't offer an option to change the page title so it needs to be done with a script tag. Tacking on a second title tag is a no-op.

#### Changelog

**New**

* `manager-head.html` is the escape hatch provided by Storybook for this sort of thing.