### PR TITLE
fix(ClickableTile): add initial state to prevent warnings

### DIFF
--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -81,8 +81,8 @@ export class ClickableTile extends Component {
   };
 
   static getDerivedStateFromProps({ clicked }, state) {
-    const { prevClicked } = state || {};
-    return state && prevClicked === clicked
+    const { prevClicked } = state;
+    return prevClicked === clicked
       ? null
       : {
           clicked,
@@ -213,8 +213,8 @@ export class SelectableTile extends Component {
   };
 
   static getDerivedStateFromProps({ selected }, state) {
-    const { prevSelected } = state || {};
-    return state && prevSelected === selected
+    const { prevSelected } = state;
+    return prevSelected === selected
       ? null
       : {
           selected,

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -24,6 +24,8 @@ export class Tile extends Component {
 }
 
 export class ClickableTile extends Component {
+  state = {};
+
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,


### PR DESCRIPTION
Closes IBM/carbon-components-react#1297

Added an initial state for ClickableTile component to prevent warning.

`Warning: 'ClickableTile' uses 'getDerivedStateFromProps' but its initial state is undefined. This is not recommended. Instead, define the initial state by assigning an object to 'his.state' in the constructor of 'ClickableTile'. This ensures that 'getDerivedStateFromProps' arguments have a consistent shape.
`
#### Changelog

**New**

* initial state for ClickableTile component
