### PR TITLE
Revert "docs(FileUploader): restore 'none' `buttonKind` knob (#1202)"

### DIFF
--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -17,7 +17,6 @@ import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
 import Button from '../Button';
 
 const buttonKinds = {
-  none: 'None ()',
   primary: 'Primary (primary)',
   secondary: 'Secondary (secondary)',
   danger: 'Danger (danger)',
@@ -34,13 +33,13 @@ const filenameStatuses = {
 
 const props = {
   fileUploaderButton: () => {
-    const buttonKind = select('Button kind (buttonKind)', buttonKinds, 'none');
+    const buttonKind = select('Button kind (buttonKind)', buttonKinds, '');
     return {
       className: 'bob',
       labelText: text('Label text (labelText)', 'Add files'),
       name: text('Form item name: (name)', ''),
       multiple: boolean('Supports multiple files (multiple)', true),
-      buttonKind: buttonKind === 'none' ? '' : buttonKind,
+      buttonKind: buttonKind || 'primary',
       disableLabelChanges: boolean(
         'Prevent the label from being replaced with file selected file (disableLabelChanges)',
         false


### PR DESCRIPTION
This reverts commit 052822271c4663c153e25bd92f00ccb49e278153.

After a discussion with @asudoh who brought the issue to the rest of the core carbon team, it was decided that the values of `buttonKind` in the `FileUploaderButton` should be in sync with regular `Button`. This commit will revert the change that allowed `FileUploaderButton` to have a null value for the `buttonKind` prop in the Storybook example