### PR TITLE
fix(multi-select): add ability to add title tooltip on hover

### DIFF
--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -30,7 +30,7 @@ const props = () => ({
   ),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
-  title: boolean('Show tooltip on hover', false),
+  useTitleInItem: boolean('Show tooltip on hover', false),
   type: select('UI type (Only for `<MultiSelect>`) (type)', types, 'default'),
   label: text('Label (label)', defaultLabel),
   invalid: boolean('Show form validation UI (invalid)', false),

--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -30,6 +30,7 @@ const props = () => ({
   ),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
+  title: boolean('Show tooltip on hover', false),
   type: select('UI type (Only for `<MultiSelect>`) (type)', types, 'default'),
   label: text('Label (label)', defaultLabel),
   invalid: boolean('Show form validation UI (invalid)', false),

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -63,7 +63,7 @@ export default class MultiSelect extends React.Component {
     /**
      *  Specify title to show title on hover
      */
-    title: PropTypes.bool,
+    useTitleInItem: PropTypes.bool,
 
     /**
      * `true` to use the light version.
@@ -160,7 +160,7 @@ export default class MultiSelect extends React.Component {
       light,
       invalid,
       invalidText,
-      title,
+      useTitleInItem,
     } = this.props;
     const className = cx('bx--multi-select', containerClassName, {
       'bx--list-box--light': light,
@@ -225,7 +225,7 @@ export default class MultiSelect extends React.Component {
                           {...itemProps}>
                           <Checkbox
                             id={itemProps.id}
-                            title={title ? itemText : null}
+                            title={useTitleInItem ? itemText : null}
                             name={itemText}
                             checked={isChecked}
                             readOnly={true}

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -61,6 +61,11 @@ export default class MultiSelect extends React.Component {
     type: PropTypes.oneOf(['default', 'inline']),
 
     /**
+     *  Specify title to show title on hover
+     */
+    title: PropTypes.bool,
+
+    /**
      * `true` to use the light version.
      */
     light: PropTypes.bool,
@@ -83,6 +88,7 @@ export default class MultiSelect extends React.Component {
     sortItems: defaultSortItems,
     type: 'default',
     light: false,
+    title: false,
   };
 
   constructor(props) {
@@ -154,6 +160,7 @@ export default class MultiSelect extends React.Component {
       light,
       invalid,
       invalidText,
+      title,
     } = this.props;
     const className = cx('bx--multi-select', containerClassName, {
       'bx--list-box--light': light,
@@ -218,6 +225,7 @@ export default class MultiSelect extends React.Component {
                           {...itemProps}>
                           <Checkbox
                             id={itemProps.id}
+                            title={title ? itemText : null}
                             name={itemText}
                             checked={isChecked}
                             readOnly={true}

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -39,6 +39,7 @@ exports[`MultiSelect should render 1`] = `
   light={false}
   locale="en"
   sortItems={[Function]}
+  title={false}
   type="default"
 >
   <Selection


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-react/issues/1393

Adds in the ability to add `title` to a `MultiSelectItem`

#### Changelog

**New**

- `title` prop to toggle whether or not a title is added

