### PR TITLE
feat(ModalWrapper): return focus to modal trigger button on modal close

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -53,6 +53,8 @@ export default class Modal extends Component {
   };
 
   button = React.createRef();
+  outerModal = React.createRef();
+  innerModal = React.createRef();
 
   elementOrParentIsFloatingMenu = target => {
     if (target && typeof target.closest === 'function') {
@@ -88,8 +90,8 @@ export default class Modal extends Component {
 
   handleClick = evt => {
     if (
-      this.innerModal &&
-      !this.innerModal.contains(evt.target) &&
+      this.innerModal.current &&
+      !this.innerModal.current.contains(evt.target) &&
       !this.elementOrParentIsFloatingMenu(evt.target)
     ) {
       this.props.onRequestClose();
@@ -99,10 +101,10 @@ export default class Modal extends Component {
   handleBlur = evt => {
     // Keyboard trap
     if (
-      this.innerModal &&
+      this.innerModal.current &&
       this.props.open &&
       evt.relatedTarget &&
-      !this.innerModal.contains(evt.relatedTarget) &&
+      !this.innerModal.current.contains(evt.relatedTarget) &&
       !this.elementOrParentIsFloatingMenu(evt.relatedTarget)
     ) {
       this.focusModal();
@@ -118,8 +120,8 @@ export default class Modal extends Component {
   }
 
   focusModal = () => {
-    if (this.outerModal) {
-      this.outerModal.focus();
+    if (this.outerModal.current) {
+      this.outerModal.current.focus();
     }
   };
 
@@ -138,8 +140,8 @@ export default class Modal extends Component {
 
   handleTransitionEnd = evt => {
     if (
-      this.outerModal.offsetWidth &&
-      this.outerModal.offsetHeight &&
+      this.outerModal.current.offsetWidth &&
+      this.outerModal.current.offsetHeight &&
       this.beingOpen
     ) {
       this.focusButton(evt);
@@ -196,9 +198,7 @@ export default class Modal extends Component {
 
     const modalBody = (
       <div
-        ref={modal => {
-          this.innerModal = modal;
-        }}
+        ref={this.innerModal}
         role="dialog"
         className="bx--modal-container"
         aria-label={modalAriaLabel}>
@@ -242,9 +242,7 @@ export default class Modal extends Component {
         role="presentation"
         tabIndex={-1}
         onTransitionEnd={this.props.open ? this.handleTransitionEnd : undefined}
-        ref={outerModal => {
-          this.outerModal = outerModal;
-        }}>
+        ref={this.outerModal}>
         {modalBody}
       </div>
     );

--- a/src/components/ModalWrapper/ModalWrapper-test.js
+++ b/src/components/ModalWrapper/ModalWrapper-test.js
@@ -41,6 +41,19 @@ describe('ModalWrapper', () => {
     expect(wrapper.state('isOpen')).toBe(false);
   });
 
+  it('should return focus to the trigger button after closing', () => {
+    const wrapper = mount(
+      <ModalWrapper {...mockProps}>
+        <p className="bx--modal-content__text">Text</p>
+      </ModalWrapper>
+    );
+    const { triggerButton } = wrapper.instance();
+    jest.spyOn(triggerButton.current, 'focus');
+    wrapper.find({ children: mockProps.buttonTriggerText }).simulate('click');
+    wrapper.find({ children: mockProps.primaryButtonText }).simulate('click');
+    expect(triggerButton.current.focus).toHaveBeenCalledTimes(1);
+  });
+
   it('should not close after an unsuccessful submit action', () => {
     mockProps.handleSubmit = jest.fn(() => false);
     const wrapper = mount(

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -34,6 +34,7 @@ export default class ModalWrapper extends React.Component {
     onKeyDown: () => {},
   };
 
+  triggerButton = React.createRef();
   state = {
     isOpen: false,
   };
@@ -45,9 +46,7 @@ export default class ModalWrapper extends React.Component {
   };
 
   handleClose = () => {
-    this.setState({
-      isOpen: false,
-    });
+    this.setState({ isOpen: false }, () => this.triggerButton.focus());
   };
 
   handleOnRequestSubmit = () => {
@@ -93,7 +92,10 @@ export default class ModalWrapper extends React.Component {
           className={buttonTriggerClassName}
           disabled={disabled}
           kind={triggerButtonKind}
-          onClick={this.handleOpen}>
+          onClick={this.handleOpen}
+          inputref={button => {
+            this.triggerButton = button;
+          }}>
           {buttonTriggerText}
         </Button>
         <Modal {...props}>{children}</Modal>

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -46,7 +46,7 @@ export default class ModalWrapper extends React.Component {
   };
 
   handleClose = () => {
-    this.setState({ isOpen: false }, () => this.triggerButton.focus());
+    this.setState({ isOpen: false }, () => this.triggerButton.current.focus());
   };
 
   handleOnRequestSubmit = () => {
@@ -93,9 +93,7 @@ export default class ModalWrapper extends React.Component {
           disabled={disabled}
           kind={triggerButtonKind}
           onClick={this.handleOpen}
-          inputref={button => {
-            this.triggerButton = button;
-          }}>
+          inputref={this.triggerButton}>
           {buttonTriggerText}
         </Button>
         <Modal {...props}>{children}</Modal>

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -23,7 +23,18 @@ exports[`ModalWrapper should render 1`] = `
       className="btn-trigger"
       disabled={false}
       iconDescription="Provide icon description if icon is used"
-      inputref={[Function]}
+      inputref={
+        Object {
+          "current": <button
+            class="btn-trigger bx--btn bx--btn--primary"
+            inputref="[object Object]"
+            tabindex="0"
+            type="button"
+          >
+            Test Modal
+          </button>,
+        }
+      }
       kind="primary"
       onClick={[Function]}
       small={false}
@@ -33,7 +44,18 @@ exports[`ModalWrapper should render 1`] = `
       <button
         className="btn-trigger bx--btn bx--btn--primary"
         disabled={false}
-        inputref={[Function]}
+        inputref={
+          Object {
+            "current": <button
+              class="btn-trigger bx--btn bx--btn--primary"
+              inputref="[object Object]"
+              tabindex="0"
+              type="button"
+            >
+              Test Modal
+            </button>,
+          }
+        }
         onClick={[Function]}
         tabIndex={0}
         type="button"

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -23,6 +23,7 @@ exports[`ModalWrapper should render 1`] = `
       className="btn-trigger"
       disabled={false}
       iconDescription="Provide icon description if icon is used"
+      inputref={[Function]}
       kind="primary"
       onClick={[Function]}
       small={false}
@@ -32,6 +33,7 @@ exports[`ModalWrapper should render 1`] = `
       <button
         className="btn-trigger bx--btn bx--btn--primary"
         disabled={false}
+        inputref={[Function]}
         onClick={[Function]}
         tabIndex={0}
         type="button"


### PR DESCRIPTION
Closes IBM/carbon-components-react#1298

This PR will return focus to the element that launches the modal when the modal is closed, which should improve keyboard a11y. This is accomplished by attaching a ref to the trigger button, which is then used to focus on the button in the callback of the `setState` operation when closing the modal

#### Changelog

**New**

* attach a ref to the `<Button>` in `<ModalWrapper>` which will launch the `<Modal>` element
* add logic to call `HTMLElement.focus()` on the button after modal is closed

**Changed**

* access `<Modal>` refs through the refs' `current` property