### PR TITLE
feat(ComposedModal): add onClick prop

### DIFF
--- a/src/components/ComposedModal/ComposedModal-test.js
+++ b/src/components/ComposedModal/ComposedModal-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ComposedModal, {
   ModalHeader,
   ModalBody,
@@ -134,5 +134,30 @@ describe('<ComposedModal />', () => {
     wrapper.setState({ open: false });
     wrapper.setProps({ open: true });
     expect(wrapper.state().open).toEqual(false);
+  });
+
+  it('calls onClick upon user-initiated closing', () => {
+    const onClose = jest.fn();
+    const wrapper = mount(
+      <ComposedModal open onClose={onClose}>
+        <ModalHeader />
+      </ComposedModal>
+    );
+    const button = wrapper.find('.bx--modal-close').first();
+    button.simulate('click');
+    expect(wrapper.state().open).toEqual(false);
+    expect(onClose.mock.calls.length).toBe(1);
+  });
+
+  it('provides a way to prevent upon user-initiated closing', () => {
+    const onClose = jest.fn(() => false);
+    const wrapper = mount(
+      <ComposedModal open onClose={onClose}>
+        <ModalHeader />
+      </ComposedModal>
+    );
+    const button = wrapper.find('.bx--modal-close').first();
+    button.simulate('click');
+    expect(wrapper.state().open).toEqual(true);
   });
 });

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -27,6 +27,12 @@ export default class ComposedModal extends Component {
     containerClassName: PropTypes.string,
 
     /**
+     * Specify an optional handler for closing modal.
+     * Returning `false` here prevents closing modal.
+     */
+    onClose: PropTypes.func,
+
+    /**
      * Specify an optional handler for the `onKeyDown` event. Called for all
      * `onKeyDown` events that do not close the modal
      */
@@ -58,9 +64,12 @@ export default class ComposedModal extends Component {
   }
 
   closeModal = () => {
-    this.setState({
-      open: false,
-    });
+    const { onClose } = this.props;
+    if (!onClose || onClose() !== false) {
+      this.setState({
+        open: false,
+      });
+    }
   };
 
   handleClick = evt => {


### PR DESCRIPTION
Fixes #1432.

#### Changelog

**New**

* `onClose` prop to `<ComposeModal>`. Returning `false` in that callback prevents modal from being closed.