### PR TITLE
fix(ExpendableTile): add initial state to prevent warnings

### DIFF
--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -271,6 +271,8 @@ export class SelectableTile extends Component {
 }
 
 export class ExpandableTile extends Component {
+  state = {};
+
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -300,15 +302,11 @@ export class ExpandableTile extends Component {
       expanded: currentExpanded,
       tileMaxHeight: currentTileMaxHeight,
       tilePadding: currentTilePadding,
-    } =
-      state || {};
+    } = state;
     const expandedChanged = prevExpanded !== expanded;
     const tileMaxHeightChanged = prevTileMaxHeight !== tileMaxHeight;
     const tilePaddingChanged = prevTilePadding !== tilePadding;
-    return state &&
-      !expandedChanged &&
-      !tileMaxHeightChanged &&
-      !tilePaddingChanged
+    return !expandedChanged && !tileMaxHeightChanged && !tilePaddingChanged
       ? null
       : {
           expanded: !expandedChanged ? currentExpanded : expanded,


### PR DESCRIPTION
Added empty state object to suppress warning and removed some validation that was not needed anymore.

#### Changelog

**New**

* Empty state object

**Removed**

* Empty state validation
