### PR TITLE
fix: We are no longer including the aria-describedby if it is false, …

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -37,6 +37,10 @@ const Select = ({
   const helper = helperText ? (
     <div className="bx--form__helper-text">{helperText}</div>
   ) : null;
+  const ariaProps = {};
+  if (invalid) {
+    ariaProps['aria-describedby'] = errorId;
+  }
   return (
     <div className="bx--form-item">
       <div className={selectClasses}>
@@ -45,12 +49,12 @@ const Select = ({
         </label>
         <select
           {...other}
+          {...ariaProps}
           id={id}
           className="bx--select-input"
           disabled={disabled || undefined}
           data-invalid={invalid || undefined}
-          aria-invalid={invalid || undefined}
-          aria-describedby={invalid && errorId}>
+          aria-invalid={invalid || undefined}>
           {children}
         </select>
         <Icon


### PR DESCRIPTION
…resolves #1367.

This PR uses a separate object for the `aria-describedby` property so we can make sure that we don't include the attribute if the component is valid.