### PR TITLE
fix(FileUploaderButton): prevent from being focusable with keyboard

### DIFF
--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -159,6 +159,7 @@ export class FileUploaderButton extends Component {
           ref={input => (this.input = input)}
           id={this.uid}
           type="file"
+          tabIndex="-1"
           multiple={multiple}
           accept={accept}
           name={name}


### PR DESCRIPTION
Closes IBM/carbon-components-react#1334

This PR sets a negative `tabIndex` value on the file input element to prevent it from being focusable on sequential keyboard navigation, while still allowing it to be focused programmatically

#### Changelog

**New**

* set negative `tabIndex` on `<input type="file" />` in `FileUploaderButton