### PR TITLE
feat(Icon): support polygon

### DIFF
--- a/src/components/Icon/Icon-test.js
+++ b/src/components/Icon/Icon-test.js
@@ -118,6 +118,23 @@ describe('Icon', () => {
       expect(content.length).toBeGreaterThan(0);
       expect(content).toEqual(['']);
     });
+
+    it('takes care of polygons', () => {
+      const svgData = {
+        polygons: [
+          {
+            points: 'POINT',
+          },
+        ],
+      };
+      expect(
+        svgShapes(svgData).map(item =>
+          item.map(({ type, key, props }) => ({ type, key, props }))
+        )
+      ).toEqual([
+        [{ type: 'polygon', key: 'key0', props: { points: 'POINT' } }],
+      ]);
+    });
   });
 
   describe('isPrefixed', () => {

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -81,6 +81,10 @@ export function svgShapes(svgData) {
         return data.map((path, index) => (
           <path d={path.d} key={`key${index}`} />
         ));
+      } else if (svgProp === 'polygons') {
+        return data.map((polygon, index) => (
+          <polygon points={polygon.points} key={`key${index}`} />
+        ));
       }
 
       return '';


### PR DESCRIPTION
Refs IBM/carbon-icons#81.

#### Changelog

**New**

* Support for `<polygon points="points">`