### PR TITLE
fix(ClickableTile): Fix state warning errors

### DIFF
--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -24,6 +24,8 @@ export class Tile extends Component {
 }
 
 export class ClickableTile extends Component {
+  state = {};
+
   static propTypes = {
     /**
      * The child nodes.


### PR DESCRIPTION
Closes IBM/carbon-components-react#1297

Update ClickableTile component to have default state of an empty object to prevent console warning error from lifecycle method getDerivedStateFromProps

#### Changelog

**Changed**

* ClickableTile component

