### PR TITLE
fix(DatePicker&DatePickerInput): add customizable iconDescription

### DIFF
--- a/src/components/DatePicker/DatePicker-story.js
+++ b/src/components/DatePicker/DatePicker-story.js
@@ -84,7 +84,13 @@ storiesOf('DatePicker', module)
           'The date format (dateFormat in <DatePicker>)',
           'm/d/Y'
         )}>
-        <DatePickerInput {...props.datePickerInput()} />
+        <DatePickerInput
+          {...props.datePickerInput()}
+          iconDescription={text(
+            'Icon description (iconDescription in <DatePickerInput>)',
+            'Icon description'
+          )}
+        />
       </DatePicker>
     ))
   )
@@ -103,6 +109,10 @@ storiesOf('DatePicker', module)
           dateFormat={text(
             'The date format (dateFormat in <DatePicker>)',
             'm/d/Y'
+          )}
+          iconDescription={text(
+            'Icon description (iconDescription in <DatePicker>)',
+            'Icon description'
           )}>
           <DatePickerInput
             {...datePickerInputProps}

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -49,6 +49,11 @@ export default class DatePicker extends Component {
     datePickerType: PropTypes.oneOf(['simple', 'single', 'range']),
 
     /**
+     * The description of the calendar icon.
+     */
+    iconDescription: PropTypes.string,
+
+    /**
      * The date format.
      */
     dateFormat: PropTypes.string,
@@ -398,6 +403,7 @@ export default class DatePicker extends Component {
       onChange, // eslint-disable-line
       locale, // eslint-disable-line
       value, // eslint-disable-line
+      iconDescription,
       ...other
     } = this.props;
 
@@ -414,6 +420,7 @@ export default class DatePicker extends Component {
         <Icon
           name="calendar"
           className="bx--date-picker__icon"
+          description={iconDescription}
           onClick={this.openCalendar}
         />
       ) : (

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -9,6 +9,10 @@ export default class DatePickerInput extends Component {
      * Specify an id that unique identifies the <input>
      */
     id: PropTypes.string.isRequired,
+    /**
+     * The description of the calendar icon.
+     */
+    iconDescription: PropTypes.string,
   };
 
   static defaultProps = {
@@ -34,6 +38,7 @@ export default class DatePickerInput extends Component {
       type,
       datePickerType,
       pattern,
+      iconDescription,
       ...other
     } = this.props;
 
@@ -60,7 +65,11 @@ export default class DatePickerInput extends Component {
 
     const datePickerIcon =
       datePickerType === 'single' ? (
-        <Icon name="calendar" className="bx--date-picker__icon" />
+        <Icon
+          name="calendar"
+          className="bx--date-picker__icon"
+          description={iconDescription}
+        />
       ) : (
         ''
       );


### PR DESCRIPTION
Closes IBM/carbon-components-react#1288

I've added a new prop in DatePicker and DatePickerInput that is passed down to icon component and used as a description.

#### Changelog

**New**

* new `iconDescription` prop in DatePicker component
* new `iconDescription` prop in DatePickerInput component

**Changed**

* props in `single with calendar` story
* props in `range with calendar` story