### PR TITLE
Short data table

### DIFF
--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -25,6 +25,22 @@ storiesOf('DataTable', module)
     )
   )
   .add(
+    'short',
+    withReadme(
+      readme,
+      withInfo({
+        /* eslint-disable no-useless-escape */
+        text: `
+        Short Data Table.
+
+        You can find more detailed information surrounding usage of this component
+        at the following url: ${readmeURL}
+      `,
+        /* eslint-enable no-useless-escape */
+      })(require('./stories/shortDataTable').default)
+    )
+  )
+  .add(
     'with toolbar',
     withReadme(
       readme,

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -90,6 +90,11 @@ export default class DataTable extends React.Component {
      * available message ids.
      */
     translateWithId: PropTypes.func,
+
+    /**
+     * Optional boolean to create a short data table.
+     */
+    short: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -97,6 +102,7 @@ export default class DataTable extends React.Component {
     filterRows: defaultFilterRows,
     locale: 'en',
     translateWithId,
+    short: false,
   };
 
   static translationKeys = Object.values(translationKeys);
@@ -237,6 +243,15 @@ export default class DataTable extends React.Component {
       shouldShowBatchActions,
       totalSelected,
       onCancel: this.handleOnCancel,
+    };
+  };
+  /**
+   * Helper utility to get the Table Props.
+   */
+  getTableProps = () => {
+    const { short } = this.props;
+    return {
+      short,
     };
   };
 
@@ -384,7 +399,7 @@ export default class DataTable extends React.Component {
   };
 
   render() {
-    const { children, filterRows, headers, render } = this.props;
+    const { children, filterRows, headers, render, short } = this.props;
     const { filterInputValue, rowIds, rowsById, cellsById } = this.state;
     const filteredRowIds =
       typeof filterInputValue === 'string'
@@ -406,6 +421,7 @@ export default class DataTable extends React.Component {
       getRowProps: this.getRowProps,
       getSelectionProps: this.getSelectionProps,
       getBatchActionProps: this.getBatchActionProps,
+      getTableProps: this.getTableProps,
 
       // Custom event handlers
       onInputChange: this.handleOnInputValueChange,
@@ -415,6 +431,8 @@ export default class DataTable extends React.Component {
       selectAll: this.handleSelectAll,
       selectRow: rowId => this.handleOnSelectRow(rowId)(),
       expandRow: rowId => this.handleOnExpandRow(rowId)(),
+      //
+      short: short,
     };
 
     if (render !== undefined) {

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -399,7 +399,7 @@ export default class DataTable extends React.Component {
   };
 
   render() {
-    const { children, filterRows, headers, render, short } = this.props;
+    const { children, filterRows, headers, render } = this.props;
     const { filterInputValue, rowIds, rowsById, cellsById } = this.state;
     const filteredRowIds =
       typeof filterInputValue === 'string'
@@ -431,8 +431,6 @@ export default class DataTable extends React.Component {
       selectAll: this.handleSelectAll,
       selectRow: rowId => this.handleOnSelectRow(rowId)(),
       expandRow: rowId => this.handleOnExpandRow(rowId)(),
-      //
-      short: short,
     };
 
     if (render !== undefined) {

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-export const Table = ({ zebra, className, children, ...other }) => {
+export const Table = ({ zebra, className, children, short, ...other }) => {
   const componentClass = cx('bx--data-table-v2', className, {
     'bx--data-table-v2--zebra': zebra,
+    'bx--data-table-v2--short': short,
   });
   return (
     <table {...other} className={componentClass}>
@@ -23,10 +24,16 @@ Table.propTypes = {
    * `true` to add zebra striping.
    */
   zebra: PropTypes.bool,
+
+  /**
+   * `true` for short data table.
+   */
+  short: PropTypes.bool,
 };
 
 Table.defaultProps = {
   zebra: true,
+  short: false,
 };
 
 export default Table;

--- a/src/components/DataTable/stories/shortDataTable.js
+++ b/src/components/DataTable/stories/shortDataTable.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { iconDownload, iconEdit, iconSettings } from 'carbon-icons';
+import Button from '../../Button';
+import DataTable, {
+  Table,
+  TableBatchAction,
+  TableBatchActions,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSelectAll,
+  TableSelectRow,
+  TableToolbar,
+  TableToolbarAction,
+  TableToolbarContent,
+  TableToolbarSearch,
+} from '../../DataTable';
+import { batchActionClick, initialRows, headers } from './shared';
+
+export default () => (
+  <DataTable
+    rows={initialRows}
+    headers={headers}
+    short
+    render={({
+      rows,
+      headers,
+      getHeaderProps,
+      getRowProps,
+      getSelectionProps,
+      getBatchActionProps,
+      onInputChange,
+      selectedRows,
+      getTableProps,
+    }) => (
+      <TableContainer title="DataTable">
+        <TableToolbar>
+          <TableBatchActions {...getBatchActionProps()}>
+            <TableBatchAction onClick={batchActionClick(selectedRows)}>
+              Ghost
+            </TableBatchAction>
+            <TableBatchAction onClick={batchActionClick(selectedRows)}>
+              Ghost
+            </TableBatchAction>
+            <TableBatchAction onClick={batchActionClick(selectedRows)}>
+              Ghost
+            </TableBatchAction>
+          </TableBatchActions>
+          <TableToolbarSearch onChange={onInputChange} />
+          <TableToolbarContent>
+            <TableToolbarAction
+              icon={iconDownload}
+              iconDescription="Download"
+              onClick={action('TableToolbarAction - Download')}
+            />
+            <TableToolbarAction
+              icon={iconEdit}
+              iconDescription="Edit"
+              onClick={action('TableToolbarAction - Edit')}
+            />
+            <TableToolbarAction
+              icon={iconSettings}
+              iconDescription="Settings"
+              onClick={action('TableToolbarAction - Settings')}
+            />
+            <Button onClick={action('Add new row')} small kind="primary">
+              Add new
+            </Button>
+          </TableToolbarContent>
+        </TableToolbar>
+        <Table {...getTableProps()}>
+          <TableHead>
+            <TableRow>
+              <TableSelectAll {...getSelectionProps()} />
+              {headers.map(header => (
+                <TableHeader {...getHeaderProps({ header })}>
+                  {header.header}
+                </TableHeader>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(row => (
+              <TableRow {...getRowProps({ row })}>
+                <TableSelectRow {...getSelectionProps({ row })} />
+                {row.cells.map(cell => (
+                  <TableCell key={cell.id}>{cell.value}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    )}
+  />
+);


### PR DESCRIPTION
Closes IBM/carbon-components-react#1408

Added a support for a short data table. A new boolean prop 'short' is added to the Data Table component. That prop if passed to the component, created a short Data Table instead of default Data Table. The prop is not mandatory and the default value of the prop is false. 

#### Changelog

**Changed**

* Data-Table component accepts an optional prop 'short', which if set to true created a short data table.

