### PR TITLE
fix(Modal): no focus-wrap for "window lost focus" condition

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -101,7 +101,8 @@ export default class Modal extends Component {
     if (
       this.innerModal &&
       this.props.open &&
-      (!evt.relatedTarget || !this.innerModal.contains(evt.relatedTarget)) &&
+      evt.relatedTarget &&
+      !this.innerModal.contains(evt.relatedTarget) &&
       !this.elementOrParentIsFloatingMenu(evt.relatedTarget)
     ) {
       this.focusModal();


### PR DESCRIPTION
As focus-wrap behavior is for handling focus on an element outside modal.

IE11 behaves as though window lost focus when focus goes onto `<select>`, which causes an adverse effect if such `<select>` is in a modal.

Fixes #1257.

#### Changelog

**Changed**

* Stopped running "focus-wrap" behavior in modal if browser window loses focus (aligned with vanilla).