### PR TITLE
fix(ComboBox): add support for light option

### DIFF
--- a/src/components/ComboBox/ComboBox.js
+++ b/src/components/ComboBox/ComboBox.js
@@ -112,6 +112,11 @@ export default class ComboBox extends React.Component {
      * @param {string} inputText
      */
     onInputChange: PropTypes.func,
+
+    /**
+     * should use "light theme" (white background)?
+     */
+    light: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -120,6 +125,7 @@ export default class ComboBox extends React.Component {
     shouldFilterItem: defaultShouldFilterItem,
     type: 'default',
     ariaLabel: 'ListBox input field',
+    light: false,
   };
 
   constructor(props) {
@@ -182,6 +188,7 @@ export default class ComboBox extends React.Component {
       translateWithId,
       invalid,
       invalidText,
+      light,
     } = this.props;
     const className = cx('bx--combo-box', containerClassName);
 
@@ -208,6 +215,7 @@ export default class ComboBox extends React.Component {
             disabled={disabled}
             invalid={invalid}
             invalidText={invalidText}
+            light={light}
             {...getRootProps({ refKey: 'innerRef' })}>
             <ListBox.Field {...getButtonProps({ disabled })}>
               <input

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -30,6 +30,7 @@ const ListBox = ({
   type,
   invalid,
   invalidText,
+  light,
   ...rest
 }) => {
   const className = cx({
@@ -37,6 +38,7 @@ const ListBox = ({
     'bx--list-box': true,
     'bx--list-box--inline': type === 'inline',
     'bx--list-box--disabled': disabled,
+    'bx--list-box--light': light,
   });
   return (
     <>


### PR DESCRIPTION
addresses IBM/carbon-components-react#1100

Adds support for light option on `ComboBox`. matches `Dropdown`. (issue number **3** described in the issue https://github.com/ibm/carbon-components-react/issues/1100 )

#### Changelog

**New**

* adds option for `light` to `ComboBox`, as well as cascading properties to get the `ListBox` component to apply appropriate styles.