### PR TITLE
fix: Added the correct roles to the overflow menu for accessibility, …

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -492,7 +492,8 @@ export default class OverflowMenu extends Component {
       <ul
         className={overflowMenuOptionsClasses}
         tabIndex="-1"
-        ref={!floatingMenu && this._bindMenuBody}>
+        ref={!floatingMenu && this._bindMenuBody}
+        role="menu">
         {childrenWithProps}
       </ul>
     );


### PR DESCRIPTION
This fixes https://github.com/IBM/carbon-components-react/issues/1424

![screen shot 2018-10-10 at 1 48 22 pm](https://user-images.githubusercontent.com/664044/46755505-39fde700-cc93-11e8-9b5f-d7102ba67643.png)

The PR just adds the one new attribute.  The problem with the button element getting the incorrect role was specific to the way Carbon was being used and not part of the Carbon library.