### PR TITLE
feat: add SkeletonPlaceholder component

### DIFF
--- a/src/components/SkeletonPlaceholder/SkeletonPlaceholder-story.js
+++ b/src/components/SkeletonPlaceholder/SkeletonPlaceholder-story.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-console */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import SkeletonPlaceholder from '../SkeletonPlaceholder';
+
+const widths = {
+  '100px': '100px',
+  '200px': '200px',
+  '250px': '250px',
+  '50%': '50%',
+  '75%': '75%',
+  '100%': '100%',
+};
+
+const heights = {
+  '100px': '100px',
+  '200px': '200px',
+  '250px': '250px',
+  '50%': '50%',
+  '75%': '75%',
+  '100%': '100%',
+};
+
+const props = () => ({
+  width: select('Width (in px or %)', widths),
+  height: select('Height (in px or %)', heights),
+});
+
+storiesOf('SkeletonPlaceholder', module)
+  .addDecorator(withKnobs)
+  .add(
+    'Default',
+    withInfo({
+      text: `
+        Skeleton states are used as a progressive loading state while the user waits for content to load.
+
+        By taking a height and/or width property, this component can be used when you know the exact dimensions of the incoming content, such as an image.
+      `,
+    })(() => (
+      <div style={{ height: '250px', width: '250px' }}>
+        <SkeletonPlaceholder {...props()} />
+      </div>
+    ))
+  );

--- a/src/components/SkeletonPlaceholder/SkeletonPlaceholder-story.js
+++ b/src/components/SkeletonPlaceholder/SkeletonPlaceholder-story.js
@@ -6,27 +6,14 @@ import { withInfo } from '@storybook/addon-info';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import SkeletonPlaceholder from '../SkeletonPlaceholder';
 
-const widths = {
-  '100px': '100px',
-  '200px': '200px',
-  '250px': '250px',
-  '50%': '50%',
-  '75%': '75%',
-  '100%': '100%',
-};
-
-const heights = {
-  '100px': '100px',
-  '200px': '200px',
-  '250px': '250px',
-  '50%': '50%',
-  '75%': '75%',
-  '100%': '100%',
+const classNames = {
+  'my--skeleton__placeholder--small': 'my--skeleton__placeholder--small',
+  'my--skeleton__placeholder--medium': 'my--skeleton__placeholder--medium',
+  'my--skeleton__placeholder--large': 'my--skeleton__placeholder--large',
 };
 
 const props = () => ({
-  width: select('Width (in px or %)', widths),
-  height: select('Height (in px or %)', heights),
+  className: select('Classes with different sizes', classNames),
 });
 
 storiesOf('SkeletonPlaceholder', module)
@@ -38,9 +25,31 @@ storiesOf('SkeletonPlaceholder', module)
         Skeleton states are used as a progressive loading state while the user waits for content to load.
 
         By taking a height and/or width property, this component can be used when you know the exact dimensions of the incoming content, such as an image.
+
+        However, for performance reasons, it's recommended to create a class in your stylesheet to set the dimensions.
       `,
     })(() => (
       <div style={{ height: '250px', width: '250px' }}>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+          .my--skeleton__placeholder--small {
+            height: 100px;
+            width: 100px;
+          }
+
+          .my--skeleton__placeholder--medium {
+            height: 150px;
+            width: 150px;
+          }
+
+          .my--skeleton__placeholder--large {
+            height: 250px;
+            width: 250px;
+          }
+        `,
+          }}
+        />
         <SkeletonPlaceholder {...props()} />
       </div>
     ))

--- a/src/components/SkeletonPlaceholder/SkeletonPlaceholder-test.js
+++ b/src/components/SkeletonPlaceholder/SkeletonPlaceholder-test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import SkeletonPlaceholder from '../SkeletonPlaceholder';
+import { shallow } from 'enzyme';
+
+describe('SkeletonPlaceholder', () => {
+  const wrapper = shallow(<SkeletonPlaceholder />);
+
+  it('Has the expected classes', () => {
+    expect(wrapper.hasClass('bx--skeleton__placeholder')).toEqual(true);
+  });
+});

--- a/src/components/SkeletonPlaceholder/SkeletonPlaceholder.js
+++ b/src/components/SkeletonPlaceholder/SkeletonPlaceholder.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const SkeletonPlaceholder = ({ height, width, className, ...other }) => {
+  const skeletonPlaceholderClasses = classNames({
+    'bx--skeleton__placeholder': true,
+    [className]: className,
+  });
+
+  return (
+    <div
+      style={{ height, width }}
+      className={skeletonPlaceholderClasses}
+      {...other}
+    />
+  );
+};
+
+SkeletonPlaceholder.propTypes = {
+  /**
+   * the height of the skeleton, in % or px
+   */
+  height: PropTypes.string,
+
+  /**
+   * the width of the skeleton, in % or px
+   */
+  width: PropTypes.string,
+
+  /**
+   * the class to be applied to the component
+   */
+  className: PropTypes.string,
+};
+
+SkeletonPlaceholder.defaultProps = {
+  height: '100px',
+  width: '100px',
+};
+
+export default SkeletonPlaceholder;

--- a/src/components/SkeletonPlaceholder/SkeletonPlaceholder.js
+++ b/src/components/SkeletonPlaceholder/SkeletonPlaceholder.js
@@ -2,41 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const SkeletonPlaceholder = ({ height, width, className, ...other }) => {
+const SkeletonPlaceholder = ({ className, ...other }) => {
   const skeletonPlaceholderClasses = classNames({
     'bx--skeleton__placeholder': true,
     [className]: className,
   });
 
-  return (
-    <div
-      style={{ height, width }}
-      className={skeletonPlaceholderClasses}
-      {...other}
-    />
-  );
+  return <div className={skeletonPlaceholderClasses} {...other} />;
 };
 
 SkeletonPlaceholder.propTypes = {
   /**
-   * the height of the skeleton, in % or px
-   */
-  height: PropTypes.string,
-
-  /**
-   * the width of the skeleton, in % or px
-   */
-  width: PropTypes.string,
-
-  /**
    * the class to be applied to the component
    */
   className: PropTypes.string,
-};
-
-SkeletonPlaceholder.defaultProps = {
-  height: '100px',
-  width: '100px',
 };
 
 export default SkeletonPlaceholder;

--- a/src/components/SkeletonPlaceholder/index.js
+++ b/src/components/SkeletonPlaceholder/index.js
@@ -1,0 +1,1 @@
+export default from './SkeletonPlaceholder';

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ export TooltipIcon from './components/TooltipIcon';
 export TooltipSimple from './components/TooltipSimple';
 export UnorderedList from './components/UnorderedList';
 export SkeletonText from './components/SkeletonText';
+export SkeletonPlaceholder from './components/SkeletonPlaceholder';
 export DataTableSkeleton from './components/DataTableSkeleton';
 export AccordionSkeleton from './components/Accordion/Accordion.Skeleton';
 export BreadcrumbSkeleton from './components/Breadcrumb/Breadcrumb.Skeleton';


### PR DESCRIPTION
Closes IBM/carbon-components-react#1313

Adds a new Skeleton component that takes a height and/or width property.

Accompanying PR for the SCSS here: https://github.com/IBM/carbon-components/pull/1202

#### Changelog

**New**

* Adds a new `<SkeletonPlaceholder />` component

**Changed**

* N/A

**Removed**

* N/A
