### PR TITLE
chore(combo-box): replace deprecated @storybook/react action

### DIFF
--- a/src/components/ComboBox/ComboBox-story.js
+++ b/src/components/ComboBox/ComboBox-story.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { storiesOf, action } from '@storybook/react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import ComboBox from '../ComboBox';


### PR DESCRIPTION
Importing `{ action }` from `@storybook/react` is deprecated and will cause a console warning. Almost all of the other components in this library import `{ action }` from  `@storybook/addon-actions` instead. For example: https://github.com/IBM/carbon-components-react/blob/22af70d4ab0d7ab12b68fb7be8e0ca844d139b6c/src/components/Select/Select-story.js#L2-L3

#### Changelog

**New**

* Adds `import { action } from '@storybook/addon-actions';`

**Removed**

* Removes `{ action }` from `@storybook/react` import
