### PR TITLE
fix(DatePicker): open calendar on icon click

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -438,6 +438,7 @@ export default class DatePicker extends Component {
         return React.cloneElement(child, {
           datePickerType,
           ref: this.assignInputFieldRef,
+          openCalendar: this.openCalendar,
         });
       } else if (index === 1 && child.type === DatePickerInput) {
         return React.cloneElement(child, {

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -39,6 +39,7 @@ export default class DatePickerInput extends Component {
       datePickerType,
       pattern,
       iconDescription,
+      openCalendar,
       ...other
     } = this.props;
 
@@ -69,6 +70,7 @@ export default class DatePickerInput extends Component {
           name="calendar"
           className="bx--date-picker__icon"
           description={iconDescription}
+          onClick={openCalendar}
         />
       ) : (
         ''


### PR DESCRIPTION
Closes IBM/carbon-components-react#1290

Calendar now can be opened by clicking on calendar icon.

#### Changelog

**New**

* new `openCalendar` prop gets passed down to `DatePickerInput` and lets you open a calendar.