### PR TITLE
docs(Storybook): switch @storybook/addon-options to dev dependency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,6 @@
 ---
 name: "Bug Report \U0001F41B"
 about: Create a report to help us improve
-
 ---
 
 <!-- Feel free to remove sections that aren't relevant.
@@ -31,8 +30,8 @@ about: Create a report to help us improve
 3. Step three
 4. etc.
 
-> Please create a reduced test case in code sandbox 
-https://codesandbox.io/s/r4zxq9pvq
+> Please create a reduced test case in code sandbox
+> https://codesandbox.io/s/r4zxq9pvq
 
 ## Additional information
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,6 @@
 ---
 name: "Feature request \U0001F4A1"
 about: Suggest an idea for this project
-
 ---
 
 Use this template if you want to request a new feature, or a change to an existing feature.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,6 @@
 ---
 name: Question ❓
 about: Usage question or discussion about Carbon Components React.
-
 ---
 
 <!--

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "react-dom": "^16.4.0"
   },
   "dependencies": {
-    "@storybook/addon-options": "^3.4.10",
     "classnames": "2.2.6",
     "downshift": "^1.31.14",
     "flatpickr": "4.5.1",
@@ -146,6 +145,7 @@
     "@storybook/addon-actions": "^3.4.10",
     "@storybook/addon-info": "^3.4.10",
     "@storybook/addon-knobs": "^3.4.10",
+    "@storybook/addon-options": "^3.4.10",
     "@storybook/addons": "^3.4.10",
     "@storybook/react": "^3.4.10",
     "all-contributors-cli": "^5.2.1",


### PR DESCRIPTION
Closes IBM/carbon-components-react#1259

@storybookaddon-options was added as a regular dependency when it should have been a dev dependency.

#### Changelog

**Changed**

* @storybook/addon-options from `dependencies` to `devDependencies`