### PR TITLE
feat(components): support configurable selector prefix

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -11,6 +11,7 @@
 * [Documentation](#documentation)
   * [File Structure](#file-structure)
   * [Storybook README](#storybook-readme)
+* [CSS class prefix](#css-class-prefix)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -75,4 +76,50 @@ storiesOf('ComponentName', module).add(
     })(() => <ComponentExample />)
   )
 );
+```
+
+## CSS class prefix
+
+Carbon CSS classes begin with `bx--` by default. It can be changed by setting `$prefix` Sass variable and building `carbon-components` Sass files.
+
+To apply your CSS class prefix to `carbon-components-react` components, you can define your CSS class prefix as a React context and create wrapper components with your React context applied. Here's an example:
+
+```javascript
+import React, { Component, createContext } from 'react';
+import mapValues from 'lodash.mapvalues';
+import { Button, Checkbox } from 'carbon-components-react';
+
+// The `PrefixConsumer` and `withOurBrandPrefix` here can be defined in a separate module
+const { Consumer: PrefixConsumer } = createContext('ourbrand');
+
+const withOurBrandPrefix = components =>
+  mapValues(components, Component => props => (
+    <PrefixConsumer>
+      {prefix => <Component {...props} prefix={prefix} />}
+    </PrefixConsumer>
+  ));
+
+// Create wrapper components with `ourbrand` CSS class prefix applied
+const {
+  Button: OurBrandButton,
+  Checkbox: OurBrandCheckbox,
+} = withOurBrandPrefix({ Button, Checkbox });
+
+class MyApp extends Component {
+  render() {
+    <>
+      {/* Uses ourbrand--btn instead of bx--btn */}
+      <OurBrandButton kind="primary">Button in our brand</OurBrandButton>
+      <fieldset className="ourbrand--fieldset">
+        <legend className="ourbrand--label">Checkbox in our brand</legend>
+        {/* Uses ourbrand--checkbox instead of bx--checkbox */}
+        <OurBrandCheckbox
+          defaultChecked
+          id="checkbox"
+          labelText="Checkbox label"
+        />
+      </fieldset>
+    </>;
+  }
+}
 ```

--- a/src/components/Accordion/Accordion.Skeleton.js
+++ b/src/components/Accordion/Accordion.Skeleton.js
@@ -1,26 +1,46 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from '../Icon';
 import SkeletonText from '../SkeletonText';
 import { iconChevronRight } from 'carbon-icons';
 
 export default class AccordionSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
+    const { prefix } = this.props;
     const item = (
-      <li className="bx--accordion__item">
-        <button type="button" className="bx--accordion__heading">
-          <Icon className="bx--accordion__arrow" icon={iconChevronRight} />
-          <SkeletonText className="bx--accordion__title" />
+      <li className={`${prefix}--accordion__item`}>
+        <button type="button" className={`${prefix}--accordion__heading`}>
+          <Icon
+            className={`${prefix}--accordion__arrow`}
+            icon={iconChevronRight}
+          />
+          <SkeletonText className={`${prefix}--accordion__title`} />
         </button>
       </li>
     );
     return (
-      <ul className="bx--accordion bx--skeleton">
-        <li className="bx--accordion__item bx--accordion__item--active">
-          <button type="button" className="bx--accordion__heading">
-            <Icon className="bx--accordion__arrow" icon={iconChevronRight} />
-            <SkeletonText className="bx--accordion__title" />
+      <ul className={`${prefix}--accordion ${prefix}--skeleton`}>
+        <li
+          className={`${prefix}--accordion__item ${prefix}--accordion__item--active`}>
+          <button type="button" className={`${prefix}--accordion__heading`}>
+            <Icon
+              className={`${prefix}--accordion__arrow`}
+              icon={iconChevronRight}
+            />
+            <SkeletonText className={`${prefix}--accordion__title`} />
           </button>
-          <div className="bx--accordion__content">
+          <div className={`${prefix}--accordion__content`}>
             <SkeletonText width="90%" />
             <SkeletonText width="80%" />
             <SkeletonText width="95%" />

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Accordion = ({ children, className, ...other }) => {
-  const classNames = classnames('bx--accordion', className);
+const Accordion = ({ children, className, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--accordion`, className);
   return (
     <ul
       className={classNames}
@@ -25,6 +25,15 @@ Accordion.propTypes = {
    * Specify an optional className to be applied to the container node
    */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Accordion.defaultProps = {
+  prefix: 'bx',
 };
 
 export default Accordion;

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -42,6 +42,11 @@ export default class AccordionItem extends Component {
     open: PropTypes.bool,
 
     /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+
+    /**
      * The handler of the massaged `click` event.
      */
     onClick: PropTypes.func,
@@ -59,6 +64,7 @@ export default class AccordionItem extends Component {
     open: false,
     onClick: () => {},
     onHeadingClick: () => {},
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ open }, state) {
@@ -99,14 +105,15 @@ export default class AccordionItem extends Component {
       children,
       onClick, // eslint-disable-line no-unused-vars
       onHeadingClick, // eslint-disable-line no-unused-vars
+      prefix,
       ...other
     } = this.props;
 
     const classNames = classnames(
       {
-        'bx--accordion__item--active': this.state.open,
+        [`${prefix}--accordion__item--active`]: this.state.open,
       },
-      'bx--accordion__item',
+      `${prefix}--accordion__item`,
       className
     );
     return (
@@ -118,17 +125,17 @@ export default class AccordionItem extends Component {
         {...other}>
         <Expando
           type="button"
-          className="bx--accordion__heading"
+          className={`${prefix}--accordion__heading`}
           role="tab"
           onClick={this.handleHeadingClick}>
           <Icon
-            className="bx--accordion__arrow"
+            className={`${prefix}--accordion__arrow`}
             icon={iconChevronRight}
             description={iconDescription}
           />
-          <div className="bx--accordion__title">{title}</div>
+          <div className={`${prefix}--accordion__title`}>{title}</div>
         </Expando>
-        <div className="bx--accordion__content">{children}</div>
+        <div className={`${prefix}--accordion__content`}>{children}</div>
       </li>
     );
   }

--- a/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -1,16 +1,29 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class BreadcrumbSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
+    const { prefix } = this.props;
     const item = (
-      <div className="bx--breadcrumb-item">
-        <a href="/#" className="bx--link">
+      <div className={`${prefix}--breadcrumb-item`}>
+        <a href="/#" className={`${prefix}--link`}>
           &nbsp;
         </a>
       </div>
     );
     return (
-      <div className="bx--breadcrumb bx--skeleton">
+      <div className={`${prefix}--breadcrumb ${prefix}--skeleton`}>
         {item}
         {item}
         {item}

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -2,10 +2,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Breadcrumb = ({ children, className, noTrailingSlash, ...other }) => {
+const Breadcrumb = ({
+  children,
+  className,
+  noTrailingSlash,
+  prefix,
+  ...other
+}) => {
   const classNames = classnames(className, {
-    'bx--breadcrumb': true,
-    'bx--breadcrumb--no-trailing-slash': noTrailingSlash,
+    [`${prefix}--breadcrumb`]: true,
+    [`${prefix}--breadcrumb--no-trailing-slash`]: noTrailingSlash,
   });
   return (
     <div className={classNames} {...other}>
@@ -29,6 +35,15 @@ Breadcrumb.propTypes = {
    * Optional prop to omit the trailing slash for the breadcrumbs
    */
   noTrailingSlash: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Breadcrumb.defaultProps = {
+  prefix: 'bx',
 };
 
 export default Breadcrumb;

--- a/src/components/BreadcrumbItem/BreadcrumbItem.js
+++ b/src/components/BreadcrumbItem/BreadcrumbItem.js
@@ -3,21 +3,21 @@ import React from 'react';
 import classnames from 'classnames';
 import Link from '../Link';
 
-const newChild = (children, href) => {
+const newChild = (children, href, prefix) => {
   if (typeof children === 'string' && !(href === undefined)) {
     return <Link href={href}>{children}</Link>;
   } else {
     return React.cloneElement(React.Children.only(children), {
-      className: 'bx--link',
+      className: `${prefix}--link`,
     });
   }
 };
 
-const BreadcrumbItem = ({ children, className, href, ...other }) => {
-  const classNames = classnames('bx--breadcrumb-item', className);
+const BreadcrumbItem = ({ children, className, href, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--breadcrumb-item`, className);
   return (
     <div className={classNames} {...other}>
-      {newChild(children, href)}
+      {newChild(children, href, prefix)}
     </div>
   );
 };
@@ -37,6 +37,15 @@ BreadcrumbItem.propTypes = {
    * Optional string representing the link location for the BreadcrumbItem
    */
   href: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+BreadcrumbItem.defaultProps = {
+  prefix: 'bx',
 };
 
 export default BreadcrumbItem;

--- a/src/components/Button/Button.Skeleton.js
+++ b/src/components/Button/Button.Skeleton.js
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const ButtonSkeleton = ({ small, href }) => {
+const ButtonSkeleton = ({ small, href, prefix }) => {
   const buttonClasses = classNames({
-    'bx--skeleton': true,
-    'bx--btn': true,
-    'bx--btn--sm': small,
+    [`${prefix}--skeleton`]: true,
+    [`${prefix}--btn`]: true,
+    [`${prefix}--btn--sm`]: small,
   });
 
   const commonProps = {
@@ -21,12 +21,25 @@ const ButtonSkeleton = ({ small, href }) => {
 };
 
 ButtonSkeleton.propTypes = {
+  /**
+   * Specify whether the Button should be a small variant
+   */
   small: PropTypes.bool,
+
+  /**
+   * Optionally specify an href for your Button to become an <a> element
+   */
   href: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 ButtonSkeleton.defaultProps = {
   small: false,
+  prefix: 'bx',
 };
 
 export default ButtonSkeleton;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -15,17 +15,18 @@ const Button = ({
   type,
   icon,
   iconDescription,
+  prefix,
   ...other
 }) => {
   const buttonClasses = classNames(className, {
-    'bx--btn': true,
-    'bx--btn--sm': small,
-    'bx--btn--primary': kind === 'primary',
-    'bx--btn--danger': kind === 'danger',
-    'bx--btn--secondary': kind === 'secondary',
-    'bx--btn--ghost': kind === 'ghost',
-    'bx--btn--danger--primary': kind === 'danger--primary',
-    'bx--btn--tertiary': kind === 'tertiary',
+    [`${prefix}--btn`]: true,
+    [`${prefix}--btn--sm`]: small,
+    [`${prefix}--btn--primary`]: kind === 'primary',
+    [`${prefix}--btn--danger`]: kind === 'danger',
+    [`${prefix}--btn--secondary`]: kind === 'secondary',
+    [`${prefix}--btn--ghost`]: kind === 'ghost',
+    [`${prefix}--btn--danger--primary`]: kind === 'danger--primary',
+    [`${prefix}--btn--tertiary`]: kind === 'tertiary',
   });
 
   const commonProps = {
@@ -38,7 +39,7 @@ const Button = ({
       icon={Object(icon) === icon ? icon : undefined}
       name={Object(icon) !== icon ? icon : undefined}
       description={iconDescription}
-      className="bx--btn__icon"
+      className={`${prefix}--btn__icon`}
     />
   ) : null;
 
@@ -141,6 +142,11 @@ Button.propTypes = {
     }
     return undefined;
   },
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 Button.defaultProps = {
@@ -150,6 +156,7 @@ Button.defaultProps = {
   disabled: false,
   small: false,
   kind: 'primary',
+  prefix: 'bx',
 };
 
 export default Button;

--- a/src/components/Checkbox/Checkbox.Skeleton.js
+++ b/src/components/Checkbox/Checkbox.Skeleton.js
@@ -1,13 +1,28 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class CheckboxSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
-    const { id } = this.props;
+    const { id, prefix } = this.props;
     return (
-      <div className="bx--form-item bx--checkbox-wrapper">
+      <div className={`${prefix}--form-item ${prefix}--checkbox-wrapper`}>
         {
           // eslint-disable-next-line jsx-a11y/label-has-for
-          <label className="bx--checkbox-label bx--skeleton" htmlFor={id} />
+          <label
+            className={`${prefix}--checkbox-label ${prefix}--skeleton`}
+            htmlFor={id}
+          />
         }
       </div>
     );

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -11,16 +11,17 @@ const Checkbox = ({
   hideLabel,
   wrapperClassName,
   title = '',
+  prefix,
   ...other
 }) => {
   let input;
-  const labelClasses = classNames('bx--checkbox-label', className);
+  const labelClasses = classNames(`${prefix}--checkbox-label`, className);
   const innerLabelClasses = classNames({
-    'bx--visually-hidden': hideLabel,
+    [`${prefix}--visually-hidden`]: hideLabel,
   });
   const wrapperClasses = classNames(
-    'bx--form-item',
-    'bx--checkbox-wrapper',
+    `${prefix}--form-item`,
+    `${prefix}--checkbox-wrapper`,
     wrapperClassName
   );
 
@@ -32,7 +33,7 @@ const Checkbox = ({
         onChange={evt => {
           onChange(input.checked, id, evt);
         }}
-        className="bx--checkbox"
+        className={`${prefix}--checkbox`}
         id={id}
         ref={el => {
           input = el;
@@ -105,11 +106,17 @@ Checkbox.propTypes = {
    * The CSS class name to be placed on the wrapping element
    */
   wrapperClassName: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 Checkbox.defaultProps = {
   onChange: () => {},
   indeterminate: false,
+  prefix: 'bx',
 };
 
 export default Checkbox;

--- a/src/components/CodeSnippet/CodeSnippet.Skeleton.js
+++ b/src/components/CodeSnippet/CodeSnippet.Skeleton.js
@@ -9,27 +9,37 @@ export default class CodeSnippetSkeleton extends Component {
      * can be single or multi
      */
     type: PropTypes.oneOf(['single', 'multi']),
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     type: 'single',
+    prefix: 'bx',
   };
 
   render() {
-    const { className, type, ...other } = this.props;
+    const { className, type, prefix, ...other } = this.props;
 
     const codeSnippetClasses = classNames(className, {
-      'bx--snippet': true,
-      'bx--skeleton': true,
-      'bx--snippet--single': type === 'single',
-      'bx--snippet--multi': type === 'multi',
+      [`${prefix}--snippet`]: true,
+      [`${prefix}--skeleton`]: true,
+      [`${prefix}--snippet--single`]: type === 'single',
+      [`${prefix}--snippet--multi`]: type === 'multi',
     });
 
     if (type === 'single') {
       return (
         <div className={codeSnippetClasses} {...other}>
-          <div className="bx--snippet-container">
+          <div className={`${prefix}--snippet-container`}>
             <span />
           </div>
         </div>
@@ -39,7 +49,7 @@ export default class CodeSnippetSkeleton extends Component {
     if (type === 'multi') {
       return (
         <div className={codeSnippetClasses} {...other}>
-          <div className="bx--snippet-container">
+          <div className={`${prefix}--snippet-container`}>
             <span />
             <span />
             <span />

--- a/src/components/CodeSnippet/CodeSnippet.js
+++ b/src/components/CodeSnippet/CodeSnippet.js
@@ -66,12 +66,18 @@ export default class CodeSnippet extends Component {
      * typically used for inline snippest to display an alternate color
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     type: 'single',
     showMoreText: 'Show more',
     showLessText: 'Show less',
+    prefix: 'bx',
   };
 
   state = {
@@ -112,16 +118,17 @@ export default class CodeSnippet extends Component {
       light,
       showMoreText,
       showLessText,
+      prefix,
       ...other
     } = this.props;
 
     const codeSnippetClasses = classNames(className, {
-      'bx--snippet': true,
-      'bx--snippet--single': type === 'single',
-      'bx--snippet--multi': type === 'multi',
-      'bx--snippet--inline': type === 'inline',
-      'bx--snippet--expand': this.state.expandedCode,
-      'bx--snippet--light': light,
+      [`${prefix}--snippet`]: true,
+      [`${prefix}--snippet--single`]: type === 'single',
+      [`${prefix}--snippet--multi`]: type === 'multi',
+      [`${prefix}--snippet--inline`]: type === 'inline',
+      [`${prefix}--snippet--expand`]: this.state.expandedCode,
+      [`${prefix}--snippet--light`]: light,
     });
 
     const expandCodeBtnText = this.state.expandedCode
@@ -130,16 +137,18 @@ export default class CodeSnippet extends Component {
 
     const moreLessBtn = (
       <button
-        className="bx--btn bx--btn--ghost bx--btn--sm bx--snippet-btn--expand"
+        className={`${prefix}--btn ${prefix}--btn--ghost ${prefix}--btn--sm ${prefix}--snippet-btn--expand`}
         type="button"
         onClick={this.expandCode}>
-        <span className="bx--snippet-btn--text">{expandCodeBtnText}</span>
+        <span className={`${prefix}--snippet-btn--text`}>
+          {expandCodeBtnText}
+        </span>
         <Icon
           aria-hidden="true"
           alt={expandCodeBtnText}
           name="chevron--down"
           description={expandCodeBtnText}
-          className="bx--icon-chevron--down"
+          className={`${prefix}--icon-chevron--down`}
         />
       </button>
     );
@@ -148,7 +157,7 @@ export default class CodeSnippet extends Component {
       <div
         role="textbox"
         tabIndex={0}
-        className="bx--snippet-container"
+        className={`${prefix}--snippet-container`}
         aria-label={ariaLabel ? ariaLabel : 'code-snippet'}>
         <code>
           <pre

--- a/src/components/ComboBox/ComboBox.js
+++ b/src/components/ComboBox/ComboBox.js
@@ -117,6 +117,11 @@ export default class ComboBox extends React.Component {
      * should use "light theme" (white background)?
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -126,6 +131,7 @@ export default class ComboBox extends React.Component {
     type: 'default',
     ariaLabel: 'ListBox input field',
     light: false,
+    prefix: 'bx',
   };
 
   constructor(props) {
@@ -189,8 +195,9 @@ export default class ComboBox extends React.Component {
       invalid,
       invalidText,
       light,
+      prefix,
     } = this.props;
-    const className = cx('bx--combo-box', containerClassName);
+    const className = cx(`${prefix}--combo-box`, containerClassName);
 
     return (
       <Downshift
@@ -219,7 +226,7 @@ export default class ComboBox extends React.Component {
             {...getRootProps({ refKey: 'innerRef' })}>
             <ListBox.Field {...getButtonProps({ disabled })}>
               <input
-                className="bx--text-input"
+                className={`${prefix}--text-input`}
                 aria-label={ariaLabel}
                 {...getInputProps({
                   disabled,

--- a/src/components/ComposedModal/ComposedModal-test.js
+++ b/src/components/ComposedModal/ComposedModal-test.js
@@ -121,6 +121,11 @@ describe('<ModalFooter />', () => {
 });
 
 describe('<ComposedModal />', () => {
+  it('renders', () => {
+    const wrapper = mount(<ComposedModal open />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('changes the open state upon change in props', () => {
     const wrapper = shallow(<ComposedModal open />);
     expect(wrapper.state().open).toEqual(true);

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -9,6 +9,7 @@ export default class ComposedModal extends Component {
   state = {};
 
   static defaultProps = {
+    prefix: 'bx',
     onKeyDown: () => {},
   };
 
@@ -25,6 +26,11 @@ export default class ComposedModal extends Component {
      * Specify an optional className to be applied to the modal node
      */
     containerClassName: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
 
     /**
      * Specify an optional handler for closing modal.
@@ -83,16 +89,22 @@ export default class ComposedModal extends Component {
 
   render() {
     const { open } = this.state;
-    const { className, containerClassName, children, ...other } = this.props;
+    const {
+      className,
+      containerClassName,
+      children,
+      prefix,
+      ...other
+    } = this.props;
 
     const modalClass = classNames({
-      'bx--modal': true,
+      [`${prefix}--modal`]: true,
       'is-visible': open,
       [className]: className,
     });
 
     const containerClass = classNames({
-      'bx--modal-container': true,
+      [`${prefix}--modal-container`]: true,
       [containerClassName]: containerClassName,
     });
 
@@ -181,11 +193,17 @@ export class ModalHeader extends Component {
      * clicked
      */
     buttonOnClick: PropTypes.func,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     iconDescription: 'Close the modal',
     buttonOnClick: () => {},
+    prefix: 'bx',
   };
 
   handleCloseButtonClick = () => {
@@ -206,31 +224,32 @@ export class ModalHeader extends Component {
       iconDescription,
       closeModal, // eslint-disable-line
       buttonOnClick, // eslint-disable-line
+      prefix,
       ...other
     } = this.props;
 
     const headerClass = classNames({
-      'bx--modal-header': true,
+      [`${prefix}--modal-header`]: true,
       [className]: className,
     });
 
     const labelClass = classNames({
-      'bx--modal-header__label bx--type-delta': true,
+      [`${prefix}--modal-header__label ${prefix}--type-delta`]: true,
       [labelClassName]: labelClassName,
     });
 
     const titleClass = classNames({
-      'bx--modal-header__heading bx--type-beta': true,
+      [`${prefix}--modal-header__heading ${prefix}--type-beta`]: true,
       [titleClassName]: titleClassName,
     });
 
     const closeClass = classNames({
-      'bx--modal-close': true,
+      [`${prefix}--modal-close`]: true,
       [closeClassName]: closeClassName,
     });
 
     const closeIconClass = classNames({
-      'bx--modal-close__icon': true,
+      [`${prefix}--modal-close__icon`]: true,
       [closeIconClassName]: closeIconClassName,
     });
 
@@ -263,13 +282,22 @@ export class ModalBody extends Component {
      * Specify an optional className to be added to the Modal Body node
      */
     className: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
   };
 
   render() {
-    const { className, children, ...other } = this.props;
+    const { className, children, prefix, ...other } = this.props;
 
     const contentClass = classNames({
-      'bx--modal-content': true,
+      [`${prefix}--modal-content`]: true,
       [className]: className,
     });
 
@@ -334,11 +362,17 @@ export class ModalFooter extends Component {
      * Pass in content that will be rendered in the Modal Footer
      */
     children: PropTypes.node,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     onRequestClose: () => {},
     onRequestSubmit: () => {},
+    prefix: 'bx',
   };
 
   handleRequestClose = evt => {
@@ -357,12 +391,13 @@ export class ModalFooter extends Component {
       closeModal, // eslint-disable-line
       onRequestClose, // eslint-disable-line
       onRequestSubmit, // eslint-disable-line
+      prefix,
       children,
       ...other
     } = this.props;
 
     const footerClass = classNames({
-      'bx--modal-footer': true,
+      [`${prefix}--modal-footer`]: true,
       [className]: className,
     });
 

--- a/src/components/ComposedModal/__snapshots__/ComposedModal-test.js.snap
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal-test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ComposedModal /> renders 1`] = `
+<ComposedModal
+  onKeyDown={[Function]}
+  open={true}
+  prefix="bx"
+>
+  <div
+    className="bx--modal is-visible"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    open={true}
+    role="presentation"
+    tabIndex={-1}
+  >
+    <div
+      className="bx--modal-container"
+    />
+  </div>
+</ComposedModal>
+`;

--- a/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/src/components/ContentSwitcher/ContentSwitcher.js
@@ -27,10 +27,16 @@ export default class ContentSwitcher extends React.Component {
      * Specify a selected index for the initially selected content
      */
     selectedIndex: PropTypes.number,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     selectedIndex: 0,
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ selectedIndex }, state) {
@@ -72,10 +78,11 @@ export default class ContentSwitcher extends React.Component {
       children,
       className,
       selectedIndex, // eslint-disable-line no-unused-vars
+      prefix,
       ...other
     } = this.props;
 
-    const classes = classNames('bx--content-switcher', className);
+    const classes = classNames(`${prefix}--content-switcher`, className);
 
     return (
       <div {...other} className={classes}>

--- a/src/components/Copy/Copy.js
+++ b/src/components/Copy/Copy.js
@@ -26,6 +26,11 @@ export default class Copy extends Component {
     feedbackTimeout: PropTypes.number,
 
     /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+
+    /**
      * Specify an optional `onClick` handler that is called when the underlying
      * <button> is clicked
      */
@@ -35,6 +40,7 @@ export default class Copy extends Component {
   static defaultProps = {
     feedback: 'Copied!',
     feedbackTimeout: 2000,
+    prefix: 'bx',
     onClick: () => {},
   };
 
@@ -65,11 +71,12 @@ export default class Copy extends Component {
       feedback,
       children,
       feedbackTimeout, // eslint-disable-line no-unused-vars
+      prefix,
       onClick, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
-    const feedbackClassNames = classnames('bx--btn--copy__feedback', {
-      'bx--btn--copy__feedback--displayed': this.state.showFeedback,
+    const feedbackClassNames = classnames(`${prefix}--btn--copy__feedback`, {
+      [`${prefix}--btn--copy__feedback--displayed`]: this.state.showFeedback,
     });
 
     return (

--- a/src/components/CopyButton/CopyButton.js
+++ b/src/components/CopyButton/CopyButton.js
@@ -29,6 +29,11 @@ export default class CopyButton extends Component {
     feedbackTimeout: PropTypes.number,
 
     /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+
+    /**
      * Specify an optional `onClick` handler that is called when the underlying
      * <button> is clicked
      */
@@ -39,6 +44,7 @@ export default class CopyButton extends Component {
     iconDescription: 'Copy to clipboard',
     feedback: 'Copied!',
     feedbackTimeout: 2000,
+    prefix: 'bx',
     onClick: () => {},
   };
 
@@ -69,12 +75,13 @@ export default class CopyButton extends Component {
       className,
       feedback,
       feedbackTimeout, // eslint-disable-line no-unused-vars
+      prefix,
       onClick, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
-    const classNames = classnames('bx--snippet-button', className);
-    const feedbackClassNames = classnames('bx--btn--copy__feedback', {
-      'bx--btn--copy__feedback--displayed': this.state.showFeedback,
+    const classNames = classnames(`${prefix}--snippet-button`, className);
+    const feedbackClassNames = classnames(`${prefix}--btn--copy__feedback`, {
+      [`${prefix}--btn--copy__feedback--displayed`]: this.state.showFeedback,
     });
 
     return (
@@ -84,7 +91,7 @@ export default class CopyButton extends Component {
         onClick={this.handleClick}
         {...other}>
         <Icon
-          className="bx--snippet__icon"
+          className={`${prefix}--snippet__icon`}
           icon={iconCopy}
           description={iconDescription}
         />

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -2,10 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-export const Table = ({ zebra, className, children, short, ...other }) => {
-  const componentClass = cx('bx--data-table-v2', className, {
-    'bx--data-table-v2--zebra': zebra,
-    'bx--data-table-v2--short': short,
+export const Table = ({
+  zebra,
+  className,
+  children,
+  short,
+  prefix,
+  ...other
+}) => {
+  const componentClass = cx(`${prefix}--data-table-v2`, className, {
+    [`${prefix}--data-table-v2--zebra`]: zebra,
+    [`${prefix}--data-table-v2--short`]: short,
   });
   return (
     <table {...other} className={componentClass}>
@@ -29,11 +36,17 @@ Table.propTypes = {
    * `true` for short data table.
    */
   short: PropTypes.bool,
+
+  /*
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 Table.defaultProps = {
   zebra: true,
   short: false,
+  prefix: 'bx',
 };
 
 export default Table;

--- a/src/components/DataTable/TableActionList.js
+++ b/src/components/DataTable/TableActionList.js
@@ -3,7 +3,7 @@ import wrapComponent from '../../tools/wrapComponent';
 const TableActionList = wrapComponent({
   name: 'TableActionList',
   type: 'div',
-  className: ['bx--action-list'],
+  className: prefix => [`${prefix}--action-list`],
 });
 
 export default TableActionList;

--- a/src/components/DataTable/TableBatchActions.js
+++ b/src/components/DataTable/TableBatchActions.js
@@ -20,14 +20,15 @@ const TableBatchActions = ({
   children,
   shouldShowBatchActions,
   totalSelected,
+  prefix,
   onCancel,
   translateWithId: t,
   ...rest
 }) => {
   const batchActionsClasses = cx(
     {
-      'bx--batch-actions': true,
-      'bx--batch-actions--active': shouldShowBatchActions,
+      [`${prefix}--batch-actions`]: true,
+      [`${prefix}--batch-actions--active`]: shouldShowBatchActions,
     },
     className
   );
@@ -35,15 +36,17 @@ const TableBatchActions = ({
   return (
     <div {...rest} className={batchActionsClasses}>
       {children}
-      <div className="bx--batch-summary">
-        <p className="bx--batch-summary__para">
+      <div className={`${prefix}--batch-summary`}>
+        <p className={`${prefix}--batch-summary__para`}>
           <span>
             {totalSelected > 1
               ? t('carbon.table.batch.items.selected', { totalSelected })
               : t('carbon.table.batch.item.selected', { totalSelected })}
           </span>
         </p>
-        <button className="bx--batch-summary__cancel" onClick={onCancel}>
+        <button
+          className={`${prefix}--batch-summary__cancel`}
+          onClick={onCancel}>
           {t('carbon.table.batch.cancel')}
         </button>
       </div>
@@ -70,6 +73,11 @@ TableBatchActions.propTypes = {
   totalSelected: PropTypes.number.isRequired,
 
   /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+
+  /**
    * Hook required to listen for when the user initiates a cancel request
    * through this comopnent
    */
@@ -84,6 +92,7 @@ TableBatchActions.propTypes = {
 };
 
 TableBatchActions.defaultProps = {
+  prefix: 'bx',
   translateWithId,
 };
 

--- a/src/components/DataTable/TableContainer.js
+++ b/src/components/DataTable/TableContainer.js
@@ -2,11 +2,14 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TableContainer = ({ className, children, title, ...rest }) => {
-  const tableContainerClasses = cx(className, 'bx--data-table-v2-container');
+const TableContainer = ({ className, children, title, prefix, ...rest }) => {
+  const tableContainerClasses = cx(
+    className,
+    `${prefix}--data-table-v2-container`
+  );
   return (
     <div {...rest} className={tableContainerClasses}>
-      {title && <h4 className="bx--data-table-v2-header">{title}</h4>}
+      {title && <h4 className={`${prefix}--data-table-v2-header`}>{title}</h4>}
       {children}
     </div>
   );
@@ -19,6 +22,14 @@ TableContainer.propTypes = {
    * Provide a title for the Table
    */
   title: PropTypes.node,
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableContainer.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableContainer;

--- a/src/components/DataTable/TableExpandRow.js
+++ b/src/components/DataTable/TableExpandRow.js
@@ -13,13 +13,14 @@ const TableExpandRow = ({
   onExpand,
   expandIconDescription,
   isSelected,
+  prefix,
   ...rest
 }) => {
   const className = cx(
     {
-      'bx--parent-row-v2': true,
-      'bx--expandable-row-v2': isExpanded,
-      'bx--data-table-v2--selected': isSelected,
+      [`${prefix}--parent-row-v2`]: true,
+      [`${prefix}--expandable-row-v2`]: isExpanded,
+      [`${prefix}--data-table-v2--selected`]: isSelected,
     },
     rowClassName
   );
@@ -28,14 +29,14 @@ const TableExpandRow = ({
   return (
     <tr {...rest} className={className} data-parent-row>
       <TableCell
-        className="bx--table-expand-v2"
+        className={`${prefix}--table-expand-v2`}
         data-previous-value={previousValue}>
         <button
-          className="bx--table-expand-v2__button"
+          className={`${prefix}--table-expand-v2__button`}
           onClick={onExpand}
           aria-label={ariaLabel}>
           <Icon
-            className="bx--table-expand-v2__svg"
+            className={`${prefix}--table-expand-v2__svg`}
             icon={iconChevronRight}
             description={expandIconDescription}
           />
@@ -69,6 +70,15 @@ TableExpandRow.propTypes = {
    * The description of the chevron right icon, to be put in its SVG `<title>` element.
    */
   expandIconDescription: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableExpandRow.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableExpandRow;

--- a/src/components/DataTable/TableExpandedRow.js
+++ b/src/components/DataTable/TableExpandedRow.js
@@ -4,10 +4,11 @@ import React from 'react';
 
 const TableExpandedRow = ({
   className: customClassName,
+  prefix,
   children,
   ...rest
 }) => {
-  const className = cx('bx--expandable-row-v2', customClassName);
+  const className = cx(`${prefix}--expandable-row-v2`, customClassName);
   return (
     <tr {...rest} className={className} data-child-row>
       {children}
@@ -16,8 +17,24 @@ const TableExpandedRow = ({
 };
 
 TableExpandedRow.propTypes = {
+  /**
+   * Pass in the contents for your TableExpandedRow
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to the container node
+   */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableExpandedRow.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableExpandedRow;

--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -30,6 +30,7 @@ const TableHeader = ({
   onClick,
   scope,
   sortDirection,
+  prefix,
   translateWithId: t,
   ...rest
 }) => {
@@ -42,19 +43,19 @@ const TableHeader = ({
   }
 
   const className = cx(headerClassName, {
-    'bx--table-sort-v2': true,
-    'bx--table-sort-v2--active':
+    [`${prefix}--table-sort-v2`]: true,
+    [`${prefix}--table-sort-v2--active`]:
       isSortHeader && sortDirection !== sortStates.NONE,
-    'bx--table-sort-v2--ascending':
+    [`${prefix}--table-sort-v2--ascending`]:
       isSortHeader && sortDirection === sortStates.ASC,
   });
 
   return (
     <th scope={scope} className={headerClassName}>
       <button className={className} onClick={onClick} {...rest}>
-        <span className="bx--table-header-label">{children}</span>
+        <span className={`${prefix}--table-header-label`}>{children}</span>
         <Icon
-          className="bx--table-sort-v2__icon"
+          className={`${prefix}--table-sort-v2__icon`}
           icon={iconCaretUp}
           description={t('carbon.table.header.icon.description', {
             header: children,
@@ -109,6 +110,11 @@ TableHeader.propTypes = {
   sortDirection: PropTypes.oneOf(Object.values(sortStates)),
 
   /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
+
+  /**
    * Supply a method to translate internal strings with your i18n tool of
    * choice. Translation keys are avabile on the `translationKeys` field for
    * this component.
@@ -119,6 +125,7 @@ TableHeader.propTypes = {
 TableHeader.defaultProps = {
   isSortable: false,
   scope: 'col',
+  prefix: 'bx',
   translateWithId,
 };
 

--- a/src/components/DataTable/TableRow.js
+++ b/src/components/DataTable/TableRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import cx from 'classnames';
 
@@ -6,13 +7,29 @@ const TableRow = props => {
   // Remove unnecessary props if provided to this component, these are
   // only useful in `TableExpandRow`
   const className = cx(props.className, {
-    'bx--data-table-v2--selected': props.isSelected,
+    [`${props.prefix}--data-table-v2--selected`]: props.isSelected,
   });
   const cleanProps = {
-    ...omit(props, ['ariaLabel', 'onExpand', 'isExpanded']),
+    ...omit(props, ['ariaLabel', 'onExpand', 'isExpanded', 'prefix']),
     className: className || undefined,
   };
   return <tr {...cleanProps} />;
+};
+
+TableRow.propTypes = {
+  /**
+   * Specify an optional className to be applied to the container node
+   */
+  className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableRow.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableRow;

--- a/src/components/DataTable/TableToolbar.js
+++ b/src/components/DataTable/TableToolbar.js
@@ -3,7 +3,7 @@ import wrapComponent from '../../tools/wrapComponent';
 const TableToolbar = wrapComponent({
   name: 'TableToolbar',
   type: 'section',
-  className: ['bx--table-toolbar'],
+  className: prefix => [`${prefix}--table-toolbar`],
 });
 
 export default TableToolbar;

--- a/src/components/DataTable/TableToolbarAction.js
+++ b/src/components/DataTable/TableToolbarAction.js
@@ -9,13 +9,14 @@ const TableToolbarAction = ({
   icon,
   iconName,
   iconDescription,
+  prefix,
   ...rest
 }) => {
-  const toolbarActionClasses = cx(className, 'bx--toolbar-action');
+  const toolbarActionClasses = cx(className, `${prefix}--toolbar-action`);
   return (
     <button className={toolbarActionClasses} {...rest}>
       <Icon
-        className="bx--toolbar-action__icon"
+        className={`${prefix}--toolbar-action__icon`}
         icon={icon}
         name={iconName}
         description={iconDescription}
@@ -49,6 +50,15 @@ TableToolbarAction.propTypes = {
    * Specify the description of the icon for the toolbar action
    */
   iconDescription: PropTypes.string.isRequired,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableToolbarAction.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableToolbarAction;

--- a/src/components/DataTable/TableToolbarContent.js
+++ b/src/components/DataTable/TableToolbarContent.js
@@ -3,7 +3,7 @@ import wrapComponent from '../../tools/wrapComponent';
 const TableToolbarContent = wrapComponent({
   name: 'TableToolbarContent',
   type: 'div',
-  className: ['bx--toolbar-content'],
+  className: prefix => [`${prefix}--toolbar-content`],
 });
 
 export default TableToolbarContent;

--- a/src/components/DataTable/TableToolbarSearch.js
+++ b/src/components/DataTable/TableToolbarSearch.js
@@ -17,6 +17,7 @@ const translateWithId = id => {
 const TableToolbarSearch = ({
   className,
   searchContainerClass,
+  prefix,
   onChange,
   translateWithId: t,
   placeHolderText,
@@ -26,7 +27,7 @@ const TableToolbarSearch = ({
 }) => {
   const searchContainerClasses = cx(
     searchContainerClass,
-    'bx--toolbar-search-container'
+    `${prefix}--toolbar-search-container`
   );
   return (
     <div className={searchContainerClasses}>
@@ -65,6 +66,11 @@ TableToolbarSearch.propTypes = {
   searchContainerClasses: PropTypes.string,
 
   /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+
+  /**
    * Provide an optional hook that is called each time the input is updated
    */
   onChange: PropTypes.func,
@@ -86,6 +92,7 @@ TableToolbarSearch.propTypes = {
 };
 
 TableToolbarSearch.defaultProps = {
+  prefix: 'bx',
   translateWithId,
 };
 

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -50,14 +50,20 @@ exports[`DataTable selection should have select-all default to un-checked if no 
         Object {
           "isThrow": false,
           "value": <TableContainer
+            prefix="bx"
             title="DataTable with selection"
           >
             <Table
+              prefix="bx"
               short={false}
               zebra={true}
             >
-              <TableHead>
-                <TableRow>
+              <TableHead
+                prefix="bx"
+              >
+                <TableRow
+                  prefix="bx"
+                >
                   <TableSelectAll
                     ariaLabel="Select all rows"
                     checked={false}
@@ -70,6 +76,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     isSortHeader={false}
                     isSortable={true}
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -80,6 +87,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     isSortHeader={false}
                     isSortable={true}
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -88,7 +96,9 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                   </TableHeader>
                 </TableRow>
               </TableHead>
-              <TableBody />
+              <TableBody
+                prefix="bx"
+              />
             </Table>
           </TableContainer>,
         },
@@ -101,6 +111,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
   translateWithId={[Function]}
 >
   <TableContainer
+    prefix="bx"
     title="DataTable with selection"
   >
     <div
@@ -112,15 +123,20 @@ exports[`DataTable selection should have select-all default to un-checked if no 
         DataTable with selection
       </h4>
       <Table
+        prefix="bx"
         short={false}
         zebra={true}
       >
         <table
           className="bx--data-table-v2 bx--data-table-v2--zebra"
         >
-          <TableHead>
+          <TableHead
+            prefix="bx"
+          >
             <thead>
-              <TableRow>
+              <TableRow
+                prefix="bx"
+              >
                 <tr>
                   <TableSelectAll
                     ariaLabel="Select all rows"
@@ -140,6 +156,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                         indeterminate={false}
                         name="select-all"
                         onClick={[Function]}
+                        prefix="bx"
                       >
                         <input
                           checked={false}
@@ -162,6 +179,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     isSortable={true}
                     key="fieldA"
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -234,6 +252,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     isSortable={true}
                     key="fieldB"
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -305,7 +324,9 @@ exports[`DataTable selection should have select-all default to un-checked if no 
               </TableRow>
             </thead>
           </TableHead>
-          <TableBody>
+          <TableBody
+            prefix="bx"
+          >
             <tbody />
           </TableBody>
         </table>
@@ -453,14 +474,20 @@ exports[`DataTable selection should render 1`] = `
         Object {
           "isThrow": false,
           "value": <TableContainer
+            prefix="bx"
             title="DataTable with selection"
           >
             <Table
+              prefix="bx"
               short={false}
               zebra={true}
             >
-              <TableHead>
-                <TableRow>
+              <TableHead
+                prefix="bx"
+              >
+                <TableRow
+                  prefix="bx"
+                >
                   <TableSelectAll
                     ariaLabel="Select all rows"
                     checked={false}
@@ -473,6 +500,7 @@ exports[`DataTable selection should render 1`] = `
                     isSortHeader={false}
                     isSortable={true}
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -483,6 +511,7 @@ exports[`DataTable selection should render 1`] = `
                     isSortHeader={false}
                     isSortable={true}
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -491,8 +520,12 @@ exports[`DataTable selection should render 1`] = `
                   </TableHeader>
                 </TableRow>
               </TableHead>
-              <TableBody>
-                <TableRow>
+              <TableBody
+                prefix="bx"
+              >
+                <TableRow
+                  prefix="bx"
+                >
                   <TableSelectRow
                     ariaLabel="Select row"
                     checked={false}
@@ -500,14 +533,20 @@ exports[`DataTable selection should render 1`] = `
                     name="select-row-b"
                     onSelect={[Function]}
                   />
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 2:A
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 2:B
                   </TableCell>
                 </TableRow>
-                <TableRow>
+                <TableRow
+                  prefix="bx"
+                >
                   <TableSelectRow
                     ariaLabel="Select row"
                     checked={false}
@@ -515,14 +554,20 @@ exports[`DataTable selection should render 1`] = `
                     name="select-row-a"
                     onSelect={[Function]}
                   />
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 1:A
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 1:B
                   </TableCell>
                 </TableRow>
-                <TableRow>
+                <TableRow
+                  prefix="bx"
+                >
                   <TableSelectRow
                     ariaLabel="Select row"
                     checked={false}
@@ -530,10 +575,14 @@ exports[`DataTable selection should render 1`] = `
                     name="select-row-c"
                     onSelect={[Function]}
                   />
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 3:A
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 3:B
                   </TableCell>
                 </TableRow>
@@ -568,6 +617,7 @@ exports[`DataTable selection should render 1`] = `
   translateWithId={[Function]}
 >
   <TableContainer
+    prefix="bx"
     title="DataTable with selection"
   >
     <div
@@ -579,15 +629,20 @@ exports[`DataTable selection should render 1`] = `
         DataTable with selection
       </h4>
       <Table
+        prefix="bx"
         short={false}
         zebra={true}
       >
         <table
           className="bx--data-table-v2 bx--data-table-v2--zebra"
         >
-          <TableHead>
+          <TableHead
+            prefix="bx"
+          >
             <thead>
-              <TableRow>
+              <TableRow
+                prefix="bx"
+              >
                 <tr>
                   <TableSelectAll
                     ariaLabel="Select all rows"
@@ -607,6 +662,7 @@ exports[`DataTable selection should render 1`] = `
                         indeterminate={false}
                         name="select-all"
                         onClick={[Function]}
+                        prefix="bx"
                       >
                         <input
                           checked={false}
@@ -629,6 +685,7 @@ exports[`DataTable selection should render 1`] = `
                     isSortable={true}
                     key="fieldA"
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -701,6 +758,7 @@ exports[`DataTable selection should render 1`] = `
                     isSortable={true}
                     key="fieldB"
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -772,10 +830,13 @@ exports[`DataTable selection should render 1`] = `
               </TableRow>
             </thead>
           </TableHead>
-          <TableBody>
+          <TableBody
+            prefix="bx"
+          >
             <tbody>
               <TableRow
                 key="b"
+                prefix="bx"
               >
                 <tr>
                   <TableSelectRow
@@ -792,6 +853,7 @@ exports[`DataTable selection should render 1`] = `
                         id="data-table-6__select-row-b"
                         name="select-row-b"
                         onClick={[Function]}
+                        prefix="bx"
                       >
                         <input
                           checked={false}
@@ -811,6 +873,7 @@ exports[`DataTable selection should render 1`] = `
                   </TableSelectRow>
                   <TableCell
                     key="b:fieldA"
+                    prefix="bx"
                   >
                     <td>
                       Field 2:A
@@ -818,6 +881,7 @@ exports[`DataTable selection should render 1`] = `
                   </TableCell>
                   <TableCell
                     key="b:fieldB"
+                    prefix="bx"
                   >
                     <td>
                       Field 2:B
@@ -827,6 +891,7 @@ exports[`DataTable selection should render 1`] = `
               </TableRow>
               <TableRow
                 key="a"
+                prefix="bx"
               >
                 <tr>
                   <TableSelectRow
@@ -843,6 +908,7 @@ exports[`DataTable selection should render 1`] = `
                         id="data-table-6__select-row-a"
                         name="select-row-a"
                         onClick={[Function]}
+                        prefix="bx"
                       >
                         <input
                           checked={false}
@@ -862,6 +928,7 @@ exports[`DataTable selection should render 1`] = `
                   </TableSelectRow>
                   <TableCell
                     key="a:fieldA"
+                    prefix="bx"
                   >
                     <td>
                       Field 1:A
@@ -869,6 +936,7 @@ exports[`DataTable selection should render 1`] = `
                   </TableCell>
                   <TableCell
                     key="a:fieldB"
+                    prefix="bx"
                   >
                     <td>
                       Field 1:B
@@ -878,6 +946,7 @@ exports[`DataTable selection should render 1`] = `
               </TableRow>
               <TableRow
                 key="c"
+                prefix="bx"
               >
                 <tr>
                   <TableSelectRow
@@ -894,6 +963,7 @@ exports[`DataTable selection should render 1`] = `
                         id="data-table-6__select-row-c"
                         name="select-row-c"
                         onClick={[Function]}
+                        prefix="bx"
                       >
                         <input
                           checked={false}
@@ -913,6 +983,7 @@ exports[`DataTable selection should render 1`] = `
                   </TableSelectRow>
                   <TableCell
                     key="c:fieldA"
+                    prefix="bx"
                   >
                     <td>
                       Field 3:A
@@ -920,6 +991,7 @@ exports[`DataTable selection should render 1`] = `
                   </TableCell>
                   <TableCell
                     key="c:fieldB"
+                    prefix="bx"
                   >
                     <td>
                       Field 3:B
@@ -1074,15 +1146,21 @@ exports[`DataTable should render 1`] = `
         Object {
           "isThrow": false,
           "value": <TableContainer
+            prefix="bx"
             title="DataTable with toolbar"
           >
-            <TableToolbar>
+            <TableToolbar
+              prefix="bx"
+            >
               <TableToolbarSearch
                 id="custom-id"
                 onChange={[Function]}
+                prefix="bx"
                 translateWithId={[Function]}
               />
-              <TableToolbarContent>
+              <TableToolbarContent
+                prefix="bx"
+              >
                 <TableToolbarAction
                   icon={
                     Object {
@@ -1109,6 +1187,7 @@ exports[`DataTable should render 1`] = `
                   }
                   iconDescription="Download"
                   onClick={[MockFunction]}
+                  prefix="bx"
                 />
                 <TableToolbarAction
                   icon={
@@ -1137,6 +1216,7 @@ exports[`DataTable should render 1`] = `
                   }
                   iconDescription="Edit"
                   onClick={[MockFunction]}
+                  prefix="bx"
                 />
                 <TableToolbarAction
                   icon={
@@ -1167,12 +1247,14 @@ exports[`DataTable should render 1`] = `
                   }
                   iconDescription="Settings"
                   onClick={[MockFunction]}
+                  prefix="bx"
                 />
                 <Button
                   disabled={false}
                   iconDescription="Provide icon description if icon is used"
                   kind="primary"
                   onClick={[MockFunction]}
+                  prefix="bx"
                   small={true}
                   tabIndex={0}
                   type="button"
@@ -1182,15 +1264,21 @@ exports[`DataTable should render 1`] = `
               </TableToolbarContent>
             </TableToolbar>
             <Table
+              prefix="bx"
               short={false}
               zebra={true}
             >
-              <TableHead>
-                <TableRow>
+              <TableHead
+                prefix="bx"
+              >
+                <TableRow
+                  prefix="bx"
+                >
                   <TableHeader
                     isSortHeader={false}
                     isSortable={true}
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -1201,6 +1289,7 @@ exports[`DataTable should render 1`] = `
                     isSortHeader={false}
                     isSortable={true}
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -1209,28 +1298,48 @@ exports[`DataTable should render 1`] = `
                   </TableHeader>
                 </TableRow>
               </TableHead>
-              <TableBody>
-                <TableRow>
-                  <TableCell>
+              <TableBody
+                prefix="bx"
+              >
+                <TableRow
+                  prefix="bx"
+                >
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 2:A
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 2:B
                   </TableCell>
                 </TableRow>
-                <TableRow>
-                  <TableCell>
+                <TableRow
+                  prefix="bx"
+                >
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 1:A
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 1:B
                   </TableCell>
                 </TableRow>
-                <TableRow>
-                  <TableCell>
+                <TableRow
+                  prefix="bx"
+                >
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 3:A
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    prefix="bx"
+                  >
                     Field 3:B
                   </TableCell>
                 </TableRow>
@@ -1265,6 +1374,7 @@ exports[`DataTable should render 1`] = `
   translateWithId={[Function]}
 >
   <TableContainer
+    prefix="bx"
     title="DataTable with toolbar"
   >
     <div
@@ -1275,13 +1385,16 @@ exports[`DataTable should render 1`] = `
       >
         DataTable with toolbar
       </h4>
-      <TableToolbar>
+      <TableToolbar
+        prefix="bx"
+      >
         <section
           className="bx--table-toolbar"
         >
           <TableToolbarSearch
             id="custom-id"
             onChange={[Function]}
+            prefix="bx"
             translateWithId={[Function]}
           >
             <div
@@ -1293,6 +1406,7 @@ exports[`DataTable should render 1`] = `
                 light={true}
                 onChange={[Function]}
                 placeHolderText="Search"
+                prefix="bx"
                 small={true}
                 type="text"
               >
@@ -1420,7 +1534,9 @@ exports[`DataTable should render 1`] = `
               </Search>
             </div>
           </TableToolbarSearch>
-          <TableToolbarContent>
+          <TableToolbarContent
+            prefix="bx"
+          >
             <div
               className="bx--toolbar-content"
             >
@@ -1450,6 +1566,7 @@ exports[`DataTable should render 1`] = `
                 }
                 iconDescription="Download"
                 onClick={[MockFunction]}
+                prefix="bx"
               >
                 <button
                   className="bx--toolbar-action"
@@ -1532,6 +1649,7 @@ exports[`DataTable should render 1`] = `
                 }
                 iconDescription="Edit"
                 onClick={[MockFunction]}
+                prefix="bx"
               >
                 <button
                   className="bx--toolbar-action"
@@ -1617,6 +1735,7 @@ exports[`DataTable should render 1`] = `
                 }
                 iconDescription="Settings"
                 onClick={[MockFunction]}
+                prefix="bx"
               >
                 <button
                   className="bx--toolbar-action"
@@ -1684,6 +1803,7 @@ exports[`DataTable should render 1`] = `
                 iconDescription="Provide icon description if icon is used"
                 kind="primary"
                 onClick={[MockFunction]}
+                prefix="bx"
                 small={true}
                 tabIndex={0}
                 type="button"
@@ -1703,21 +1823,27 @@ exports[`DataTable should render 1`] = `
         </section>
       </TableToolbar>
       <Table
+        prefix="bx"
         short={false}
         zebra={true}
       >
         <table
           className="bx--data-table-v2 bx--data-table-v2--zebra"
         >
-          <TableHead>
+          <TableHead
+            prefix="bx"
+          >
             <thead>
-              <TableRow>
+              <TableRow
+                prefix="bx"
+              >
                 <tr>
                   <TableHeader
                     isSortHeader={false}
                     isSortable={true}
                     key="fieldA"
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -1790,6 +1916,7 @@ exports[`DataTable should render 1`] = `
                     isSortable={true}
                     key="fieldB"
                     onClick={[Function]}
+                    prefix="bx"
                     scope="col"
                     sortDirection="NONE"
                     translateWithId={[Function]}
@@ -1861,14 +1988,18 @@ exports[`DataTable should render 1`] = `
               </TableRow>
             </thead>
           </TableHead>
-          <TableBody>
+          <TableBody
+            prefix="bx"
+          >
             <tbody>
               <TableRow
                 key="b"
+                prefix="bx"
               >
                 <tr>
                   <TableCell
                     key="b:fieldA"
+                    prefix="bx"
                   >
                     <td>
                       Field 2:A
@@ -1876,6 +2007,7 @@ exports[`DataTable should render 1`] = `
                   </TableCell>
                   <TableCell
                     key="b:fieldB"
+                    prefix="bx"
                   >
                     <td>
                       Field 2:B
@@ -1885,10 +2017,12 @@ exports[`DataTable should render 1`] = `
               </TableRow>
               <TableRow
                 key="a"
+                prefix="bx"
               >
                 <tr>
                   <TableCell
                     key="a:fieldA"
+                    prefix="bx"
                   >
                     <td>
                       Field 1:A
@@ -1896,6 +2030,7 @@ exports[`DataTable should render 1`] = `
                   </TableCell>
                   <TableCell
                     key="a:fieldB"
+                    prefix="bx"
                   >
                     <td>
                       Field 1:B
@@ -1905,10 +2040,12 @@ exports[`DataTable should render 1`] = `
               </TableRow>
               <TableRow
                 key="c"
+                prefix="bx"
               >
                 <tr>
                   <TableCell
                     key="c:fieldA"
+                    prefix="bx"
                   >
                     <td>
                       Field 3:A
@@ -1916,6 +2053,7 @@ exports[`DataTable should render 1`] = `
                   </TableCell>
                   <TableCell
                     key="c:fieldB"
+                    prefix="bx"
                   >
                     <td>
                       Field 3:B

--- a/src/components/DataTable/__tests__/__snapshots__/Table-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/Table-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.Table should render 1`] = `
 <Table
   className="custom-class"
+  prefix="bx"
   short={false}
   zebra={true}
 >

--- a/src/components/DataTable/__tests__/__snapshots__/TableActionList-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableActionList-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableActionList should render 1`] = `
 <TableActionList
   className="custom-class"
+  prefix="bx"
 >
   <div
     className="bx--action-list custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
@@ -33,6 +33,7 @@ exports[`DataTable.TableBatchAction should render 1`] = `
     }
     iconDescription="Add"
     kind="ghost"
+    prefix="bx"
     small={true}
     tabIndex={0}
     type="button"

--- a/src/components/DataTable/__tests__/__snapshots__/TableBatchActions-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableBatchActions-test.js.snap
@@ -4,6 +4,7 @@ exports[`DataTable.TableBatchActions should render 1`] = `
 <TableBatchActions
   className="custom-class"
   onCancel={[MockFunction]}
+  prefix="bx"
   shouldShowBatchActions={false}
   totalSelected={10}
   translateWithId={[Function]}
@@ -36,6 +37,7 @@ exports[`DataTable.TableBatchActions should render 2`] = `
 <TableBatchActions
   className="custom-class"
   onCancel={[MockFunction]}
+  prefix="bx"
   shouldShowBatchActions={true}
   totalSelected={10}
   translateWithId={[Function]}

--- a/src/components/DataTable/__tests__/__snapshots__/TableBody-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableBody-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`DataTable.TableBody should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
@@ -10,6 +11,7 @@ exports[`DataTable.TableBody should render 1`] = `
   >
     <TableBody
       className="custom-class"
+      prefix="bx"
     >
       <tbody
         className="custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableCell-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableCell-test.js.snap
@@ -2,18 +2,24 @@
 
 exports[`DataTable.TableCell should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableBody>
+    <TableBody
+      prefix="bx"
+    >
       <tbody>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableCell
               className="custom-class"
+              prefix="bx"
             >
               <td
                 className="custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableContainer-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableContainer-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableContainer should render 1`] = `
 <TableContainer
   className="custom-class"
+  prefix="bx"
 >
   <div
     className="custom-class bx--data-table-v2-container"

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandHeader-test.js.snap
@@ -2,15 +2,20 @@
 
 exports[`DataTable.TableExpandHeader should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableExpandHeader
               className="custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -2,19 +2,23 @@
 
 exports[`DataTable.TableExpandRow should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableBody>
+    <TableBody
+      prefix="bx"
+    >
       <tbody>
         <TableExpandRow
           ariaLabel="Aria label"
           className="custom-class"
           isExpanded={false}
           onExpand={[MockFunction]}
+          prefix="bx"
         >
           <tr
             className="bx--parent-row-v2 custom-class"
@@ -22,6 +26,7 @@ exports[`DataTable.TableExpandRow should render 1`] = `
           >
             <TableCell
               className="bx--table-expand-v2"
+              prefix="bx"
             >
               <td
                 className="bx--table-expand-v2"
@@ -85,7 +90,9 @@ exports[`DataTable.TableExpandRow should render 1`] = `
             </TableCell>
           </tr>
         </TableExpandRow>
-        <TableExpandedRow>
+        <TableExpandedRow
+          prefix="bx"
+        >
           <tr
             className="bx--expandable-row-v2"
             data-child-row={true}

--- a/src/components/DataTable/__tests__/__snapshots__/TableHead-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHead-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`DataTable.TableHead should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
@@ -10,6 +11,7 @@ exports[`DataTable.TableHead should render 1`] = `
   >
     <TableHead
       className="custom-class"
+      prefix="bx"
     >
       <thead
         className="custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
@@ -2,20 +2,26 @@
 
 exports[`DataTable.TableHeader should have an active and ascending class if sorting by ASC 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableHeader
               isSortHeader={true}
               isSortable={false}
               onClick={[MockFunction]}
+              prefix="bx"
               scope="col"
               sortDirection="ASC"
               translateWithId={[Function]}
@@ -36,20 +42,26 @@ exports[`DataTable.TableHeader should have an active and ascending class if sort
 
 exports[`DataTable.TableHeader should have an active class if it is the sort header and the sort state is not NONE 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableHeader
               isSortHeader={true}
               isSortable={false}
               onClick={[MockFunction]}
+              prefix="bx"
               scope="col"
               sortDirection="NONE"
               translateWithId={[Function]}
@@ -70,20 +82,26 @@ exports[`DataTable.TableHeader should have an active class if it is the sort hea
 
 exports[`DataTable.TableHeader should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableHeader
               isSortHeader={false}
               isSortable={false}
               onClick={[MockFunction]}
+              prefix="bx"
               scope="col"
               sortDirection="NONE"
               translateWithId={[Function]}
@@ -104,20 +122,26 @@ exports[`DataTable.TableHeader should render 1`] = `
 
 exports[`DataTable.TableHeader should render 2`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableHeader
               isSortHeader={true}
               isSortable={false}
               onClick={[MockFunction]}
+              prefix="bx"
               scope="col"
               sortDirection="NONE"
               translateWithId={[Function]}

--- a/src/components/DataTable/__tests__/__snapshots__/TableRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableRow-test.js.snap
@@ -2,16 +2,20 @@
 
 exports[`DataTable.TableRow should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableBody>
+    <TableBody
+      prefix="bx"
+    >
       <tbody>
         <TableRow
           className="custom-class"
+          prefix="bx"
         >
           <tr
             className="custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
@@ -2,15 +2,20 @@
 
 exports[`DataTable.TableSelectAll should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableSelectAll
               ariaLabel="Select all rows in the table"
@@ -29,6 +34,7 @@ exports[`DataTable.TableSelectAll should render 1`] = `
                   id="id"
                   name="select-all"
                   onClick={[MockFunction]}
+                  prefix="bx"
                 >
                   <input
                     checked={false}

--- a/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
@@ -2,15 +2,20 @@
 
 exports[`DataTable.TableSelectRow should render 1`] = `
 <Table
+  prefix="bx"
   short={false}
   zebra={true}
 >
   <table
     className="bx--data-table-v2 bx--data-table-v2--zebra"
   >
-    <TableHead>
+    <TableHead
+      prefix="bx"
+    >
       <thead>
-        <TableRow>
+        <TableRow
+          prefix="bx"
+        >
           <tr>
             <TableSelectRow
               ariaLabel="Aria label"
@@ -27,6 +32,7 @@ exports[`DataTable.TableSelectRow should render 1`] = `
                   id="id"
                   name="select-all"
                   onClick={[MockFunction]}
+                  prefix="bx"
                 >
                   <input
                     checked={false}

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbar-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbar-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableToolbar should render 1`] = `
 <TableToolbar
   className="custom-class"
+  prefix="bx"
 >
   <section
     className="bx--table-toolbar custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarAction-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarAction-test.js.snap
@@ -27,6 +27,7 @@ exports[`DataTable.TableToolbarAction should render 1`] = `
     }
   }
   iconDescription="Add"
+  prefix="bx"
 >
   <button
     className="custom-class bx--toolbar-action"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarContent-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarContent-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableToolbarContent should render 1`] = `
 <TableToolbarContent
   className="custom-class"
+  prefix="bx"
 >
   <div
     className="bx--toolbar-content custom-class"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -5,6 +5,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
   className="custom-class"
   id="custom-id"
   onChange={[MockFunction]}
+  prefix="bx"
   translateWithId={[Function]}
 >
   <div
@@ -17,6 +18,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
       light={true}
       onChange={[MockFunction]}
       placeHolderText="Search"
+      prefix="bx"
       small={true}
       type="text"
     >

--- a/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const DataTableSkeleton = ({ rowCount, zebra, compact, ...other }) => {
+const DataTableSkeleton = ({ rowCount, zebra, compact, prefix, ...other }) => {
   const dataTableSkeletonClasses = classNames({
-    'bx--skeleton': true,
-    'bx--data-table-v2': true,
-    'bx--data-table-v2--zebra': zebra,
-    'bx--data-table-v2--compact': compact,
+    [`${prefix}--skeleton`]: true,
+    [`${prefix}--data-table-v2`]: true,
+    [`${prefix}--data-table-v2--zebra`]: zebra,
+    [`${prefix}--data-table-v2--compact`]: compact,
   });
 
   const rows = [];
@@ -75,12 +75,18 @@ DataTableSkeleton.propTypes = {
    * compact DataTable
    */
   compact: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 DataTableSkeleton.defaultProps = {
   rowCount: 5,
   zebra: false,
   compact: false,
+  prefix: 'bx',
 };
 
 export default DataTableSkeleton;

--- a/src/components/DatePicker/DatePicker.Skeleton.js
+++ b/src/components/DatePicker/DatePicker.Skeleton.js
@@ -1,21 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const DatePickerSkeleton = ({ range, id }) => {
+const DatePickerSkeleton = ({ range, id, prefix }) => {
   const dateInput = (
-    <div className="bx--date-picker-container">
+    <div className={`${prefix}--date-picker-container`}>
       {
         /* eslint-disable jsx-a11y/label-has-for */
-        <label className="bx--label" htmlFor={id} />
+        <label className={`${prefix}--label`} htmlFor={id} />
       }
-      <div className="bx--date-picker__input bx--skeleton" />
+      <div className={`${prefix}--date-picker__input ${prefix}--skeleton`} />
     </div>
   );
 
   if (range) {
     return (
-      <div className="bx--form-item">
-        <div className="bx--date-picker bx--date-picker--range bx--skeleton">
+      <div className={`${prefix}--form-item`}>
+        <div
+          className={`${prefix}--date-picker ${prefix}--date-picker--range ${prefix}--skeleton`}>
           {dateInput}
           {dateInput}
         </div>
@@ -24,8 +25,9 @@ const DatePickerSkeleton = ({ range, id }) => {
   }
 
   return (
-    <div className="bx--form-item">
-      <div className="bx--date-picker bx--date-picker--short bx--date-picker--simple bx--skeleton">
+    <div className={`${prefix}--form-item`}>
+      <div
+        className={`${prefix}--date-picker ${prefix}--date-picker--short ${prefix}--date-picker--simple ${prefix}--skeleton`}>
         {dateInput}
       </div>
     </div>
@@ -33,7 +35,19 @@ const DatePickerSkeleton = ({ range, id }) => {
 };
 
 DatePickerSkeleton.propTypes = {
+  /**
+   * Specify whether the skeleton should be of range date picker.
+   */
   range: PropTypes.bool,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
+};
+
+DatePickerSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default DatePickerSkeleton;

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -203,6 +203,11 @@ export default class DatePicker extends Component {
      * The maximum date that a user can pick to.
      */
     maxDate: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -210,6 +215,7 @@ export default class DatePicker extends Component {
     light: false,
     dateFormat: 'm/d/Y',
     locale: 'en',
+    prefix: 'bx',
   };
 
   UNSAFE_componentWillUpdate(nextProps) {
@@ -341,27 +347,28 @@ export default class DatePicker extends Component {
     const calendarContainer = calendar.calendarContainer;
     const daysContainer = calendar.days;
     if (calendarContainer && daysContainer) {
+      const { prefix } = this.props;
       // calendarContainer and daysContainer are undefined if flatpickr detects a mobile device
-      calendarContainer.classList.add('bx--date-picker__calendar');
+      calendarContainer.classList.add(`${prefix}--date-picker__calendar`);
       calendarContainer
         .querySelector('.flatpickr-month')
-        .classList.add('bx--date-picker__month');
+        .classList.add(`${prefix}--date-picker__month`);
       calendarContainer
         .querySelector('.flatpickr-weekdays')
-        .classList.add('bx--date-picker__weekdays');
+        .classList.add(`${prefix}--date-picker__weekdays`);
       calendarContainer
         .querySelector('.flatpickr-days')
-        .classList.add('bx--date-picker__days');
+        .classList.add(`${prefix}--date-picker__days`);
       forEach.call(
         calendarContainer.querySelectorAll('.flatpickr-weekday'),
         item => {
           const currentItem = item;
           currentItem.innerHTML = currentItem.innerHTML.replace(/\s+/g, '');
-          currentItem.classList.add('bx--date-picker__weekday');
+          currentItem.classList.add(`${prefix}--date-picker__weekday`);
         }
       );
       forEach.call(daysContainer.querySelectorAll('.flatpickr-day'), item => {
-        item.classList.add('bx--date-picker__day');
+        item.classList.add(`${prefix}--date-picker__day`);
         if (
           item.classList.contains('today') &&
           calendar.selectedDates.length > 0
@@ -378,11 +385,12 @@ export default class DatePicker extends Component {
   };
 
   assignInputFieldRef = node => {
+    const { prefix } = this.props;
     this.inputField = !node
       ? null
       : // Child is a regular DOM node, seen in tests
         node.nodeType === Node.ELEMENT_NODE
-        ? node.querySelector('.bx--date-picker__input')
+        ? node.querySelector(`.${prefix}--date-picker__input`)
         : // Child is a React component
           node.input && node.input.nodeType === Node.ELEMENT_NODE
           ? node.input
@@ -390,11 +398,12 @@ export default class DatePicker extends Component {
   };
 
   assignToInputFieldRef = node => {
+    const { prefix } = this.props;
     this.toInputField = !node
       ? null
       : // Child is a regular DOM node, seen in tests
         node.nodeType === Node.ELEMENT_NODE
-        ? node.querySelector('.bx--date-picker__input')
+        ? node.querySelector(`.${prefix}--date-picker__input`)
         : // Child is a React component
           node.input && node.input.nodeType === Node.ELEMENT_NODE
           ? node.input
@@ -419,16 +428,17 @@ export default class DatePicker extends Component {
       locale, // eslint-disable-line
       value, // eslint-disable-line
       iconDescription,
+      prefix,
       ...other
     } = this.props;
 
-    const datePickerClasses = classNames('bx--date-picker', className, {
-      'bx--date-picker--short': short,
-      'bx--date-picker--light': light,
-      'bx--date-picker--simple': datePickerType === 'simple',
-      'bx--date-picker--single': datePickerType === 'single',
-      'bx--date-picker--range': datePickerType === 'range',
-      'bx--date-picker--nolabel':
+    const datePickerClasses = classNames(`${prefix}--date-picker`, className, {
+      [`${prefix}--date-picker--short`]: short,
+      [`${prefix}--date-picker--light`]: light,
+      [`${prefix}--date-picker--simple`]: datePickerType === 'simple',
+      [`${prefix}--date-picker--single`]: datePickerType === 'single',
+      [`${prefix}--date-picker--range`]: datePickerType === 'range',
+      [`${prefix}--date-picker--nolabel`]:
         datePickerType === 'range' && this.isLabelTextEmpty(children),
     });
 
@@ -436,7 +446,7 @@ export default class DatePicker extends Component {
       datePickerType === 'range' ? (
         <Icon
           name="calendar"
-          className="bx--date-picker__icon"
+          className={`${prefix}--date-picker__icon`}
           description={iconDescription}
           onClick={this.openCalendar}
         />
@@ -468,7 +478,7 @@ export default class DatePicker extends Component {
       }
     });
     return (
-      <div className="bx--form-item">
+      <div className={`${prefix}--form-item`}>
         <div className={datePickerClasses} {...other}>
           {childrenWithProps}
           {datePickerIcon}

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -9,10 +9,16 @@ export default class DatePickerInput extends Component {
      * Specify an id that unique identifies the <input>
      */
     id: PropTypes.string.isRequired,
+
     /**
      * The description of the calendar icon.
      */
     iconDescription: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -21,6 +27,7 @@ export default class DatePickerInput extends Component {
     disabled: false,
     invalid: false,
     labelText: '',
+    prefix: 'bx',
     onClick: () => {},
     onChange: () => {},
   };
@@ -40,6 +47,7 @@ export default class DatePickerInput extends Component {
       pattern,
       iconDescription,
       openCalendar,
+      prefix,
       ...other
     } = this.props;
 
@@ -60,15 +68,15 @@ export default class DatePickerInput extends Component {
       pattern,
     };
 
-    const labelClasses = classNames('bx--label', {
-      'bx--visually-hidden': hideLabel,
+    const labelClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--visually-hidden`]: hideLabel,
     });
 
     const datePickerIcon =
       datePickerType === 'single' ? (
         <Icon
           name="calendar"
-          className="bx--date-picker__icon"
+          className={`${prefix}--date-picker__icon`}
           description={iconDescription}
           onClick={openCalendar}
         />
@@ -83,11 +91,11 @@ export default class DatePickerInput extends Component {
     ) : null;
 
     const error = invalid ? (
-      <div className="bx--form-requirement">{invalidText}</div>
+      <div className={`${prefix}--form-requirement`}>{invalidText}</div>
     ) : null;
 
-    const containerClasses = classNames('bx--date-picker-container', {
-      'bx--date-picker--nolabel': !label,
+    const containerClasses = classNames(`${prefix}--date-picker-container`, {
+      [`${prefix}--date-picker--nolabel`]: !label,
     });
 
     const input = invalid ? (
@@ -98,7 +106,7 @@ export default class DatePickerInput extends Component {
           this.input = input;
         }}
         data-invalid
-        className="bx--date-picker__input"
+        className={`${prefix}--date-picker__input`}
       />
     ) : (
       <input
@@ -107,7 +115,7 @@ export default class DatePickerInput extends Component {
         }}
         {...other}
         {...datePickerInputProps}
-        className="bx--date-picker__input"
+        className={`${prefix}--date-picker__input`}
       />
     );
 

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -10,21 +10,84 @@ let didWarnAboutDeprecation = false;
 
 export default class Dropdown extends PureComponent {
   static propTypes = {
+    /**
+     * Specify a label to be read by screen readers on the container node
+     */
     ariaLabel: PropTypes.string.isRequired,
+
+    /**
+     * Specify the drop down items
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify the text for the trigger button until a selection is made
+     */
     defaultText: PropTypes.string,
+
+    /**
+     * Specify the value of the selected dropdown item
+     */
     value: PropTypes.string,
+
+    /**
+     * Specify the tab index of the container node
+     */
     tabIndex: PropTypes.number,
+
     onClick: PropTypes.func,
+
+    /**
+     * Specify an `onChange` handler that is called whenever the Dropdown
+     * changes which item is selected
+     */
     onChange: PropTypes.func.isRequired,
+
+    /**
+     * Function called when menu is open
+     */
     onOpen: PropTypes.func,
+
+    /**
+     * Function called when menu is closed
+     */
     onClose: PropTypes.func,
+
+    /**
+     * Specify the text content of the selected dropdown item
+     */
     selectedText: PropTypes.string,
+
+    /**
+     * `true` if the menu should be open.
+     */
     open: PropTypes.bool,
+
+    /**
+     * Specify a description for the twistie icon that can be read by screen
+     * readers
+     */
     iconDescription: PropTypes.string,
+
+    /**
+     * Specify if the control should be disabled, or not
+     */
     disabled: PropTypes.bool,
+
+    /**
+     * Specify whether you want the light version of this control
+     */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -33,6 +96,7 @@ export default class Dropdown extends PureComponent {
     disabled: false,
     light: false,
     iconDescription: 'open list of options',
+    prefix: 'bx',
     onChange: () => {},
     onOpen: () => {},
     onClose: () => {},
@@ -138,6 +202,7 @@ export default class Dropdown extends PureComponent {
       disabled,
       light,
       selectedText, // eslint-disable-line no-unused-vars
+      prefix,
       onOpen, // eslint-disable-line no-unused-vars
       onClose, // eslint-disable-line no-unused-vars
       ...other
@@ -156,10 +221,10 @@ export default class Dropdown extends PureComponent {
       );
 
     const dropdownClasses = classNames({
-      'bx--dropdown': true,
-      'bx--dropdown--open': this.state.open,
-      'bx--dropdown--disabled': disabled,
-      'bx--dropdown--light': light,
+      [`${prefix}--dropdown`]: true,
+      [`${prefix}--dropdown--open`]: this.state.open,
+      [`${prefix}--dropdown--disabled`]: disabled,
+      [`${prefix}--dropdown--light`]: light,
       [this.props.className]: this.props.className,
     });
 
@@ -174,18 +239,20 @@ export default class Dropdown extends PureComponent {
           tabIndex={tabIndex}
           aria-label={ariaLabel}
           role="listbox">
-          <li className="bx--dropdown-text">{this.state.selectedText}</li>
+          <li className={`${prefix}--dropdown-text`}>
+            {this.state.selectedText}
+          </li>
           <li>
             <Icon
               icon={iconCaretDown}
-              className="bx--dropdown__arrow"
+              className={`${prefix}--dropdown__arrow`}
               description={iconDescription}
             />
           </li>
           <li>
             <ul
               role="menu"
-              className="bx--dropdown-list"
+              className={`${prefix}--dropdown-list`}
               aria-label="inner dropdown menu">
               {children}
             </ul>

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -14,6 +14,7 @@ const DropdownItem = ({
   onKeyPress,
   href,
   selected,
+  prefix,
   ...other
 }) => {
   if (__DEV__) {
@@ -27,7 +28,7 @@ const DropdownItem = ({
   }
 
   const dropdownItemClasses = classNames({
-    'bx--dropdown-item': true,
+    [`${prefix}--dropdown-item`]: true,
     [className]: className,
   });
 
@@ -61,7 +62,7 @@ const DropdownItem = ({
         tabIndex={isDropdownOpen ? 0 : -1}
         href={href}
         onClick={/* istanbul ignore next */ evt => evt.preventDefault()}
-        className="bx--dropdown-link">
+        className={`${prefix}--dropdown-link`}>
         {itemText}
       </a>
     </li>
@@ -69,13 +70,46 @@ const DropdownItem = ({
 };
 
 DropdownItem.propTypes = {
+  /**
+   * Specify the value of the <DropdownItem>
+   */
   value: PropTypes.string.isRequired,
+
+  /**
+   * Specify the content of the <DropdownItem>
+   */
   itemText: PropTypes.string.isRequired,
+
+  /**
+   * Specify an optional className to be applied to the container node
+   */
   className: PropTypes.string,
+
+  /**
+   * Provide an optional function to be called when the container node is
+   * clicked
+   */
   onClick: PropTypes.func,
+
+  /**
+   * Provide an optional function to be called when a key is pressed on the <DropdownItem>
+   */
   onKeyPress: PropTypes.func,
+
+  /**
+   * Optional string representing the link location for the <DropdownItem>
+   */
   href: PropTypes.string,
+
+  /**
+   * Specify whether the <DropdownItem> is selected
+   */
   selected: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 DropdownItem.defaultProps = {
@@ -83,6 +117,7 @@ DropdownItem.defaultProps = {
   onKeyPress: /* istanbul ignore next */ () => {},
   href: '',
   selected: false,
+  prefix: 'bx',
 };
 
 export default DropdownItem;

--- a/src/components/DropdownV2/Dropdown.Skeleton.js
+++ b/src/components/DropdownV2/Dropdown.Skeleton.js
@@ -2,29 +2,38 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const DropdownSkeleton = ({ inline }) => {
+const DropdownSkeleton = ({ inline, prefix }) => {
   const wrapperClasses = classNames({
-    'bx--skeleton': true,
-    'bx--dropdown-v2': true,
-    'bx--list-box': true,
-    'bx--form-item': true,
-    'bx--list-box--inline': inline,
+    [`${prefix}--skeleton`]: true,
+    [`${prefix}--dropdown-v2`]: true,
+    [`${prefix}--list-box`]: true,
+    [`${prefix}--form-item`]: true,
+    [`${prefix}--list-box--inline`]: inline,
   });
   return (
     <div className={wrapperClasses}>
-      <div role="button" className="bx--list-box__field">
-        <span className="bx--list-box__label" />
+      <div role="button" className={`${prefix}--list-box__field`}>
+        <span className={`${prefix}--list-box__label`} />
       </div>
     </div>
   );
 };
 
 DropdownSkeleton.propTypes = {
+  /**
+   * Specify whether you want the inline version of this control
+   */
   inline: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 DropdownSkeleton.defaultProps = {
   inline: false,
+  prefix: 'bx',
 };
 
 export default DropdownSkeleton;

--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -72,6 +72,11 @@ export default class DropdownV2 extends React.Component {
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -79,6 +84,7 @@ export default class DropdownV2 extends React.Component {
     type: 'default',
     itemToString: defaultItemToString,
     light: false,
+    prefix: 'bx',
   };
 
   handleOnChange = selectedItem => {
@@ -99,10 +105,11 @@ export default class DropdownV2 extends React.Component {
       initialSelectedItem,
       selectedItem,
       light,
+      prefix,
       id,
     } = this.props;
-    const className = cx('bx--dropdown', containerClassName, {
-      'bx--dropdown--light': light,
+    const className = cx(`${prefix}--dropdown`, containerClassName, {
+      [`${prefix}--dropdown--light`]: light,
     });
     return (
       <Downshift
@@ -128,7 +135,9 @@ export default class DropdownV2 extends React.Component {
             ariaLabel={ariaLabel}
             {...getRootProps({ refKey: 'innerRef' })}>
             <ListBox.Field {...getButtonProps({ disabled })}>
-              <span className="bx--list-box__label" {...getLabelProps()}>
+              <span
+                className={`${prefix}--list-box__label`}
+                {...getLabelProps()}>
                 {selectedItem ? itemToString(selectedItem) : label}
               </span>
               <ListBox.MenuIcon isOpen={isOpen} />

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -37,6 +37,7 @@ exports[`DropdownV2 should render 1`] = `
   light={false}
   onChange={[MockFunction]}
   placeholder="Filter..."
+  prefix="bx"
   type="default"
 >
   <Downshift
@@ -62,6 +63,7 @@ exports[`DropdownV2 should render 1`] = `
       className="bx--dropdown"
       disabled={false}
       innerRef={[Function]}
+      prefix="bx"
       type="default"
     >
       <div
@@ -81,6 +83,7 @@ exports[`DropdownV2 should render 1`] = `
           onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
+          prefix="bx"
           role="button"
           type="button"
         >
@@ -106,6 +109,7 @@ exports[`DropdownV2 should render 1`] = `
             </span>
             <ListBoxMenuIcon
               isOpen={false}
+              prefix="bx"
               translateWithId={[Function]}
             >
               <div

--- a/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/src/components/FileUploader/FileUploader.Skeleton.js
@@ -1,13 +1,29 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SkeletonText from '../SkeletonText';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 
 export default class FileUploaderSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
+    const { prefix } = this.props;
     return (
-      <div className="bx--form-item">
+      <div className={`${prefix}--form-item`}>
         <SkeletonText heading width="100px" />
-        <SkeletonText width="225px" className="bx--label-description" />
+        <SkeletonText
+          width="225px"
+          className={`${prefix}--label-description`}
+        />
         <ButtonSkeleton />
       </div>
     );

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -80,6 +80,11 @@ export class FileUploaderButton extends Component {
      * Specify the types of files that this input should be able to receive
      */
     accept: PropTypes.arrayOf(PropTypes.string),
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -91,6 +96,7 @@ export class FileUploaderButton extends Component {
     onChange: () => {},
     onClick: () => {},
     accept: [],
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ labelText }, state) {
@@ -126,11 +132,12 @@ export class FileUploaderButton extends Component {
       tabIndex,
       buttonKind,
       accept,
+      prefix,
       name,
       ...other
     } = this.props;
     const classes = classNames({
-      'bx--file': true,
+      [`${prefix}--file`]: true,
       [className]: className,
     });
 
@@ -147,7 +154,7 @@ export class FileUploaderButton extends Component {
           }
         }}>
         <label
-          className={`bx--btn bx--btn--${buttonKind}`}
+          className={`${prefix}--btn ${prefix}--btn--${buttonKind}`}
           tabIndex={tabIndex}
           htmlFor={this.uid}
           role={role}
@@ -155,7 +162,7 @@ export class FileUploaderButton extends Component {
           {this.state.labelText}
         </label>
         <input
-          className="bx--visually-hidden"
+          className={`${prefix}--visually-hidden`}
           ref={input => (this.input = input)}
           id={this.uid}
           type="file"
@@ -185,6 +192,16 @@ export class Filename extends Component {
      * Specify the status of the File Upload
      */
     status: PropTypes.oneOf(['edit', 'complete', 'uploading']),
+
+    /**
+     * Provide a description for the complete/close icon that can be read by screen readers
+     */
+    iconDescription: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -192,18 +209,19 @@ export class Filename extends Component {
     status: 'uploading',
     style: {},
     tabIndex: 0,
+    prefix: 'bx',
   };
 
   render() {
-    const { iconDescription, status, style, ...other } = this.props;
+    const { iconDescription, status, style, prefix, ...other } = this.props;
 
     if (status === 'uploading') {
       return (
         <div
-          className="bx--loading"
+          className={`${prefix}--loading`}
           style={{ ...style, width: '1rem', height: '1rem' }}
           {...other}>
-          <svg className="bx--loading__svg" viewBox="-42 -42 84 84">
+          <svg className={`${prefix}--loading__svg`} viewBox="-42 -42 84 84">
             <circle cx="0" cy="0" r="37.5" />
           </svg>
         </div>
@@ -212,7 +230,7 @@ export class Filename extends Component {
       return (
         <Icon
           description={iconDescription}
-          className="bx--file-close"
+          className={`${prefix}--file-close`}
           icon={iconCloseSolid}
           style={style}
           {...other}
@@ -222,7 +240,7 @@ export class Filename extends Component {
       return (
         <Icon
           description={iconDescription}
-          className="bx--file-complete"
+          className={`${prefix}--file-complete`}
           icon={iconCheckmarkSolid}
           style={style}
           {...other}
@@ -236,18 +254,68 @@ export class Filename extends Component {
 
 export default class FileUploader extends Component {
   static propTypes = {
+    /**
+     * Provide a description for the complete/close icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string,
+
+    /**
+     * Provide the label text to be read by screen readers when interacting with
+     * the <FileUploaderButton>
+     */
     buttonLabel: PropTypes.string,
+
+    /**
+     * Specify the type of the <FileUploaderButton>
+     */
     buttonKind: ButtonTypes.buttonKind,
+
+    /**
+     * Specify the status of the File Upload
+     */
     filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading'])
       .isRequired,
+
+    /**
+     * Specify the description text of this <FileUploader>
+     */
     labelDescription: PropTypes.string,
+
+    /**
+     * Specify the title text of this <FileUploader>
+     */
     labelTitle: PropTypes.string,
+
+    /**
+     * Specify if the component should accept multiple files to upload
+     */
     multiple: PropTypes.bool,
+
+    /**
+     * Provide a name for the underlying <input> node
+     */
     name: PropTypes.string,
+
+    /**
+     * Provide an optional `onClick` hook that is called each time the button is
+     * clicked
+     */
     onClick: PropTypes.func,
+
+    /**
+     * Provide a custom className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify the types of files that this input should be able to receive
+     */
     accept: PropTypes.arrayOf(PropTypes.string),
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -258,6 +326,7 @@ export default class FileUploader extends Component {
     multiple: false,
     onClick: () => {},
     accept: [],
+    prefix: 'bx',
   };
 
   state = {
@@ -311,18 +380,19 @@ export default class FileUploader extends Component {
       multiple,
       accept,
       name,
+      prefix,
       ...other
     } = this.props;
 
     const classes = classNames({
-      'bx--form-item': true,
+      [`${prefix}--form-item`]: true,
       [className]: className,
     });
 
     return (
       <div className={classes} {...other}>
-        <strong className="bx--label">{labelTitle}</strong>
-        <p className="bx--label-description">{labelDescription}</p>
+        <strong className={`${prefix}--label`}>{labelTitle}</strong>
+        <p className={`${prefix}--label-description`}>{labelDescription}</p>
         <FileUploaderButton
           labelText={buttonLabel}
           multiple={multiple}
@@ -332,17 +402,17 @@ export default class FileUploader extends Component {
           accept={accept}
           name={name}
         />
-        <div className="bx--file-container">
+        <div className={`${prefix}--file-container`}>
           {this.state.filenames.length === 0
             ? null
             : this.state.filenames.map((name, index) => (
                 <span
                   key={index}
-                  className="bx--file__selected-file"
+                  className={`${prefix}--file__selected-file`}
                   ref={node => (this.nodes[index] = node)} // eslint-disable-line
                   {...other}>
-                  <p className="bx--file-filename">{name}</p>
-                  <span className="bx--file__state-container">
+                  <p className={`${prefix}--file-filename`}>{name}</p>
+                  <span className={`${prefix}--file__state-container`}>
                     <Filename
                       iconDescription={iconDescription}
                       status={filenameStatus}

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -14,10 +14,11 @@ const Footer = ({
   linkTextTwo,
   linkHrefTwo,
   buttonText,
+  prefix,
   ...other
 }) => {
   const classNames = classnames(
-    'bx--footer bx--footer--bottom-fixed',
+    `${prefix}--footer ${prefix}--footer--bottom-fixed`,
     className
   );
 
@@ -27,17 +28,17 @@ const Footer = ({
     </footer>
   ) : (
     <footer {...other} className={classNames}>
-      <div className="bx--footer-info">
-        <div className="bx--footer-info__item">
-          <p className="bx--footer-label">{labelOne}</p>
+      <div className={`${prefix}--footer-info`}>
+        <div className={`${prefix}--footer-info__item`}>
+          <p className={`${prefix}--footer-label`}>{labelOne}</p>
           <Link href={linkHrefOne}>{linkTextOne}</Link>
         </div>
-        <div className="bx--footer-info__item">
-          <p className="bx--footer-label">{labelTwo}</p>
+        <div className={`${prefix}--footer-info__item`}>
+          <p className={`${prefix}--footer-label`}>{labelTwo}</p>
           <Link href={linkHrefTwo}>{linkTextTwo}</Link>
         </div>
       </div>
-      <div className="bx--footer-cta">
+      <div className={`${prefix}--footer-cta`}>
         <Button type="submit">{buttonText}</Button>
       </div>
     </footer>
@@ -91,6 +92,11 @@ Footer.propTypes = {
    * Provide the text for the footer button
    */
   buttonText: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 Footer.defaultProps = {
@@ -101,6 +107,7 @@ Footer.defaultProps = {
   linkTextTwo: 'Cost Calculator',
   linkHrefTwo: '#',
   buttonText: 'Create',
+  prefix: 'bx',
 };
 
 export default Footer;

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Form = ({ className, children, ...other }) => {
-  const classNames = classnames('bx--form', className);
+const Form = ({ className, children, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--form`, className);
 
   return (
     <form className={classNames} {...other}>
@@ -23,6 +23,15 @@ Form.propTypes = {
    * Provide a custom className to be applied on the containing <form> node
    */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Form.defaultProps = {
+  prefix: 'bx',
 };
 
 export default Form;

--- a/src/components/FormGroup/FormGroup.js
+++ b/src/components/FormGroup/FormGroup.js
@@ -9,10 +9,11 @@ const FormGroup = ({
   className,
   message,
   messageText,
+  prefix,
   ...other
 }) => {
-  const classNamesLegend = classnames('bx--label', className);
-  const classNamesFieldset = classnames('bx--fieldset', className);
+  const classNamesLegend = classnames(`${prefix}--label`, className);
+  const classNamesFieldset = classnames(`${prefix}--fieldset`, className);
 
   return (
     <fieldset
@@ -22,7 +23,7 @@ const FormGroup = ({
       <legend className={classNamesLegend}>{legendText}</legend>
       {children}
       {message ? (
-        <div className="bx--form__requirements">{messageText}</div>
+        <div className={`${prefix}--form__requirements`}>{messageText}</div>
       ) : null}
     </fieldset>
   );
@@ -58,12 +59,18 @@ FormGroup.propTypes = {
    * Provide the text for the message in the <FormGroup>
    */
   messageText: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 FormGroup.defaultProps = {
   invalid: false,
   message: false,
   messageText: '',
+  prefix: 'bx',
 };
 
 export default FormGroup;

--- a/src/components/FormItem/FormItem.js
+++ b/src/components/FormItem/FormItem.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const FormItem = ({ className, children, ...other }) => {
-  const classNames = classnames('bx--form-item', className);
+const FormItem = ({ className, children, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--form-item`, className);
 
   return (
     <div className={classNames} {...other}>
@@ -22,6 +22,15 @@ FormItem.propTypes = {
    * Provide a custom className to be applied to the containing node
    */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+FormItem.defaultProps = {
+  prefix: 'bx',
 };
 
 export default FormItem;

--- a/src/components/FormLabel/FormLabel.js
+++ b/src/components/FormLabel/FormLabel.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const FormLabel = ({ className, children, id, ...other }) => {
-  const classNames = classnames('bx--label', className);
+const FormLabel = ({ className, children, id, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--label`, className);
 
   return (
     <label htmlFor={id} className={classNames} {...other}>
@@ -27,6 +27,15 @@ FormLabel.propTypes = {
    * Provide a unique id for the given <FormLabel>
    */
   id: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+FormLabel.defaultProps = {
+  prefix: 'bx',
 };
 
 export default FormLabel;

--- a/src/components/Icon/Icon.Skeleton.js
+++ b/src/components/Icon/Icon.Skeleton.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const IconSkeleton = ({ style }) => {
+const IconSkeleton = ({ style, prefix }) => {
   const props = {
     style,
   };
 
-  return <div className="bx--icon--skeleton" {...props} />;
+  return <div className={`${prefix}--icon--skeleton`} {...props} />;
 };
 
 IconSkeleton.propTypes = {
@@ -14,6 +14,15 @@ IconSkeleton.propTypes = {
    * The CSS styles.
    */
   style: PropTypes.object,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
+};
+
+IconSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default IconSkeleton;

--- a/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/src/components/InlineCheckbox/InlineCheckbox.js
@@ -34,6 +34,11 @@ export default class InlineCheckbox extends React.Component {
     name: PropTypes.string.isRequired,
 
     /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+
+    /**
      * Provide a handler that is invoked when a user clicks on the control
      */
     onClick: PropTypes.func,
@@ -42,6 +47,10 @@ export default class InlineCheckbox extends React.Component {
      * Provide a handler that is invoked on the key down event for the control
      */
     onKeyDown: PropTypes.func,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
   };
 
   componentDidMount() {
@@ -66,6 +75,7 @@ export default class InlineCheckbox extends React.Component {
       disabled,
       ariaLabel,
       name,
+      prefix,
       onClick,
       onKeyDown,
     } = this.props;
@@ -74,7 +84,7 @@ export default class InlineCheckbox extends React.Component {
       name,
       onClick,
       onKeyDown,
-      className: 'bx--checkbox',
+      className: `${prefix}--checkbox`,
       type: 'checkbox',
       ref: this.handleRef,
       checked: false,
@@ -97,7 +107,7 @@ export default class InlineCheckbox extends React.Component {
           /* eslint-disable jsx-a11y/label-has-for */
           <label
             htmlFor={id}
-            className="bx--checkbox-label"
+            className={`${prefix}--checkbox-label`}
             aria-label={ariaLabel}
           />
         }

--- a/src/components/InlineLoading/InlineLoading.js
+++ b/src/components/InlineLoading/InlineLoading.js
@@ -30,11 +30,17 @@ export default class InlineLoading extends React.Component {
      * Provide a delay for the `setTimeout` for success
      */
     successDelay: PropTypes.number,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     success: false,
     successDelay: 1500,
+    prefix: 'bx',
   };
 
   render() {
@@ -44,10 +50,11 @@ export default class InlineLoading extends React.Component {
       description,
       onSuccess,
       successDelay,
+      prefix,
       ...other
     } = this.props;
 
-    const loadingClasses = classNames('bx--inline-loading', className);
+    const loadingClasses = classNames(`${prefix}--inline-loading`, className);
 
     const getLoading = () => {
       if (success) {
@@ -59,11 +66,11 @@ export default class InlineLoading extends React.Component {
 
         return (
           <svg
-            className="bx--inline-loading__checkmark-container bx--inline-loading__svg"
+            className={`${prefix}--inline-loading__checkmark-container ${prefix}--inline-loading__svg`}
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 10 10">
             <polyline
-              className="bx--inline-loading__checkmark"
+              className={`${prefix}--inline-loading__checkmark`}
               points="0.74 3.4 3.67 6.34 9.24 0.74"
             />
           </svg>
@@ -74,12 +81,14 @@ export default class InlineLoading extends React.Component {
     };
 
     const loadingText = (
-      <p className="bx--inline-loading__text">{description}</p>
+      <p className={`${prefix}--inline-loading__text`}>{description}</p>
     );
 
     return (
       <div className={loadingClasses} {...other}>
-        <div className="bx--inline-loading__animation">{getLoading()}</div>
+        <div className={`${prefix}--inline-loading__animation`}>
+          {getLoading()}
+        </div>
         {description && loadingText}
       </div>
     );

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Link = ({ children, className, href, ...other }) => {
-  const classNames = classnames('bx--link', className);
+const Link = ({ children, className, href, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--link`, className);
   return (
     <a href={href} className={classNames} {...other}>
       {children}
@@ -26,6 +26,15 @@ Link.propTypes = {
    * Provide the `href` attribute for the <a> node
    */
   href: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Link.defaultProps = {
+  prefix: 'bx',
 };
 
 export default Link;

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -31,14 +31,15 @@ const ListBox = ({
   invalid,
   invalidText,
   light,
+  prefix,
   ...rest
 }) => {
   const className = cx({
     [containerClassName]: !!containerClassName,
-    'bx--list-box': true,
-    'bx--list-box--inline': type === 'inline',
-    'bx--list-box--disabled': disabled,
-    'bx--list-box--light': light,
+    [`${prefix}--list-box`]: true,
+    [`${prefix}--list-box--inline`]: type === 'inline',
+    [`${prefix}--list-box--disabled`]: disabled,
+    [`${prefix}--list-box--light`]: light,
   });
   return (
     <>
@@ -56,7 +57,7 @@ const ListBox = ({
         {children}
       </div>
       {invalid ? (
-        <div className="bx--form-requirement">{invalidText}</div>
+        <div className={`${prefix}--form-requirement`}>{invalidText}</div>
       ) : null}
     </>
   );
@@ -91,6 +92,11 @@ ListBox.propTypes = {
    * Specify the "aria-label" of the ListBox.
    */
   ariaLabel: PropTypes.string,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 ListBox.defaultProps = {
@@ -98,6 +104,7 @@ ListBox.defaultProps = {
   disabled: false,
   type: 'default',
   ariaLabel: 'Choose an item',
+  prefix: 'bx',
 };
 
 export default ListBox;

--- a/src/components/ListBox/ListBoxField.js
+++ b/src/components/ListBox/ListBoxField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ListBoxMenuIcon from './ListBoxMenuIcon';
 import ListBoxSelection from './ListBoxSelection';
 import childrenOf from '../../prop-types/childrenOf';
@@ -8,14 +9,30 @@ import childrenOf from '../../prop-types/childrenOf';
  * elements inside of a field. It also provides a11y-related attributes like
  * `role` to make sure a user can focus the given field.
  */
-const ListBoxField = ({ children, ...rest }) => (
-  <div role="button" className="bx--list-box__field" tabIndex="0" {...rest}>
+const ListBoxField = ({ children, prefix, ...rest }) => (
+  <div
+    role="button"
+    className={`${prefix}--list-box__field`}
+    tabIndex="0"
+    {...rest}>
     {children}
   </div>
 );
 
 ListBoxField.propTypes = {
+  /**
+   * Provide the contents of your ListBoxField
+   */
   children: childrenOf([ListBoxMenuIcon, ListBoxSelection, 'span', 'input']),
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+ListBoxField.defaultProps = {
+  prefix: 'bx',
 };
 
 export default ListBoxField;

--- a/src/components/ListBox/ListBoxMenu.js
+++ b/src/components/ListBox/ListBoxMenu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ListBoxMenuItem from './ListBoxMenuItem';
 import childrenOfType from '../../prop-types/childrenOfType';
 
@@ -7,16 +8,28 @@ import childrenOfType from '../../prop-types/childrenOfType';
  * class into a single component. It is also being used to validate given
  * `children` components.
  */
-const ListBoxMenu = ({ children, ...rest }) => {
+const ListBoxMenu = ({ children, prefix, ...rest }) => {
   return (
-    <div className="bx--list-box__menu" {...rest}>
+    <div className={`${prefix}--list-box__menu`} {...rest}>
       {children}
     </div>
   );
 };
 
 ListBoxMenu.propTypes = {
+  /**
+   * Provide the contents of your ListBoxMenu
+   */
   children: childrenOfType(ListBoxMenuItem),
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+ListBoxMenu.defaultProps = {
+  prefix: 'bx',
 };
 
 export default ListBoxMenu;

--- a/src/components/ListBox/ListBoxMenuIcon.js
+++ b/src/components/ListBox/ListBoxMenuIcon.js
@@ -18,10 +18,10 @@ const defaultTranslations = {
  * `ListBoxMenuIcon` is used to orient the icon up or down depending on the
  * state of the menu for a given `ListBox`
  */
-const ListBoxMenuIcon = ({ isOpen, translateWithId: t }) => {
+const ListBoxMenuIcon = ({ isOpen, prefix, translateWithId: t }) => {
   const className = cx({
-    'bx--list-box__menu-icon': true,
-    'bx--list-box__menu-icon--open': isOpen,
+    [`${prefix}--list-box__menu-icon`]: true,
+    [`${prefix}--list-box__menu-icon--open`]: isOpen,
   });
   const description = isOpen ? t('close.menu') : t('open.menu');
   return (
@@ -39,6 +39,11 @@ ListBoxMenuIcon.propTypes = {
   isOpen: PropTypes.bool.isRequired,
 
   /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+
+  /**
    * i18n hook used to provide the appropriate description for the given menu
    * icon. This function takes in an id defined in `translationIds` and should
    * return a string message for that given message id.
@@ -47,6 +52,7 @@ ListBoxMenuIcon.propTypes = {
 };
 
 ListBoxMenuIcon.defaultProps = {
+  prefix: 'bx',
   translateWithId: id => defaultTranslations[id],
 };
 

--- a/src/components/ListBox/ListBoxMenuItem.js
+++ b/src/components/ListBox/ListBoxMenuItem.js
@@ -7,11 +7,17 @@ import PropTypes from 'prop-types';
  * name, alongside any classes for any corresponding states, for a generic list
  * box menu item.
  */
-const ListBoxMenuItem = ({ children, isActive, isHighlighted, ...rest }) => {
+const ListBoxMenuItem = ({
+  children,
+  isActive,
+  isHighlighted,
+  prefix,
+  ...rest
+}) => {
   const className = cx({
-    'bx--list-box__menu-item': true,
-    'bx--list-box__menu-item--active': isActive,
-    'bx--list-box__menu-item--highlighted': isHighlighted,
+    [`${prefix}--list-box__menu-item`]: true,
+    [`${prefix}--list-box__menu-item--active`]: isActive,
+    [`${prefix}--list-box__menu-item--highlighted`]: isHighlighted,
   });
   return (
     <div className={className} {...rest}>
@@ -36,11 +42,17 @@ ListBoxMenuItem.propTypes = {
    * Specify whether the current menu item is "highlighed".
    */
   isHighlighted: PropTypes.bool.isRequired,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 ListBoxMenuItem.defaultProps = {
   isActive: false,
   isHighlighted: false,
+  prefix: 'bx',
 };
 
 export default ListBoxMenuItem;

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -12,11 +12,12 @@ import Icon from '../Icon';
 const ListBoxSelection = ({
   clearSelection,
   selectionCount,
+  prefix,
   translateWithId: t,
 }) => {
   const className = cx({
-    'bx--list-box__selection': true,
-    'bx--list-box__selection--multi': selectionCount,
+    [`${prefix}--list-box__selection`]: true,
+    [`${prefix}--list-box__selection--multi`]: selectionCount,
   });
   const handleOnClick = event => {
     // If we have a mult-select badge, clicking it shouldn't open the menu back
@@ -72,6 +73,11 @@ ListBoxSelection.propTypes = {
   selectionCount: PropTypes.number,
 
   /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
+
+  /**
    * i18n hook used to provide the appropriate description for the given menu
    * icon. This function takes in an id defined in `translationIds` and should
    * return a string message for that given message id.
@@ -80,6 +86,7 @@ ListBoxSelection.propTypes = {
 };
 
 ListBoxSelection.defaultProps = {
+  prefix: 'bx',
   translateWithId: id => defaultTranslations[id],
 };
 

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -31,6 +31,7 @@ exports[`ListBox should render 1`] = `
       ],
     }
   }
+  prefix="bx"
   type="default"
 >
   <div
@@ -41,7 +42,9 @@ exports[`ListBox should render 1`] = `
     role="listbox"
     tabIndex="0"
   >
-    <ListBoxField>
+    <ListBoxField
+      prefix="bx"
+    >
       <div
         className="bx--list-box__field"
         role="button"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ListBoxField should render 1`] = `
-<ListBoxField>
+<ListBoxField
+  prefix="bx"
+>
   <div
     className="bx--list-box__field"
     role="button"
@@ -9,6 +11,7 @@ exports[`ListBoxField should render 1`] = `
   >
     <ListBoxSelection
       clearSelection={[MockFunction]}
+      prefix="bx"
       translateWithId={[Function]}
     >
       <div

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenu-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenu-test.js.snap
@@ -1,13 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ListBoxMenu should render 1`] = `
-<ListBoxMenu>
+<ListBoxMenu
+  prefix="bx"
+>
   <div
     className="bx--list-box__menu"
   >
     <ListBoxMenuItem
       isActive={false}
       isHighlighted={false}
+      prefix="bx"
     >
       <div
         className="bx--list-box__menu-item"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
@@ -3,6 +3,7 @@
 exports[`ListBoxMenuIcon should render 1`] = `
 <ListBoxMenuIcon
   isOpen={true}
+  prefix="bx"
   translateWithId={[Function]}
 >
   <div
@@ -62,6 +63,7 @@ exports[`ListBoxMenuIcon should render 1`] = `
 exports[`ListBoxMenuIcon should render 2`] = `
 <ListBoxMenuIcon
   isOpen={false}
+  prefix="bx"
   translateWithId={[Function]}
 >
   <div

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuItem-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuItem-test.js.snap
@@ -4,6 +4,7 @@ exports[`ListBoxMenuItem should render 1`] = `
 <ListBoxMenuItem
   isActive={false}
   isHighlighted={false}
+  prefix="bx"
 >
   <div
     className="bx--list-box__menu-item"
@@ -19,6 +20,7 @@ exports[`ListBoxMenuItem should render 2`] = `
 <ListBoxMenuItem
   isActive={true}
   isHighlighted={false}
+  prefix="bx"
 >
   <div
     className="bx--list-box__menu-item bx--list-box__menu-item--active"
@@ -34,6 +36,7 @@ exports[`ListBoxMenuItem should render 3`] = `
 <ListBoxMenuItem
   isActive={false}
   isHighlighted={true}
+  prefix="bx"
 >
   <div
     className="bx--list-box__menu-item bx--list-box__menu-item--highlighted"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -3,6 +3,7 @@
 exports[`ListBoxSelection should render 1`] = `
 <ListBoxSelection
   clearSelection={[MockFunction]}
+  prefix="bx"
   translateWithId={
     [MockFunction] {
       "calls": Array [
@@ -90,6 +91,7 @@ exports[`ListBoxSelection should render 1`] = `
 exports[`ListBoxSelection should render 2`] = `
 <ListBoxSelection
   clearSelection={[MockFunction]}
+  prefix="bx"
   selectionCount={3}
   translateWithId={
     [MockFunction] {

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const ListItem = ({ children, className, ...other }) => {
-  const classNames = classnames('bx--list__item', className);
+const ListItem = ({ children, className, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--list__item`, className);
   return (
     <li className={classNames} {...other}>
       {children}
@@ -21,6 +21,15 @@ ListItem.propTypes = {
    * Specify an optional className to apply to the underlying <li> node
    */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+ListItem.defaultProps = {
+  prefix: 'bx',
 };
 
 export default ListItem;

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -23,24 +23,37 @@ export default class Loading extends React.Component {
      * Specify whether you would like the small variant of <Loading>
      */
     small: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     active: true,
     withOverlay: true,
     small: false,
+    prefix: 'bx',
   };
 
   render() {
-    const { active, className, withOverlay, small, ...other } = this.props;
+    const {
+      active,
+      className,
+      withOverlay,
+      small,
+      prefix,
+      ...other
+    } = this.props;
 
-    const loadingClasses = classNames('bx--loading', className, {
-      'bx--loading--small': small,
-      'bx--loading--stop': !active,
+    const loadingClasses = classNames(`${prefix}--loading`, className, {
+      [`${prefix}--loading--small`]: small,
+      [`${prefix}--loading--stop`]: !active,
     });
 
-    const overlayClasses = classNames('bx--loading-overlay', {
-      'bx--loading-overlay--stop': !active,
+    const overlayClasses = classNames(`${prefix}--loading-overlay`, {
+      [`${prefix}--loading-overlay--stop`]: !active,
     });
 
     const loading = (
@@ -48,7 +61,7 @@ export default class Loading extends React.Component {
         {...other}
         aria-live={active ? 'assertive' : 'off'}
         className={loadingClasses}>
-        <svg className="bx--loading__svg" viewBox="-75 -75 150 150">
+        <svg className={`${prefix}--loading__svg`} viewBox="-75 -75 150 150">
           <circle cx="0" cy="0" r="37.5" />
         </svg>
       </div>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -13,26 +13,112 @@ const matchesFuncName =
 
 export default class Modal extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your Modal
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the modal root node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify whether the modal should be button-less
+     */
     passiveModal: PropTypes.bool,
+
+    /**
+     * Specify a handler for closing modal.
+     * The handler should care of closing modal, e.g. changing `open` prop.
+     */
     onRequestClose: PropTypes.func,
+
+    /**
+     * Specify the DOM element ID of the top-level node.
+     */
     id: PropTypes.string,
+
+    /**
+     * Specify the content of the modal header title.
+     */
     modalHeading: PropTypes.string,
+
+    /**
+     * Specify the content of the modal header label.
+     */
     modalLabel: PropTypes.string,
+
+    /**
+     * Specify a label to be read by screen readers on the modal root node
+     */
     modalAriaLabel: PropTypes.string,
+
+    /**
+     * Specify the text for the secondary button
+     */
     secondaryButtonText: PropTypes.string,
+
+    /**
+     * Specify the text for the primary button
+     */
     primaryButtonText: PropTypes.string,
+
+    /**
+     * Specify whether the Modal is currently open
+     */
     open: PropTypes.bool,
+
+    /**
+     * Specify a handler for "submitting" modal.
+     * The handler should care of closing modal, e.g. changing `open` prop, if necessary.
+     */
     onRequestSubmit: PropTypes.func,
+
     onKeyDown: PropTypes.func,
+
+    /**
+     * Provide a description for "close" icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string,
+
+    /**
+     * Specify whether the Button should be disabled, or not
+     */
     primaryButtonDisabled: PropTypes.bool,
+
+    /**
+     * Specify a handler for the secondary button.
+     * Useful if separate handler from `onRequestClose` is desirable
+     */
     onSecondarySubmit: PropTypes.func,
+
+    /**
+     * Specify whether the Modal is for dangerous actions
+     */
     danger: PropTypes.bool,
+
+    /**
+     * Specify if Enter key should be used as "submit" action
+     */
     shouldSubmitOnEnter: PropTypes.bool,
+
+    /**
+     * Specify CSS selectors that match DOM elements working as floating menus.
+     * Focusing on those elements won't trigger "focus-wrap" behavior
+     */
     selectorsFloatingMenus: PropTypes.arrayOf(PropTypes.string),
+
+    /**
+     * Specify a CSS selector that matches the DOM element that should be focused
+     * when the Modal becomes open
+     */
     selectorPrimaryFocus: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -44,12 +130,8 @@ export default class Modal extends Component {
     iconDescription: 'close the modal',
     modalHeading: '',
     modalLabel: '',
-    selectorsFloatingMenus: [
-      '.bx--overflow-menu-options',
-      '.bx--tooltip',
-      '.flatpickr-calendar',
-    ],
     selectorPrimaryFocus: '[data-modal-primary-focus]',
+    prefix: 'bx',
   };
 
   button = React.createRef();
@@ -57,16 +139,22 @@ export default class Modal extends Component {
   innerModal = React.createRef();
 
   elementOrParentIsFloatingMenu = target => {
+    const {
+      prefix,
+      selectorsFloatingMenus = [
+        `.${prefix}--overflow-menu-options`,
+        `.${prefix}--tooltip`,
+        '.flatpickr-calendar',
+      ],
+    } = this.props;
     if (target && typeof target.closest === 'function') {
-      return this.props.selectorsFloatingMenus.some(selector =>
-        target.closest(selector)
-      );
+      return selectorsFloatingMenus.some(selector => target.closest(selector));
     } else {
       // Alternative if closest does not exist.
       while (target) {
         if (typeof target[matchesFuncName] === 'function') {
           if (
-            this.props.selectorsFloatingMenus.some(selector =>
+            selectorsFloatingMenus.some(selector =>
               target[matchesFuncName](selector)
             )
           ) {
@@ -167,6 +255,7 @@ export default class Modal extends Component {
       selectorPrimaryFocus, // eslint-disable-line
       selectorsFloatingMenus, // eslint-disable-line
       shouldSubmitOnEnter, // eslint-disable-line
+      prefix,
       ...other
     } = this.props;
 
@@ -175,22 +264,22 @@ export default class Modal extends Component {
       : onRequestClose;
 
     const modalClasses = classNames({
-      'bx--modal': true,
-      'bx--modal-tall': !passiveModal,
+      [`${prefix}--modal`]: true,
+      [`${prefix}--modal-tall`]: !passiveModal,
       'is-visible': open,
-      'bx--modal--danger': this.props.danger,
+      [`${prefix}--modal--danger`]: this.props.danger,
       [this.props.className]: this.props.className,
     });
 
     const modalButton = (
       <button
-        className="bx--modal-close"
+        className={`${prefix}--modal-close`}
         type="button"
         onClick={onRequestClose}
         ref={this.button}>
         <Icon
           icon={iconClose}
-          className="bx--modal-close__icon"
+          className={`${prefix}--modal-close__icon`}
           description={iconDescription}
         />
       </button>
@@ -200,20 +289,20 @@ export default class Modal extends Component {
       <div
         ref={this.innerModal}
         role="dialog"
-        className="bx--modal-container"
+        className={`${prefix}--modal-container`}
         aria-label={modalAriaLabel}>
-        <div className="bx--modal-header">
+        <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}
           {modalLabel && (
-            <h4 className="bx--modal-header__label">{modalLabel}</h4>
+            <h4 className={`${prefix}--modal-header__label`}>{modalLabel}</h4>
           )}
-          <h2 className="bx--modal-header__heading">{modalHeading}</h2>
+          <h2 className={`${prefix}--modal-header__heading`}>{modalHeading}</h2>
           {!passiveModal && modalButton}
         </div>
-        <div className="bx--modal-content">{this.props.children}</div>
+        <div className={`${prefix}--modal-content`}>{this.props.children}</div>
         {!passiveModal && (
-          <div className="bx--modal-footer">
-            <div className="bx--modal__buttons-container">
+          <div className={`${prefix}--modal-footer`}>
+            <div className={`${prefix}--modal__buttons-container`}>
               <Button
                 kind={danger ? 'tertiary' : 'secondary'}
                 onClick={onSecondaryButtonClick}>

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -37,6 +37,7 @@ exports[`ModalWrapper should render 1`] = `
       }
       kind="primary"
       onClick={[Function]}
+      prefix="bx"
       small={false}
       tabIndex={0}
       type="button"
@@ -73,17 +74,11 @@ exports[`ModalWrapper should render 1`] = `
       onRequestSubmit={[Function]}
       open={false}
       passiveModal={false}
+      prefix="bx"
       primaryButtonDisabled={false}
       primaryButtonText="Save"
       secondaryButtonText="Cancel"
       selectorPrimaryFocus="[data-modal-primary-focus]"
-      selectorsFloatingMenus={
-        Array [
-          ".bx--overflow-menu-options",
-          ".bx--tooltip",
-          ".flatpickr-calendar",
-        ]
-      }
     >
       <div
         className="bx--modal bx--modal-tall"
@@ -187,6 +182,7 @@ exports[`ModalWrapper should render 1`] = `
                 iconDescription="Provide icon description if icon is used"
                 kind="secondary"
                 onClick={[Function]}
+                prefix="bx"
                 small={false}
                 tabIndex={0}
                 type="button"
@@ -218,6 +214,7 @@ exports[`ModalWrapper should render 1`] = `
                 }
                 kind="primary"
                 onClick={[Function]}
+                prefix="bx"
                 small={false}
                 tabIndex={0}
                 type="button"

--- a/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/src/components/MultiSelect/FilterableMultiSelect.js
@@ -61,6 +61,11 @@ export default class FilterableMultiSelect extends React.Component {
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -72,6 +77,7 @@ export default class FilterableMultiSelect extends React.Component {
     locale: 'en',
     sortItems: defaultSortItems,
     light: false,
+    prefix: 'bx',
   };
 
   constructor(props) {
@@ -176,13 +182,14 @@ export default class FilterableMultiSelect extends React.Component {
       sortItems,
       compareItems,
       light,
+      prefix,
     } = this.props;
     const className = cx(
-      'bx--multi-select',
-      'bx--combo-box',
+      `${prefix}--multi-select`,
+      `${prefix}--combo-box`,
       containerClassName,
       {
-        'bx--list-box--light': light,
+        [`${prefix}--list-box--light`]: light,
       }
     );
     return (
@@ -221,7 +228,7 @@ export default class FilterableMultiSelect extends React.Component {
                     />
                   )}
                   <input
-                    className="bx--text-input"
+                    className={`${prefix}--text-input`}
                     ref={el => (this.inputNode = el)}
                     {...getInputProps({
                       disabled,

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -55,6 +55,7 @@ export default class MultiSelect extends React.Component {
      * consuming component what kind of internal state changes are occuring.
      */
     onChange: PropTypes.func,
+
     /**
      * Specify 'inline' to create an inline multi-select.
      */
@@ -69,14 +70,21 @@ export default class MultiSelect extends React.Component {
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
     /**
      * Is the current selection invalid?
      */
     invalid: PropTypes.bool,
+
     /**
      * If invalid, what is the error?
      */
     invalidText: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -89,6 +97,7 @@ export default class MultiSelect extends React.Component {
     type: 'default',
     light: false,
     title: false,
+    prefix: 'bx',
   };
 
   constructor(props) {
@@ -161,9 +170,10 @@ export default class MultiSelect extends React.Component {
       invalid,
       invalidText,
       useTitleInItem,
+      prefix,
     } = this.props;
-    const className = cx('bx--multi-select', containerClassName, {
-      'bx--list-box--light': light,
+    const className = cx(`${prefix}--multi-select`, containerClassName, {
+      [`${prefix}--list-box--light`]: light,
     });
     return (
       <Selection
@@ -201,7 +211,7 @@ export default class MultiSelect extends React.Component {
                       selectionCount={selectedItem.length}
                     />
                   )}
-                  <span className="bx--list-box__label">{label}</span>
+                  <span className={`${prefix}--list-box__label`}>{label}</span>
                   <ListBox.MenuIcon isOpen={isOpen} />
                 </ListBox.Field>
                 {isOpen && (

--- a/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -40,6 +40,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
   locale="en"
   onChange={[MockFunction]}
   placeholder="Placeholder..."
+  prefix="bx"
   sortItems={[Function]}
 >
   <Selection
@@ -75,6 +76,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
         className="bx--multi-select bx--combo-box"
         disabled={false}
         innerRef={[Function]}
+        prefix="bx"
         type="default"
       >
         <div
@@ -94,6 +96,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
+            prefix="bx"
             role="button"
             type="button"
           >
@@ -128,6 +131,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
               />
               <ListBoxMenuIcon
                 isOpen={false}
+                prefix="bx"
                 translateWithId={[Function]}
               >
                 <div

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -38,6 +38,7 @@ exports[`MultiSelect should render 1`] = `
   label="Field"
   light={false}
   locale="en"
+  prefix="bx"
   sortItems={[Function]}
   title={false}
   type="default"
@@ -74,6 +75,7 @@ exports[`MultiSelect should render 1`] = `
         className="bx--multi-select"
         disabled={false}
         innerRef={[Function]}
+        prefix="bx"
         type="default"
       >
         <div
@@ -93,6 +95,7 @@ exports[`MultiSelect should render 1`] = `
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
+            prefix="bx"
             role="button"
             type="button"
           >
@@ -117,6 +120,7 @@ exports[`MultiSelect should render 1`] = `
               </span>
               <ListBoxMenuIcon
                 isOpen={false}
+                prefix="bx"
                 translateWithId={[Function]}
               >
                 <div

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -12,25 +12,62 @@ import Icon from '../Icon';
 
 export class NotificationButton extends Component {
   static propTypes = {
+    /**
+     * Specify an optional className to be applied to the notification button
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify a label to be read by screen readers on the notification button
+     */
     ariaLabel: PropTypes.string,
+
+    /**
+     * Optional prop to specify the type of the Button
+     */
     type: PropTypes.string,
+
+    /**
+     * Provide a description for "close" icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string,
+
+    /**
+     * Specify an optional icon for the Button through an object representing the SVG data of the icon,
+     * if something but regular "close" icon is desirable
+     */
     icon: PropTypes.shape({
       width: PropTypes.string,
       height: PropTypes.string,
       viewBox: PropTypes.string.isRequired,
       svgData: PropTypes.object.isRequired,
     }),
+
+    /**
+     * Specify an optional icon for the Button through a string,
+     * if something but regular "close" icon is desirable
+     */
     name: PropTypes.string,
+
+    /**
+     * Specify the notification type
+     */
     notificationType: PropTypes.oneOf(['toast', 'inline']),
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
+
   static defaultProps = {
     ariaLabel: 'close notificaion',
     notificationType: 'toast',
     type: 'button',
     iconDescription: 'close icon',
+    prefix: 'bx',
   };
+
   render() {
     const {
       ariaLabel,
@@ -40,20 +77,24 @@ export class NotificationButton extends Component {
       icon,
       name,
       notificationType,
+      prefix,
       ...other
     } = this.props;
 
     const buttonClasses = classNames(
       {
-        'bx--toast-notification__close-button': notificationType === 'toast',
-        'bx--inline-notification__close-button': notificationType === 'inline',
+        [`${prefix}--toast-notification__close-button`]:
+          notificationType === 'toast',
+        [`${prefix}--inline-notification__close-button`]:
+          notificationType === 'inline',
       },
       className
     );
 
     const iconClasses = classNames({
-      'bx--toast-notification__icon': notificationType === 'toast',
-      'bx--inline-notification__close-icon': notificationType === 'inline',
+      [`${prefix}--toast-notification__icon`]: notificationType === 'toast',
+      [`${prefix}--inline-notification__close-icon`]:
+        notificationType === 'inline',
     });
 
     return (
@@ -72,10 +113,30 @@ export class NotificationButton extends Component {
 
 export class NotificationTextDetails extends Component {
   static propTypes = {
+    /**
+     * Specify the title
+     */
     title: PropTypes.string,
+
+    /**
+     * Specify the sub-title
+     */
     subtitle: PropTypes.node,
+
+    /**
+     * Specify the caption
+     */
     caption: PropTypes.node,
+
+    /**
+     * Specify the notification type
+     */
     notificationType: PropTypes.oneOf(['toast', 'inline']),
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -83,26 +144,42 @@ export class NotificationTextDetails extends Component {
     subtitle: 'subtitle',
     caption: 'caption',
     notificationType: 'toast',
+    prefix: 'bx',
   };
 
   render() {
-    const { title, subtitle, caption, notificationType, ...other } = this.props;
+    const {
+      title,
+      subtitle,
+      caption,
+      notificationType,
+      prefix,
+      ...other
+    } = this.props;
 
     if (notificationType === 'toast') {
       return (
-        <div {...other} className="bx--toast-notification__details">
-          <h3 className="bx--toast-notification__title">{title}</h3>
-          <div className="bx--toast-notification__subtitle">{subtitle}</div>
-          <div className="bx--toast-notification__caption">{caption}</div>
+        <div {...other} className={`${prefix}--toast-notification__details`}>
+          <h3 className={`${prefix}--toast-notification__title`}>{title}</h3>
+          <div className={`${prefix}--toast-notification__subtitle`}>
+            {subtitle}
+          </div>
+          <div className={`${prefix}--toast-notification__caption`}>
+            {caption}
+          </div>
         </div>
       );
     }
 
     if (notificationType === 'inline') {
       return (
-        <div {...other} className="bx--inline-notification__text-wrapper">
-          <p className="bx--inline-notification__title">{title}</p>
-          <div className="bx--inline-notification__subtitle">{subtitle}</div>
+        <div
+          {...other}
+          className={`${prefix}--inline-notification__text-wrapper`}>
+          <p className={`${prefix}--inline-notification__title`}>{title}</p>
+          <div className={`${prefix}--inline-notification__subtitle`}>
+            {subtitle}
+          </div>
         </div>
       );
     }
@@ -112,17 +189,68 @@ export class NotificationTextDetails extends Component {
 export class ToastNotification extends Component {
   static propTypes = {
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the notification box
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify what state the notification represents
+     */
     kind: PropTypes.oneOf(['error', 'info', 'success', 'warning']).isRequired,
+
+    /**
+     * Specify the title
+     */
     title: PropTypes.string.isRequired,
+
+    /**
+     * Specify the sub-title
+     */
     subtitle: PropTypes.node.isRequired,
+
+    /**
+     * By default, this value is "alert". You can also provide an alternate
+     * role if it makes sense from the accessibility-side
+     */
     role: PropTypes.string.isRequired,
+
+    /**
+     * Specify the caption
+     */
     caption: PropTypes.node,
+
+    /**
+     * Provide a function that is called when menu is closed
+     */
     onCloseButtonClick: PropTypes.func,
+
+    /**
+     * Provide a description for "close" icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * By default, this value is "toast". You can also provide an alternate type
+     * if it makes sense for the underlying `<NotificationTextDetails>` and `<NotificationButton>`
+     */
     notificationType: PropTypes.string,
+
+    /**
+     * Specify the close button should be disabled, or not
+     */
     hideCloseButton: PropTypes.bool,
+
+    /**
+     * Specify an optional duration the notification should be closed in
+     */
     timeout: PropTypes.number,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -136,6 +264,7 @@ export class ToastNotification extends Component {
     onCloseButtonClick: () => {},
     hideCloseButton: false,
     timeout: 0,
+    prefix: 'bx',
   };
 
   state = {
@@ -179,12 +308,15 @@ export class ToastNotification extends Component {
       title,
       kind,
       hideCloseButton,
+      prefix,
       ...other
     } = this.props;
 
     const classes = classNames(
-      'bx--toast-notification',
-      { [`bx--toast-notification--${this.props.kind}`]: this.props.kind },
+      `${prefix}--toast-notification`,
+      {
+        [`${prefix}--toast-notification--${this.props.kind}`]: this.props.kind,
+      },
       className
     );
 
@@ -211,15 +343,58 @@ export class ToastNotification extends Component {
 export class InlineNotification extends Component {
   static propTypes = {
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the notification box
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify what state the notification represents
+     */
     kind: PropTypes.oneOf(['error', 'info', 'success', 'warning']).isRequired,
+
+    /**
+     * Specify the title
+     */
     title: PropTypes.string.isRequired,
+
+    /**
+     * Specify the sub-title
+     */
     subtitle: PropTypes.node.isRequired,
+
+    /**
+     * By default, this value is "alert". You can also provide an alternate
+     * role if it makes sense from the accessibility-side
+     */
     role: PropTypes.string.isRequired,
+
+    /**
+     * Provide a function that is called when menu is closed
+     */
     onCloseButtonClick: PropTypes.func,
+
+    /**
+     * Provide a description for "close" icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * By default, this value is "inline". You can also provide an alternate type
+     * if it makes sense for the underlying `<NotificationTextDetails>` and `<NotificationButton>`
+     */
     notificationType: PropTypes.string,
+
+    /**
+     * Specify the close button should be disabled, or not
+     */
     hideCloseButton: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -228,6 +403,7 @@ export class InlineNotification extends Component {
     iconDescription: 'closes notification',
     onCloseButtonClick: () => {},
     hideCloseButton: false,
+    prefix: 'bx',
   };
 
   state = {
@@ -262,21 +438,24 @@ export class InlineNotification extends Component {
       title,
       kind,
       hideCloseButton,
+      prefix,
       ...other
     } = this.props;
 
     const classes = classNames(
-      'bx--inline-notification',
-      { [`bx--inline-notification--${this.props.kind}`]: this.props.kind },
+      `${prefix}--inline-notification`,
+      {
+        [`${prefix}--inline-notification--${this.props.kind}`]: this.props.kind,
+      },
       className
     );
 
     return (
       <div {...other} role={role} kind={kind} className={classes}>
-        <div className="bx--inline-notification__details">
+        <div className={`${prefix}--inline-notification__details`}>
           <Icon
             description={this.props.iconDescription}
-            className="bx--inline-notification__icon"
+            className={`${prefix}--inline-notification__icon`}
             aria-label="close"
             icon={this.useIcon(kind)}
           />
@@ -302,14 +481,51 @@ export class InlineNotification extends Component {
 export default class Notification extends Component {
   static propTypes = {
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the notification box
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify what state the notification represents
+     */
     kind: PropTypes.oneOf(['error', 'info', 'success', 'warning']).isRequired,
+
+    /**
+     * Specify the title
+     */
     title: PropTypes.string.isRequired,
+
+    /**
+     * Specify the sub-title
+     */
     subtitle: PropTypes.string.isRequired,
+
+    /**
+     * Specify the caption
+     */
     caption: PropTypes.string,
+
+    /**
+     * Provide a function that is called when menu is closed
+     */
     onCloseButtonClick: PropTypes.func,
+
+    /**
+     * Provide a description for "close" icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * Specify the close button should be disabled, or not
+     */
     hideCloseButton: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -318,6 +534,7 @@ export default class Notification extends Component {
     title: 'Provide a title',
     subtitle: 'Provide a subtitle',
     hideCloseButton: false,
+    prefix: 'bx',
   };
 
   state = {
@@ -351,18 +568,25 @@ export default class Notification extends Component {
       title,
       kind,
       hideCloseButton,
+      prefix,
       ...other
     } = this.props;
 
     const notificationClasses = {
       toast: classNames(
-        'bx--toast-notification',
-        { [`bx--toast-notification--${this.props.kind}`]: this.props.kind },
+        `${prefix}--toast-notification`,
+        {
+          [`${prefix}--toast-notification--${this.props.kind}`]: this.props
+            .kind,
+        },
         className
       ),
       inline: classNames(
-        'bx--inline-notification',
-        { [`bx--inline-notification--${this.props.kind}`]: this.props.kind },
+        `${prefix}--inline-notification`,
+        {
+          [`${prefix}--inline-notification--${this.props.kind}`]: this.props
+            .kind,
+        },
         className
       ),
     };
@@ -394,10 +618,10 @@ export default class Notification extends Component {
         role="alert"
         kind={kind}
         className={notificationClasses.inline}>
-        <div className="bx--inline-notification__details">
+        <div className={`${prefix}--inline-notification__details`}>
           <Icon
             description={this.props.iconDescription}
-            className="bx--inline-notification__icon"
+            className={`${prefix}--inline-notification__icon`}
             aria-label="close"
             icon={this.useIcon(kind)}
           />

--- a/src/components/NumberInput/NumberInput.Skeleton.js
+++ b/src/components/NumberInput/NumberInput.Skeleton.js
@@ -1,22 +1,34 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const NumberInputSkeleton = ({ hideLabel, id }) => {
+const NumberInputSkeleton = ({ hideLabel, id, prefix }) => {
   const label = hideLabel ? null : (
     // eslint-disable-next-line jsx-a11y/label-has-for
-    <label className="bx--label bx--skeleton" htmlFor={id} />
+    <label className={`${prefix}--label ${prefix}--skeleton`} htmlFor={id} />
   );
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
-      <div className="bx--number bx--skeleton" />
+      <div className={`${prefix}--number ${prefix}--skeleton`} />
     </div>
   );
 };
 
 NumberInputSkeleton.propTypes = {
+  /**
+   * Specify whether the label should be hidden, or not
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+NumberInputSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default NumberInputSkeleton;

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -15,32 +15,92 @@ export default class NumberInput extends Component {
   }
 
   static propTypes = {
+    /**
+     * Specify an optional className to be applied to the wrapper node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify if the control should be disabled, or not
+     */
     disabled: PropTypes.bool,
+
+    /**
+     * Provide a description for up/down icons that can be read by screen readers
+     */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * Specify a custom `id` for the input
+     */
     id: PropTypes.string.isRequired,
+
+    /**
+     * Generic `label` that will be used as the textual representation of what
+     * this field is for
+     */
     label: PropTypes.node,
+
+    /**
+     * The maximum value.
+     */
     max: PropTypes.number,
+
+    /**
+     * The minimum value.
+     */
     min: PropTypes.number,
+
     /**
      * The new value is available in 'imaginaryTarget.value'
      * i.e. to get the value: evt.imaginaryTarget.value
      */
     onChange: PropTypes.func,
+
+    /**
+     * Provide an optional function to be called when the up/down button is clicked
+     */
     onClick: PropTypes.func,
+
+    /**
+     * Specify how much the valus should increase/decrease upon clicking on up/down button
+     */
     step: PropTypes.number,
+
+    /**
+     * Specify the value of the input
+     */
     value: PropTypes.number,
+
+    /**
+     * Specify if the currently value is invalid.
+     */
     invalid: PropTypes.bool,
+
+    /**
+     * Message which is displayed if the value is invalid.
+     */
     invalidText: PropTypes.string,
+
+    /**
+     * Provide text that is used alongside the control label for additional help
+     */
     helperText: PropTypes.node,
+
     /**
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
     /**
      * `true` to allow empty string.
      */
     allowEmpty: PropTypes.bool,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -56,6 +116,7 @@ export default class NumberInput extends Component {
     helperText: '',
     light: false,
     allowEmpty: false,
+    prefix: 'bx',
   };
 
   /**
@@ -139,11 +200,12 @@ export default class NumberInput extends Component {
       helperText,
       light,
       allowEmpty,
+      prefix,
       ...other
     } = this.props;
 
-    const numberInputClasses = classNames('bx--number', className, {
-      'bx--number--light': light,
+    const numberInputClasses = classNames(`${prefix}--number`, className, {
+      [`${prefix}--number--light`]: light,
     });
 
     const props = {
@@ -165,19 +227,21 @@ export default class NumberInput extends Component {
     let error = null;
     if (invalid || (!allowEmpty && this.state.value === '')) {
       inputWrapperProps['data-invalid'] = true;
-      error = <div className="bx--form-requirement">{invalidText}</div>;
+      error = (
+        <div className={`${prefix}--form-requirement`}>{invalidText}</div>
+      );
     }
 
     const helper = helperText ? (
-      <div className="bx--form__helper-text">{helperText}</div>
+      <div className={`${prefix}--form__helper-text`}>{helperText}</div>
     ) : null;
 
     return (
-      <div className="bx--form-item">
+      <div className={`${prefix}--form-item`}>
         <div className={numberInputClasses} {...inputWrapperProps}>
-          <div className="bx--number__controls">
+          <div className={`${prefix}--number__controls`}>
             <button
-              className="bx--number__control-btn up-icon"
+              className={`${prefix}--number__control-btn up-icon`}
               {...buttonProps}
               onClick={evt => this.handleArrowClick(evt, 'up')}>
               <Icon
@@ -188,7 +252,7 @@ export default class NumberInput extends Component {
               />
             </button>
             <button
-              className="bx--number__control-btn down-icon"
+              className={`${prefix}--number__control-btn down-icon`}
               {...buttonProps}
               onClick={evt => this.handleArrowClick(evt, 'down')}>
               <Icon
@@ -199,7 +263,7 @@ export default class NumberInput extends Component {
               />
             </button>
           </div>
-          <label htmlFor={id} className="bx--label">
+          <label htmlFor={id} className={`${prefix}--label`}>
             {label}
           </label>
           <input

--- a/src/components/OrderedList/OrderedList.js
+++ b/src/components/OrderedList/OrderedList.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const OrderedList = ({ children, className, nested, ...other }) => {
-  const classNames = classnames('bx--list--ordered', className, {
-    'bx--list--nested': nested,
+const OrderedList = ({ children, className, nested, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--list--ordered`, className, {
+    [`${prefix}--list--nested`]: nested,
   });
   return (
     <ol className={classNames} {...other}>
@@ -28,10 +28,16 @@ OrderedList.propTypes = {
    * Specify whether this ordered list is nested inside of another nested list
    */
   nested: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 OrderedList.defaultProps = {
   nested: false,
+  prefix: 'bx',
 };
 
 export default OrderedList;

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -241,6 +241,11 @@ export default class OverflowMenu extends Component {
     renderIcon: PropTypes.func,
 
     /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+
+    /**
      * Function called when menu is closed
      */
     onClose: PropTypes.func,
@@ -265,6 +270,7 @@ export default class OverflowMenu extends Component {
     tabIndex: 0,
     menuOffset: getMenuOffset,
     menuOffsetFlip: getMenuOffset,
+    prefix: 'bx',
   };
 
   /**
@@ -406,6 +412,7 @@ export default class OverflowMenu extends Component {
       ).focus();
       const hasFocusin = 'onfocusin' in window;
       const focusinEventName = hasFocusin ? 'focusin' : 'focus';
+      const { prefix } = this.props;
       this._hFocusIn = on(
         menuBody.ownerDocument,
         focusinEventName,
@@ -414,7 +421,10 @@ export default class OverflowMenu extends Component {
           if (
             !menuBody.contains(target) &&
             this.menuEl &&
-            !matches(target, '.bx--overflow-menu,.bx--overflow-menu-options')
+            !matches(
+              target,
+              `.${prefix}--overflow-menu,.${prefix}--overflow-menu-options`
+            )
           ) {
             this.closeMenu();
           }
@@ -450,6 +460,7 @@ export default class OverflowMenu extends Component {
       onClick, // eslint-disable-line
       onOpen, // eslint-disable-line
       renderIcon,
+      prefix,
       ...other
     } = this.props;
 
@@ -465,19 +476,22 @@ export default class OverflowMenu extends Component {
 
     const overflowMenuClasses = classNames(
       this.props.className,
-      'bx--overflow-menu',
+      `${prefix}--overflow-menu`,
       {
-        'bx--overflow-menu--open': open,
+        [`${prefix}--overflow-menu--open`]: open,
       }
     );
 
-    const overflowMenuOptionsClasses = classNames('bx--overflow-menu-options', {
-      'bx--overflow-menu--flip': this.props.flipped,
-      'bx--overflow-menu-options--open': open,
-    });
+    const overflowMenuOptionsClasses = classNames(
+      `${prefix}--overflow-menu-options`,
+      {
+        [`${prefix}--overflow-menu--flip`]: this.props.flipped,
+        [`${prefix}--overflow-menu-options--open`]: open,
+      }
+    );
 
     const overflowMenuIconClasses = classNames(
-      'bx--overflow-menu__icon',
+      `${prefix}--overflow-menu__icon`,
       iconClass
     );
 

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -14,19 +14,20 @@ const OverflowMenuItem = ({
   floatingMenu,
   wrapperClassName,
   requireTitle,
+  prefix,
   ...other
 }) => {
   const overflowMenuBtnClasses = classNames(
-    'bx--overflow-menu-options__btn',
+    `${prefix}--overflow-menu-options__btn`,
     className
   );
 
   const overflowMenuItemClasses = classNames(
-    'bx--overflow-menu-options__option',
+    `${prefix}--overflow-menu-options__option`,
     {
-      'bx--overflow-menu--divider': hasDivider,
-      'bx--overflow-menu-options__option--danger': isDelete,
-      'bx--overflow-menu-options__option--disabled': disabled,
+      [`${prefix}--overflow-menu--divider`]: hasDivider,
+      [`${prefix}--overflow-menu-options__option--danger`]: isDelete,
+      [`${prefix}--overflow-menu-options__option--disabled`]: disabled,
     },
     wrapperClassName
   );
@@ -88,6 +89,7 @@ OverflowMenuItem.propTypes = {
    * `true` to make this menu item a "danger button".
    */
   isDelete: PropTypes.bool,
+
   /**
    * `true` to make this menu item disabled.
    */
@@ -117,10 +119,16 @@ OverflowMenuItem.propTypes = {
    * `true` if this menu item belongs to a floating OverflowMenu
    */
   floatingMenu: PropTypes.bool,
+
   /**
    * `true` if this menu item has long text and requires a browser tooltip
    */
   requireTitle: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 OverflowMenuItem.defaultProps = {
@@ -128,6 +136,7 @@ OverflowMenuItem.defaultProps = {
   isDelete: false,
   disabled: false,
   itemText: 'Provide itemText',
+  prefix: 'bx',
   onClick: () => {},
 };
 

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -14,28 +14,121 @@ let didWarnAboutDeprecation = false;
 
 export default class Pagination extends Component {
   static propTypes = {
+    /**
+     * The description for the backward icon.
+     */
     backwardText: PropTypes.string,
+
+    /**
+     * The CSS class names.
+     */
     className: PropTypes.string,
+
+    /**
+     * The function returning a translatable text showing where the current page is,
+     * in a manner of the range of items.
+     */
     itemRangeText: PropTypes.func,
+
+    /**
+     * The description for the forward icon.
+     */
     forwardText: PropTypes.string,
+
+    /**
+     * The unique ID of this component instance.
+     */
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * The translatable text indicating the number of items per page.
+     */
     itemsPerPageText: PropTypes.string,
+
+    /**
+     * A variant of `itemRangeText`, used if the total number of items is unknown.
+     */
     itemText: PropTypes.func,
+
+    /**
+     * The callback function called when the current page changes.
+     */
     onChange: PropTypes.func,
+
+    /**
+     * The label to be read by screen readers on input box showing the current page number
+     */
     pageNumberText: PropTypes.string,
+
+    /**
+     * A function returning PII showing where the current page is.
+     */
     pageRangeText: PropTypes.func,
+
+    /**
+     * The translatable text showing the current page.
+     */
     pageText: PropTypes.func,
+
+    /**
+     * The choices for `pageSize`.
+     */
     pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+
+    /**
+     * The total number of items.
+     */
     totalItems: PropTypes.number,
+
+    /**
+     * `true` if the backward/forward buttons should be disabled.
+     */
     disabled: PropTypes.bool,
+
+    /**
+     * The current page.
+     */
     page: PropTypes.number,
+
+    /**
+     * The number dictating how many items a page contains.
+     */
     pageSize: PropTypes.number,
+
+    /**
+     * `true` if the total number of items is unknown.
+     */
     pagesUnknown: PropTypes.bool,
+
+    /**
+     * `true` if the current page should be the last page.
+     */
     isLastPage: PropTypes.bool,
+
+    /**
+     * `true` if the select box to change the page should be disabled.
+     */
     pageInputDisabled: PropTypes.bool,
+
+    /**
+     * The duration of debouncing `onChange` event.
+     */
     onChangeInterval: PropTypes.number,
+
+    /**
+     * A function returning PII showing how many pages there are.
+     */
     defaultPageText: PropTypes.func,
+
+    /**
+     * A function returning PII showing how many items there are.
+     */
     defaultItemText: PropTypes.func,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -56,6 +149,7 @@ export default class Pagination extends Component {
     defaultPageText: totalPages => `${totalPages} pages`,
     defaultItemText: totalItems => `${totalItems} items`,
     onChangeInterval: 250,
+    prefix: 'bx',
   };
 
   constructor(props) {
@@ -204,20 +298,21 @@ export default class Pagination extends Component {
       onChange, // eslint-disable-line no-unused-vars
       onChangeInterval, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
+      prefix,
       ...other
     } = this.props;
 
     const statePage = this.state.page;
     const statePageSize = this.state.pageSize;
     const totalPages = Math.max(Math.ceil(totalItems / statePageSize), 1);
-    const classNames = classnames('bx--pagination', className);
+    const classNames = classnames(`${prefix}--pagination`, className);
     const inputId = id || this.uniqueId;
 
     return (
       <div className={classNames} {...other}>
-        <div className="bx--pagination__left">
+        <div className={`${prefix}--pagination__left`}>
           <Select
-            id={`bx-pagination-select-${inputId}`}
+            id={`${prefix}-pagination-select-${inputId}`}
             labelText={itemsPerPageText}
             hideLabel
             onChange={this.handleSizeChange}
@@ -226,26 +321,32 @@ export default class Pagination extends Component {
               <SelectItem key={size} value={size} text={String(size)} />
             ))}
           </Select>
-          <span className="bx--pagination__text">{itemsPerPageText}</span>
-          <span className="bx--pagination__text">{this.getItemsText()}</span>
+          <span className={`${prefix}--pagination__text`}>
+            {itemsPerPageText}
+          </span>
+          <span className={`${prefix}--pagination__text`}>
+            {this.getItemsText()}
+          </span>
         </div>
-        <div className="bx--pagination__right">
-          <span className="bx--pagination__text">{this.getPagesText()}</span>
+        <div className={`${prefix}--pagination__right`}>
+          <span className={`${prefix}--pagination__text`}>
+            {this.getPagesText()}
+          </span>
           <button
-            className="bx--pagination__button bx--pagination__button--backward"
+            className={`${prefix}--pagination__button ${prefix}--pagination__button--backward`}
             onClick={this.decrementPage}
             disabled={this.props.disabled || statePage === 1}>
             <Icon
-              className="bx--pagination__button-icon"
+              className={`${prefix}--pagination__button-icon`}
               icon={iconChevronLeft}
               description={backwardText}
             />
           </button>
           {pageInputDisabled ? (
-            <span className="bx--pagination__text">|</span>
+            <span className={`${prefix}--pagination__text`}>|</span>
           ) : (
             <TextInput
-              id={`bx-pagination-input-${inputId}`}
+              id={`${prefix}-pagination-input-${inputId}`}
               value={statePage > 0 ? statePage : ''}
               onChange={this.handlePageInputChange}
               labelText={pageNumberText}
@@ -253,13 +354,13 @@ export default class Pagination extends Component {
             />
           )}
           <button
-            className="bx--pagination__button bx--pagination__button--forward"
+            className={`${prefix}--pagination__button ${prefix}--pagination__button--forward`}
             onClick={this.incrementPage}
             disabled={
               this.props.disabled || statePage === totalPages || isLastPage
             }>
             <Icon
-              className="bx--pagination__button-icon"
+              className={`${prefix}--pagination__button-icon`}
               icon={iconChevronRight}
               description={forwardText}
             />

--- a/src/components/PaginationV2/Pagination.Skeleton.js
+++ b/src/components/PaginationV2/Pagination.Skeleton.js
@@ -1,16 +1,30 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SkeletonText from '../SkeletonText';
 
 export default class PaginationSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
+    const { prefix } = this.props;
     return (
-      <div className="bx--pagination bx--skeleton">
-        <div className="bx--pagination__left">
+      <div className={`${prefix}--pagination ${prefix}--skeleton`}>
+        <div className={`${prefix}--pagination__left`}>
           <SkeletonText width="70px" />
           <SkeletonText width="35px" />
           <SkeletonText width="105px" />
         </div>
-        <div className="bx--pagination__right bx--pagination--inline">
+        <div
+          className={`${prefix}--pagination__right ${prefix}--pagination--inline`}>
           <SkeletonText width="70px" />
         </div>
       </div>

--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -122,6 +122,11 @@ export default class PaginationV2 extends Component {
      * `true` if the select box to change the page should be disabled.
      */
     pageInputDisabled: PropTypes.bool,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -138,6 +143,7 @@ export default class PaginationV2 extends Component {
     pageInputDisabled: false,
     itemText: (min, max) => `${min}-${max} items`,
     pageText: page => `page ${page}`,
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ pageSizes, page, pageSize }, state) {
@@ -231,17 +237,18 @@ export default class PaginationV2 extends Component {
       totalItems,
       onChange, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
+      prefix,
       ...other
     } = this.props;
 
     const statePage = this.state.page;
     const statePageSize = this.state.pageSize;
-    const classNames = classnames('bx--pagination', className);
+    const classNames = classnames(`${prefix}--pagination`, className);
     const backButtonClasses = classnames(
-      'bx--pagination__button',
-      'bx--pagination__button--backward',
+      `${prefix}--pagination__button`,
+      `${prefix}--pagination__button--backward`,
       {
-        'bx--pagination__button--no-index': pageInputDisabled,
+        [`${prefix}--pagination__button--no-index`]: pageInputDisabled,
       }
     );
     const inputId = id || this.uniqueId;
@@ -250,13 +257,13 @@ export default class PaginationV2 extends Component {
 
     return (
       <div className={classNames} {...other}>
-        <div className="bx--pagination__left">
-          <span className="bx--pagination__text">
+        <div className={`${prefix}--pagination__left`}>
+          <span className={`${prefix}--pagination__text`}>
             {itemsPerPageFollowsText || itemsPerPageText}
           </span>
 
           <Select
-            id={`bx-pagination-select-${inputId}`}
+            id={`${prefix}-pagination-select-${inputId}`}
             labelText={itemsPerPageText}
             hideLabel
             inline
@@ -266,7 +273,7 @@ export default class PaginationV2 extends Component {
               <SelectItem key={size} value={size} text={String(size)} />
             ))}
           </Select>
-          <span className="bx--pagination__text">
+          <span className={`${prefix}--pagination__text`}>
             &nbsp;|&nbsp;&nbsp;
             {pagesUnknown
               ? itemText(
@@ -280,8 +287,9 @@ export default class PaginationV2 extends Component {
                 )}
           </span>
         </div>
-        <div className="bx--pagination__right bx--pagination--inline">
-          <span className="bx--pagination__text">
+        <div
+          className={`${prefix}--pagination__right ${prefix}--pagination--inline`}>
+          <span className={`${prefix}--pagination__text`}>
             {pagesUnknown
               ? pageText(statePage)
               : pageRangeText(statePage, totalPages)}
@@ -291,14 +299,14 @@ export default class PaginationV2 extends Component {
             onClick={this.decrementPage}
             disabled={this.props.disabled || statePage === 1}>
             <Icon
-              className="bx--pagination__button-icon"
+              className={`${prefix}--pagination__button-icon`}
               icon={iconChevronLeft}
               description={backwardText}
             />
           </button>
           {pageInputDisabled ? null : (
             <Select
-              id={`bx-pagination-select-${inputId + 2}`}
+              id={`${prefix}-pagination-select-${inputId + 2}`}
               labelText={itemsPerPageText}
               hideLabel
               inline
@@ -308,13 +316,13 @@ export default class PaginationV2 extends Component {
             </Select>
           )}
           <button
-            className="bx--pagination__button bx--pagination__button--forward"
+            className={`${prefix}--pagination__button ${prefix}--pagination__button--forward`}
             onClick={this.incrementPage}
             disabled={
               this.props.disabled || statePage === totalPages || isLastPage
             }>
             <Icon
-              className="bx--pagination__button-icon"
+              className={`${prefix}--pagination__button-icon`}
               icon={iconChevronRight}
               description={forwardText}
             />

--- a/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -1,21 +1,35 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class ProgressIndicatorSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
+    const { prefix } = this.props;
     const step = (
-      <li className="bx--progress-step bx--progress-step--incomplete">
+      <li
+        className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
         <svg>
           <g>
             <circle cx="12" cy="12" r="12" />
           </g>
         </svg>
-        <p className="bx--progress-label" />
-        <span className="bx--progress-line" />
+        <p className={`${prefix}--progress-label`} />
+        <span className={`${prefix}--progress-line`} />
       </li>
     );
 
     return (
-      <ul className="bx--progress bx--skeleton">
+      <ul className={`${prefix}--progress ${prefix}--skeleton`}>
         {step}
         {step}
         {step}

--- a/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.js
@@ -3,13 +3,13 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 
 export const ProgressStep = ({ ...props }) => {
-  const { label, description, className, current, complete } = props;
+  const { label, description, className, current, complete, prefix } = props;
 
   const classes = classnames({
-    'bx--progress-step': true,
-    'bx--progress-step--current': current,
-    'bx--progress-step--complete': complete,
-    'bx--progress-step--incomplete': !complete && !current,
+    [`${prefix}--progress-step`]: true,
+    [`${prefix}--progress-step--current`]: current,
+    [`${prefix}--progress-step--complete`]: complete,
+    [`${prefix}--progress-step--incomplete`]: !complete && !current,
     [className]: className,
   });
 
@@ -41,8 +41,8 @@ export const ProgressStep = ({ ...props }) => {
   return (
     <li className={classes}>
       {currentSvg || completeSvg || incompleteSvg}
-      <p className="bx--progress-label">{label}</p>
-      <span className="bx--progress-line" />
+      <p className={`${prefix}--progress-label`}>{label}</p>
+      <span className={`${prefix}--progress-line`} />
     </li>
   );
 };
@@ -72,6 +72,15 @@ ProgressStep.propTypes = {
    * Provide a description for the <ProgressStep>
    */
   description: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+ProgressStep.defaultProps = {
+  prefix: 'bx',
 };
 
 export class ProgressIndicator extends Component {
@@ -93,10 +102,16 @@ export class ProgressIndicator extends Component {
      * Optionally specify the current step array index
      */
     currentIndex: PropTypes.number,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     currentIndex: 0,
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ currentIndex }, state) {
@@ -128,9 +143,9 @@ export class ProgressIndicator extends Component {
     });
 
   render() {
-    const { className, currentIndex, ...other } = this.props; // eslint-disable-line no-unused-vars
+    const { className, currentIndex, prefix, ...other } = this.props; // eslint-disable-line no-unused-vars
     const classes = classnames({
-      'bx--progress': true,
+      [`${prefix}--progress`]: true,
       [className]: className,
     });
     return (

--- a/src/components/RadioButton/RadioButton.Skeleton.js
+++ b/src/components/RadioButton/RadioButton.Skeleton.js
@@ -1,15 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class RadioButtonSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
-    const { id } = this.props;
+    const { id, prefix } = this.props;
     return (
       <div className="radioButtonWrapper">
-        <div className="bx--radio-button bx--skeleton" />
+        <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
         {
           /* eslint-disable jsx-a11y/label-has-for */
           <label
-            className="bx--radio-button__label bx--skeleton"
+            className={`${prefix}--radio-button__label ${prefix}--skeleton`}
             htmlFor={id}
           />
         }

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -51,9 +51,15 @@ export default class RadioButton extends React.Component {
      * Specify the value of the <RadioButton>
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
+    prefix: 'bx',
     onChange: () => {},
   };
 
@@ -71,19 +77,19 @@ export default class RadioButton extends React.Component {
       this.props.className
     );
 
-    const { labelText, ...other } = this.props;
+    const { labelText, prefix, ...other } = this.props;
 
     return (
       <div className={wrapperClasses}>
         <input
           {...other}
           type="radio"
-          className="bx--radio-button"
+          className={`${prefix}--radio-button`}
           onChange={this.handleChange}
           id={this.uid}
         />
-        <label htmlFor={this.uid} className="bx--radio-button__label">
-          <span className="bx--radio-button__appearance" />
+        <label htmlFor={this.uid} className={`${prefix}--radio-button__label`}>
+          <span className={`${prefix}--radio-button__appearance`} />
           {labelText}
         </label>
       </div>

--- a/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -42,11 +42,16 @@ export default class RadioButtonGroup extends React.Component {
      * Specify the value that is currently selected in the group
      */
     valueSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     onChange: /* istanbul ignore next */ () => {},
-    className: 'bx--radio-button-group',
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ valueSelected, defaultSelected }, state) {
@@ -94,10 +99,14 @@ export default class RadioButtonGroup extends React.Component {
   };
 
   render() {
-    const { disabled, className } = this.props;
+    const {
+      disabled,
+      prefix,
+      className = `${prefix}--radio-button-group`,
+    } = this.props;
 
     return (
-      <div className="bx--form-item">
+      <div className={`${prefix}--form-item`}>
         <div className={className} disabled={disabled}>
           {this.getRadioButtons()}
         </div>

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -46,10 +46,16 @@ export default class RadioTile extends React.Component {
      * The `value` of the `<input>`.
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     iconDescription: 'Tile checkmark',
+    prefix: 'bx',
     onChange: () => {},
   };
 
@@ -62,26 +68,37 @@ export default class RadioTile extends React.Component {
   };
 
   render() {
-    const { children, className, iconDescription, ...other } = this.props;
+    const {
+      children,
+      className,
+      iconDescription,
+      prefix,
+      ...other
+    } = this.props;
 
-    const classes = classNames(className, 'bx--tile', 'bx--tile--selectable', {
-      'bx--tile--is-selected': this.props.checked,
-    });
+    const classes = classNames(
+      className,
+      `${prefix}--tile`,
+      `${prefix}--tile--selectable`,
+      {
+        [`${prefix}--tile--is-selected`]: this.props.checked,
+      }
+    );
 
     return (
       <label htmlFor={this.uid} className={classes}>
         <input
           {...other}
           type="radio"
-          className="bx--tile-input"
+          className={`${prefix}--tile-input`}
           onChange={this.handleChange}
           id={this.uid}
         />
 
-        <div className="bx--tile__checkmark">
+        <div className={`${prefix}--tile__checkmark`}>
           <Icon icon={iconCheckmarkSolid} description={iconDescription} />
         </div>
-        <div className="bx--tile-content">{children}</div>
+        <div className={`${prefix}--tile-content`}>{children}</div>
       </label>
     );
   }

--- a/src/components/Search/Search.Skeleton.js
+++ b/src/components/Search/Search.Skeleton.js
@@ -4,29 +4,38 @@ import classNames from 'classnames';
 
 export default class SearchSkeleton extends Component {
   static propTypes = {
+    /**
+     * Specify whether the Search should be a small variant
+     */
     small: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     small: false,
+    prefix: 'bx',
   };
 
   render() {
-    const { small, id } = this.props;
+    const { small, id, prefix } = this.props;
 
     const searchClasses = classNames({
-      'bx--skeleton': true,
-      'bx--search--lg': !small,
-      'bx--search--sm': small,
+      [`${prefix}--skeleton`]: true,
+      [`${prefix}--search--lg`]: !small,
+      [`${prefix}--search--sm`]: small,
     });
 
     return (
       <div className={searchClasses} role="search">
         {
           /* eslint-disable jsx-a11y/label-has-for */
-          <label htmlFor={id} className="bx--label" />
+          <label htmlFor={id} className={`${prefix}--label`} />
         }
-        <div className="bx--search-input" />
+        <div className={`${prefix}--search-input`} />
       </div>
     );
   }

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -6,17 +6,50 @@ import Icon from '../Icon';
 
 export default class Search extends Component {
   static propTypes = {
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Optional prop to specify the type of the `<input>`
+     */
     type: PropTypes.string,
+
+    /**
+     * Specify whether the Search should be a small variant
+     */
     small: PropTypes.bool,
+
+    /**
+     * Provide an optional placeholder text for the Search
+     */
     placeHolderText: PropTypes.string,
+
+    /**
+     * Provide an optional label text for the Search icon
+     */
     labelText: PropTypes.node.isRequired,
+
+    /**
+     * Specify a custom `id` for the input
+     */
     id: PropTypes.string,
+
+    /**
+     * Specify a label to be read by screen readers on the "close" button
+     */
     closeButtonLabelText: PropTypes.string,
+
     /**
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -25,6 +58,7 @@ export default class Search extends Component {
     placeHolderText: '',
     onChange: () => {},
     light: false,
+    prefix: 'bx',
   };
 
   state = {
@@ -80,22 +114,23 @@ export default class Search extends Component {
       closeButtonLabelText,
       small,
       light,
+      prefix,
       ...other
     } = this.props;
 
     const { hasContent } = this.state;
 
     const searchClasses = classNames({
-      'bx--search': true,
-      'bx--search--lg': !small,
-      'bx--search--sm': small,
-      'bx--search--light': light,
+      [`${prefix}--search`]: true,
+      [`${prefix}--search--lg`]: !small,
+      [`${prefix}--search--sm`]: small,
+      [`${prefix}--search--light`]: light,
       [className]: className,
     });
 
     const clearClasses = classNames({
-      'bx--search-close': true,
-      'bx--search-close--hidden': !hasContent,
+      [`${prefix}--search-close`]: true,
+      [`${prefix}--search-close--hidden`]: !hasContent,
     });
 
     return (
@@ -106,15 +141,15 @@ export default class Search extends Component {
         <Icon
           icon={iconSearch}
           description={labelText}
-          className="bx--search-magnifier"
+          className={`${prefix}--search-magnifier`}
         />
-        <label id={`${id}-label`} htmlFor={id} className="bx--label">
+        <label id={`${id}-label`} htmlFor={id} className={`${prefix}--label`}>
           {labelText}
         </label>
         <input
           {...other}
           type={type}
-          className="bx--search-input"
+          className={`${prefix}--search-input`}
           id={id}
           placeholder={placeHolderText}
           onChange={this.handleChange}

--- a/src/components/SearchFilterButton/SearchFilterButton.js
+++ b/src/components/SearchFilterButton/SearchFilterButton.js
@@ -6,16 +6,21 @@ import Icon from '../Icon';
 /**
  * The filter button for `<Search>`.
  */
-const SearchFilterButton = ({ labelText, iconDescription, ...other }) => (
+const SearchFilterButton = ({
+  labelText,
+  iconDescription,
+  prefix,
+  ...other
+}) => (
   <button
-    className="bx--search-button"
+    className={`${prefix}--search-button`}
     type="button"
     aria-label={labelText}
     {...other}>
     <Icon
       icon={iconFilter}
       description={iconDescription}
-      className="bx--search-filter"
+      className={`${prefix}--search-filter`}
     />
   </button>
 );
@@ -30,11 +35,17 @@ SearchFilterButton.propTypes = {
    * The icon description.
    */
   iconDescription: PropTypes.string,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 SearchFilterButton.defaultProps = {
   labelText: 'Search',
   iconDescription: 'filter',
+  prefix: 'bx',
 };
 
 export default SearchFilterButton;

--- a/src/components/SearchLayoutButton/SearchLayoutButton.js
+++ b/src/components/SearchLayoutButton/SearchLayoutButton.js
@@ -31,6 +31,11 @@ class SearchLayoutButton extends Component {
     iconDescriptionGrid: PropTypes.string,
 
     /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+
+    /**
      * The callback called when layout switches.
      */
     onChangeFormat: PropTypes.func,
@@ -40,6 +45,7 @@ class SearchLayoutButton extends Component {
     labelText: 'Filter',
     iconDescriptionList: 'list',
     iconDescriptionGrid: 'grid',
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ format }, state) {
@@ -67,27 +73,32 @@ class SearchLayoutButton extends Component {
   };
 
   render() {
-    const { labelText, iconDescriptionList, iconDescriptionGrid } = this.props;
+    const {
+      labelText,
+      iconDescriptionList,
+      iconDescriptionGrid,
+      prefix,
+    } = this.props;
     return (
       <button
-        className="bx--search-button"
+        className={`${prefix}--search-button`}
         type="button"
         onClick={this.toggleLayout}
         aria-label={labelText}>
         {this.state.format === 'list' ? (
-          <div className="bx--search__toggle-layout__container">
+          <div className={`${prefix}--search__toggle-layout__container`}>
             <Icon
               icon={iconList}
               description={iconDescriptionList}
-              className="bx--search-view"
+              className={`${prefix}--search-view`}
             />
           </div>
         ) : (
-          <div className="bx--search__toggle-layout__container">
+          <div className={`${prefix}--search__toggle-layout__container`}>
             <Icon
               icon={iconGrid}
               description={iconDescriptionGrid}
-              className="bx--search-view"
+              className={`${prefix}--search-view`}
             />
           </div>
         )}

--- a/src/components/Select/Select.Skeleton.js
+++ b/src/components/Select/Select.Skeleton.js
@@ -1,24 +1,36 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SelectSkeleton = ({ hideLabel, id }) => {
+const SelectSkeleton = ({ hideLabel, id, prefix }) => {
   const label = hideLabel ? null : (
     // eslint-disable-next-line jsx-a11y/label-has-for
-    <label className="bx--label bx--skeleton" htmlFor={id} />
+    <label className={`${prefix}--label ${prefix}--skeleton`} htmlFor={id} />
   );
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
-      <div className="bx--select bx--skeleton">
-        <select className="bx--select-input" />
+      <div className={`${prefix}--select ${prefix}--skeleton`}>
+        <select className={`${prefix}--select-input`} />
       </div>
     </div>
   );
 };
 
 SelectSkeleton.propTypes = {
+  /**
+   * Specify whether the label should be hidden, or not
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+SelectSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default SelectSkeleton;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -17,32 +17,33 @@ const Select = ({
   invalidText,
   helperText,
   light,
+  prefix,
   ...other
 }) => {
   const selectClasses = classNames({
-    'bx--select': true,
-    'bx--select--inline': inline,
-    'bx--select--light': light,
+    [`${prefix}--select`]: true,
+    [`${prefix}--select--inline`]: inline,
+    [`${prefix}--select--light`]: light,
     [className]: className,
   });
-  const labelClasses = classNames('bx--label', {
-    'bx--visually-hidden': hideLabel,
+  const labelClasses = classNames(`${prefix}--label`, {
+    [`${prefix}--visually-hidden`]: hideLabel,
   });
   const errorId = `${id}-error-msg`;
   const error = invalid ? (
-    <div className="bx--form-requirement" id={errorId}>
+    <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
     </div>
   ) : null;
   const helper = helperText ? (
-    <div className="bx--form__helper-text">{helperText}</div>
+    <div className={`${prefix}--form__helper-text`}>{helperText}</div>
   ) : null;
   const ariaProps = {};
   if (invalid) {
     ariaProps['aria-describedby'] = errorId;
   }
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       <div className={selectClasses}>
         <label htmlFor={id} className={labelClasses}>
           {labelText}
@@ -51,7 +52,7 @@ const Select = ({
           {...other}
           {...ariaProps}
           id={id}
-          className="bx--select-input"
+          className={`${prefix}--select-input`}
           disabled={disabled || undefined}
           data-invalid={invalid || undefined}
           aria-invalid={invalid || undefined}>
@@ -59,7 +60,7 @@ const Select = ({
         </select>
         <Icon
           icon={iconCaretDown}
-          className="bx--select__arrow"
+          className={`${prefix}--select__arrow`}
           description={iconDescription}
         />
         {helper}
@@ -70,20 +71,82 @@ const Select = ({
 };
 
 Select.propTypes = {
+  /**
+   * Provide the contents of your Select
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to the node containing the label and the select box
+   */
   className: PropTypes.string,
+
+  /**
+   * Specify a custom `id` for the `<select>`
+   */
   id: PropTypes.string.isRequired,
+
+  /**
+   * Specify whether you want the inline version of this control
+   */
   inline: PropTypes.bool,
+
+  /**
+   * Provide label text to be read by screen readers when interacting with the
+   * control
+   */
   labelText: PropTypes.node,
+
+  /**
+   * Provide an optional `onChange` hook that is called each time the value of
+   * the underlying <input> changes
+   */
   onChange: PropTypes.func,
+
+  /**
+   * Specify whether the control is disabled
+   */
   disabled: PropTypes.bool,
+
+  /**
+   * Optionally provide the default value of the `<select>`
+   */
   defaultValue: PropTypes.any,
+
+  /**
+   * Provide a description for the twistie icon that can be read by screen readers
+   */
   iconDescription: PropTypes.string.isRequired,
+
+  /**
+   * Specify whether the label should be hidden, or not
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify if the currently value is invalid.
+   */
   invalid: PropTypes.bool,
+
+  /**
+   * Message which is displayed if the value is invalid.
+   */
   invalidText: PropTypes.string,
+
+  /**
+   * Provide text that is used alongside the control label for additional help
+   */
   helperText: PropTypes.node,
+
+  /**
+   * Specify whether you want the light version of this control
+   */
   light: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 Select.defaultProps = {
@@ -95,6 +158,7 @@ Select.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  prefix: 'bx',
 };
 
 export default Select;

--- a/src/components/SelectItem/SelectItem.js
+++ b/src/components/SelectItem/SelectItem.js
@@ -2,9 +2,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const SelectItem = ({ className, value, disabled, hidden, text, ...other }) => {
+const SelectItem = ({
+  className,
+  value,
+  disabled,
+  hidden,
+  text,
+  prefix,
+  ...other
+}) => {
   const selectItemClasses = classNames({
-    'bx--select-option': true,
+    [`${prefix}--select-option`]: true,
     [className]: className,
   });
 
@@ -21,11 +29,35 @@ const SelectItem = ({ className, value, disabled, hidden, text, ...other }) => {
 };
 
 SelectItem.propTypes = {
+  /**
+   * Specify the value of the <SelectItem>
+   */
   value: PropTypes.any.isRequired,
+
+  /**
+   * Specify an optional className to be applied to the node
+   */
   className: PropTypes.string,
+
+  /**
+   * Specify whether the <SelectItem> should be disabled
+   */
   disabled: PropTypes.bool,
+
+  /**
+   * Specify whether the <SelectItem> is hidden
+   */
   hidden: PropTypes.bool,
+
+  /**
+   * Provide the contents of your <SelectItem>
+   */
   text: PropTypes.string.isRequired,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 SelectItem.defaultProps = {
@@ -33,6 +65,7 @@ SelectItem.defaultProps = {
   hidden: false,
   value: '',
   text: '',
+  prefix: 'bx',
 };
 
 export default SelectItem;

--- a/src/components/SelectItemGroup/SelectItemGroup.js
+++ b/src/components/SelectItemGroup/SelectItemGroup.js
@@ -7,9 +7,10 @@ const SelectItemGroup = ({
   className,
   disabled,
   label,
+  prefix,
   ...other
 }) => {
-  const classNames = classnames('bx--select-optgroup', className);
+  const classNames = classnames(`${prefix}--select-optgroup`, className);
   return (
     <optgroup
       className={classNames}
@@ -22,15 +23,36 @@ const SelectItemGroup = ({
 };
 
 SelectItemGroup.propTypes = {
+  /**
+   * Provide the contents of your <SelectItemGroup>
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to the node
+   */
   className: PropTypes.string,
+
+  /**
+   * Specify whether the <SelectItemGroup> should be disabled
+   */
   disabled: PropTypes.bool,
+
+  /**
+   * Specify the label to be displayed
+   */
   label: PropTypes.string.isRequired,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 SelectItemGroup.defaultProps = {
   disabled: false,
   label: 'Provide label',
+  prefix: 'bx',
 };
 
 export default SelectItemGroup;

--- a/src/components/SkeletonText/SkeletonText.js
+++ b/src/components/SkeletonText/SkeletonText.js
@@ -8,11 +8,12 @@ const SkeletonText = ({
   width,
   heading,
   className,
+  prefix,
   ...other
 }) => {
   const skeletonTextClasses = classNames({
-    'bx--skeleton__text': true,
-    'bx--skeleton__heading': heading,
+    [`${prefix}--skeleton__text`]: true,
+    [`${prefix}--skeleton__heading`]: heading,
     [className]: className,
   });
 
@@ -79,7 +80,14 @@ SkeletonText.propTypes = {
    * generates skeleton text at a larger size
    */
   heading: PropTypes.bool,
+  /**
+   * Specify an optional className to be applied to the container node
+   */
   className: PropTypes.string,
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 SkeletonText.defaultProps = {
@@ -87,6 +95,7 @@ SkeletonText.defaultProps = {
   width: '100%',
   heading: false,
   lineCount: 3,
+  prefix: 'bx',
 };
 
 export default SkeletonText;

--- a/src/components/Slider/Slider.Skeleton.js
+++ b/src/components/Slider/Slider.Skeleton.js
@@ -1,30 +1,42 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SliderSkeleton = ({ hideLabel, id }) => {
+const SliderSkeleton = ({ hideLabel, id, prefix }) => {
   const label = hideLabel ? null : (
     // eslint-disable-next-line jsx-a11y/label-has-for
-    <label className="bx--label bx--skeleton" htmlFor={id} />
+    <label className={`${prefix}--label ${prefix}--skeleton`} htmlFor={id} />
   );
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
-      <div className="bx--slider-container bx--skeleton">
-        <span className="bx--slider__range-label" />
-        <div className="bx--slider">
-          <div className="bx--slider__track" />
-          <div className="bx--slider__filled-track" />
-          <div className="bx--slider__thumb" />
+      <div className={`${prefix}--slider-container ${prefix}--skeleton`}>
+        <span className={`${prefix}--slider__range-label`} />
+        <div className={`${prefix}--slider`}>
+          <div className={`${prefix}--slider__track`} />
+          <div className={`${prefix}--slider__filled-track`} />
+          <div className={`${prefix}--slider__thumb`} />
         </div>
-        <span className="bx--slider__range-label" />
+        <span className={`${prefix}--slider__range-label`} />
       </div>
     </div>
   );
 };
 
 SliderSkeleton.propTypes = {
+  /**
+   * Specify whether the label should be hidden, or not
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+SliderSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default SliderSkeleton;

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -105,6 +105,11 @@ export default class Slider extends PureComponent {
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -117,6 +122,7 @@ export default class Slider extends PureComponent {
     inputType: 'number',
     ariaLabelInput: 'Slider number input',
     light: false,
+    prefix: 'bx',
   };
 
   state = {
@@ -317,19 +323,20 @@ export default class Slider extends PureComponent {
       disabled,
       name,
       light,
+      prefix,
       ...other
     } = this.props;
 
     const { value, left } = this.state;
 
     const sliderClasses = classNames(
-      'bx--slider',
-      { 'bx--slider--disabled': disabled },
+      `${prefix}--slider`,
+      { [`${prefix}--slider--disabled`]: disabled },
       className
     );
 
-    const inputClasses = classNames('bx-slider-text-input', {
-      'bx--text-input--light': light,
+    const inputClasses = classNames(`${prefix}-slider-text-input`, {
+      [`${prefix}--text-input--light`]: light,
     });
 
     const filledTrackStyle = {
@@ -340,12 +347,12 @@ export default class Slider extends PureComponent {
     };
 
     return (
-      <div className="bx--form-item">
-        <label htmlFor={id} className="bx--label">
+      <div className={`${prefix}--form-item`}>
+        <label htmlFor={id} className={`${prefix}--label`}>
           {labelText}
         </label>
-        <div className="bx--slider-container">
-          <span className="bx--slider__range-label">
+        <div className={`${prefix}--slider-container`}>
+          <span className={`${prefix}--slider__range-label`}>
             {formatLabel(min, minLabel)}
           </span>
           <div
@@ -359,17 +366,17 @@ export default class Slider extends PureComponent {
             tabIndex={-1}
             {...other}>
             <div
-              className="bx--slider__track"
+              className={`${prefix}--slider__track`}
               ref={node => {
                 this.track = node;
               }}
             />
             <div
-              className="bx--slider__filled-track"
+              className={`${prefix}--slider__filled-track`}
               style={filledTrackStyle}
             />
             <div
-              className="bx--slider__thumb"
+              className={`${prefix}--slider__thumb`}
               role="slider"
               id={id}
               tabIndex={0}
@@ -392,7 +399,7 @@ export default class Slider extends PureComponent {
               onChange={this.handleChange}
             />
           </div>
-          <span className="bx--slider__range-label">
+          <span className={`${prefix}--slider__range-label`}>
             {formatLabel(max, maxLabel)}
           </span>
           {!hideTextInput && (

--- a/src/components/StructuredList/StructuredList.Skeleton.js
+++ b/src/components/StructuredList/StructuredList.Skeleton.js
@@ -2,40 +2,41 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const StructuredListSkeleton = ({ rowCount, border }) => {
+const StructuredListSkeleton = ({ rowCount, border, prefix }) => {
   const StructuredListSkeletonClasses = classNames({
-    'bx--skeleton': true,
-    'bx--structured-list': true,
-    'bx--structured-list--border': border,
+    [`${prefix}--skeleton`]: true,
+    [`${prefix}--structured-list`]: true,
+    [`${prefix}--structured-list--border`]: border,
   });
 
   const rows = [];
   for (var i = 0; i < rowCount; i++) {
     rows.push(
-      <div className="bx--structured-list-row" key={i}>
-        <div className="bx--structured-list-td" />
-        <div className="bx--structured-list-td" />
-        <div className="bx--structured-list-td" />
+      <div className={`${prefix}--structured-list-row`} key={i}>
+        <div className={`${prefix}--structured-list-td`} />
+        <div className={`${prefix}--structured-list-td`} />
+        <div className={`${prefix}--structured-list-td`} />
       </div>
     );
   }
 
   return (
     <section className={StructuredListSkeletonClasses}>
-      <div className="bx--structured-list-thead">
-        <div className="bx--structured-list-row bx--structured-list-row--header-row">
-          <div className="bx--structured-list-th">
+      <div className={`${prefix}--structured-list-thead`}>
+        <div
+          className={`${prefix}--structured-list-row ${prefix}--structured-list-row--header-row`}>
+          <div className={`${prefix}--structured-list-th`}>
             <span />
           </div>
-          <div className="bx--structured-list-th">
+          <div className={`${prefix}--structured-list-th`}>
             <span />
           </div>
-          <div className="bx--structured-list-th">
+          <div className={`${prefix}--structured-list-th`}>
             <span />
           </div>
         </div>
       </div>
-      <div className="bx--structured-list-tbody">{rows}</div>
+      <div className={`${prefix}--structured-list-tbody`}>{rows}</div>
     </section>
   );
 };
@@ -45,12 +46,22 @@ StructuredListSkeleton.propTypes = {
    * number of table rows
    */
   rowCount: PropTypes.number,
+
+  /**
+   * Specify whether a border should be added to your StructuredListSkeleton
+   */
   border: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 StructuredListSkeleton.defaultProps = {
   rowCount: 5,
   border: false,
+  prefix: 'bx',
 };
 
 export default StructuredListSkeleton;

--- a/src/components/StructuredList/StructuredList.js
+++ b/src/components/StructuredList/StructuredList.js
@@ -5,17 +5,42 @@ import uid from '../../tools/uniqueId';
 
 export class StructuredListWrapper extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your StructuredListWrapper
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify whether a border should be added to your StructuredListWrapper
+     */
     border: PropTypes.bool,
+
+    /**
+     * Specify whether your StructuredListWrapper should have selections
+     */
     selection: PropTypes.bool,
+
+    /**
+     * Specify a label to be read by screen readers on the container node
+     */
     ariaLabel: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     border: false,
     selection: false,
     ariaLabel: 'Structured list section',
+    prefix: 'bx',
   };
 
   render() {
@@ -25,12 +50,13 @@ export class StructuredListWrapper extends Component {
       className,
       border,
       ariaLabel,
+      prefix,
       ...other
     } = this.props;
 
-    const classes = classNames('bx--structured-list', className, {
-      'bx--structured-list--border': border,
-      'bx--structured-list--selection': selection,
+    const classes = classNames(`${prefix}--structured-list`, className, {
+      [`${prefix}--structured-list--border`]: border,
+      [`${prefix}--structured-list--selection`]: selection,
     });
 
     return (
@@ -43,14 +69,25 @@ export class StructuredListWrapper extends Component {
 
 export class StructuredListHead extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your StructuredListHead
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the node
+     */
     className: PropTypes.string,
   };
 
-  render() {
-    const { children, className, ...other } = this.props;
+  static defaultProps = {
+    prefix: 'bx',
+  };
 
-    const classes = classNames('bx--structured-list-thead', className);
+  render() {
+    const { children, className, prefix, ...other } = this.props;
+
+    const classes = classNames(`${prefix}--structured-list-thead`, className);
     return (
       <div className={classes} {...other}>
         {children}
@@ -61,12 +98,44 @@ export class StructuredListHead extends Component {
 
 export class StructuredListInput extends Component {
   static propTypes = {
+    /**
+     * Specify an optional className to be applied to the input
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify a custom `id` for the input
+     */
     id: PropTypes.string,
+
+    /**
+     * Specify the value of the input
+     */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /**
+     * Provide a `name` for the input
+     */
     name: PropTypes.string,
+
+    /**
+     * Provide a `title` for the input
+     */
     title: PropTypes.string,
+
+    /**
+     * Specify whether the underlying input should be checked by default
+     */
     defaultChecked: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+
+    /**
+     * Provide an optional hook that is called each time the input is updated
+     */
     onChange: PropTypes.func,
   };
 
@@ -74,6 +143,7 @@ export class StructuredListInput extends Component {
     onChange: () => {},
     value: 'value',
     title: 'title',
+    prefix: 'bx',
   };
 
   UNSAFE_componentWillMount() {
@@ -81,8 +151,8 @@ export class StructuredListInput extends Component {
   }
 
   render() {
-    const { className, value, name, title, ...other } = this.props;
-    const classes = classNames('bx--structured-list-input', className);
+    const { className, value, name, title, prefix, ...other } = this.props;
+    const classes = classNames(`${prefix}--structured-list-input`, className);
     return (
       <input
         {...other}
@@ -100,11 +170,40 @@ export class StructuredListInput extends Component {
 
 export class StructuredListRow extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your StructuredListRow
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify whether your StructuredListRow should be used as a header row
+     */
     head: PropTypes.bool,
+
+    /**
+     * Specify whether a `<label>` should be used
+     */
     label: PropTypes.bool,
+
+    /**
+     * Specify the tab index of the container node, if `<label>` is in use
+     */
     tabIndex: PropTypes.number,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+
+    /**
+     * Provide a handler that is invoked on the key down event for the control,
+     * if `<label>` is in use
+     */
     onKeyDown: PropTypes.func,
   };
 
@@ -112,6 +211,7 @@ export class StructuredListRow extends Component {
     head: false,
     label: false,
     tabIndex: 0,
+    prefix: 'bx',
     onKeyDown: () => {},
   };
 
@@ -123,11 +223,12 @@ export class StructuredListRow extends Component {
       className,
       head,
       label,
+      prefix,
       ...other
     } = this.props;
 
-    const classes = classNames('bx--structured-list-row', className, {
-      'bx--structured-list-row--header-row': head,
+    const classes = classNames(`${prefix}--structured-list-row`, className, {
+      [`${prefix}--structured-list-row--header-row`]: head,
     });
 
     return label ? (
@@ -149,13 +250,31 @@ export class StructuredListRow extends Component {
 
 export class StructuredListBody extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your StructuredListBody
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
     head: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
+
+    /**
+     * Provide a handler that is invoked on the key down event for the control
+     */
     onKeyDown: PropTypes.func,
   };
 
   static defaultProps = {
+    prefix: 'bx',
     onKeyDown: () => {},
   };
 
@@ -165,8 +284,8 @@ export class StructuredListBody extends Component {
   };
 
   render() {
-    const { children, className, ...other } = this.props;
-    const classes = classNames('bx--structured-list-tbody', className);
+    const { children, className, prefix, ...other } = this.props;
+    const classes = classNames(`${prefix}--structured-list-tbody`, className);
     return (
       <div className={classes} {...other}>
         {children}
@@ -177,24 +296,45 @@ export class StructuredListBody extends Component {
 
 export class StructuredListCell extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your StructuredListCell
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify whether your StructuredListCell should be used as a header cell
+     */
     head: PropTypes.bool,
+
+    /**
+     * Specify whether your StructuredListCell should have text wrapping
+     */
     noWrap: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     head: false,
     noWrap: false,
+    prefix: 'bx',
   };
 
   render() {
-    const { children, className, head, noWrap, ...other } = this.props;
+    const { children, className, head, noWrap, prefix, ...other } = this.props;
 
     const classes = classNames(className, {
-      'bx--structured-list-th': head,
-      'bx--structured-list-td': !head,
-      'bx--structured-list-content--nowrap': noWrap,
+      [`${prefix}--structured-list-th`]: head,
+      [`${prefix}--structured-list-td`]: !head,
+      [`${prefix}--structured-list-content--nowrap`]: noWrap,
     });
 
     return (

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -14,6 +14,7 @@ const Switch = props => {
     text,
     icon,
     href,
+    prefix,
     ...other
   } = props;
 
@@ -30,8 +31,8 @@ const Switch = props => {
     }
   };
 
-  const classes = classNames(className, 'bx--content-switcher-btn', {
-    'bx--content-switcher--selected': selected,
+  const classes = classNames(className, `${prefix}--content-switcher-btn`, {
+    [`${prefix}--content-switcher--selected`]: selected,
   });
 
   const commonProps = {
@@ -44,7 +45,7 @@ const Switch = props => {
     ? React.cloneElement(icon, {
         className: classNames(
           icon.props.className,
-          ' bx--content-switcher__icon'
+          ` ${prefix}--content-switcher__icon`
         ),
       })
     : null;
@@ -67,16 +68,64 @@ const Switch = props => {
 };
 
 Switch.propTypes = {
+  /**
+   * Specify an optional className to be added to your Switch
+   */
   className: PropTypes.string,
+
+  /**
+   * The index of your Switch in your ContentSwitcher that is used for event handlers.
+   * Reserved for usage in ContentSwitcher
+   */
   index: PropTypes.number,
+
+  /**
+   * Specify whether the <Switch> should be used as a <button> element or an <a> element
+   */
   kind: PropTypes.oneOf(['button', 'anchor']).isRequired,
+
+  /**
+   * Provide the name of your Switch that is used for event handlers
+   */
   name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * A handler that is invoked when a user clicks on the control.
+   * Reserved for usage in ContentSwitcher
+   */
   onClick: PropTypes.func,
+
+  /**
+   * A handler that is invoked on the key down event for the control.
+   * Reserved for usage in ContentSwitcher
+   */
   onKeyDown: PropTypes.func,
+
+  /**
+   * Whether your Switch is selected. Reserved for usage in ContentSwitcher
+   */
   selected: PropTypes.bool,
+
+  /**
+   * Provide the contents of your Switch
+   */
   text: PropTypes.string.isRequired,
+
+  /**
+   * Specify an icon to include in your Switch
+   */
   icon: PropTypes.element,
+
+  /**
+   * Optional string representing the link location for the Switch,
+   * if Switch is used as an <a> element
+   */
   href: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 Switch.defaultProps = {
@@ -84,6 +133,7 @@ Switch.defaultProps = {
   kind: 'anchor',
   text: 'Provide text',
   href: '',
+  prefix: 'bx',
   onClick: () => {},
   onKeyDown: () => {},
 };

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -4,24 +4,81 @@ import classNames from 'classnames';
 
 export default class Tab extends React.Component {
   static propTypes = {
+    /**
+     * Specify an optional className to be added to your Tab
+     */
     className: PropTypes.string,
+
+    /**
+     * A handler that is invoked when a user clicks on the control.
+     * Reserved for usage in Tabs
+     */
     handleTabClick: PropTypes.func,
+
+    /**
+     * A handler that is invoked when a user presses left/right key.
+     * Reserved for usage in Tabs
+     */
     handleTabAnchorFocus: PropTypes.func,
+
+    /**
+     * A handler that is invoked on the key down event for the control.
+     * Reserved for usage in Tabs
+     */
     handleTabKeyDown: PropTypes.func,
+
+    /**
+     * Provide a string that represents the `href` of the Tab
+     */
     href: PropTypes.string.isRequired,
+
+    /**
+     * The index of your Tab in your Tabs. Reserved for usage in Tabs
+     */
     index: PropTypes.number,
+
+    /**
+     * Provide the contents of your Tab
+     */
     label: PropTypes.string,
+
+    /**
+     * Provide an accessibility role for your Tab
+     */
     role: PropTypes.string.isRequired,
+
+    /**
+     * Provide a handler that is invoked when a user clicks on the control
+     */
     onClick: PropTypes.func.isRequired,
+
+    /**
+     * Provide a handler that is invoked on the key down event for the control
+     */
     onKeyDown: PropTypes.func.isRequired,
+
+    /**
+     * Whether your Tab is selected.
+     * Reserved for usage in Tabs
+     */
     selected: PropTypes.bool.isRequired,
+
+    /**
+     * Specify the tab index of the <a> node
+     */
     tabIndex: PropTypes.number.isRequired,
+
     /*
      * An optional parameter to allow overriding the anchor rendering.
      * Useful for using Tab along with react-router or other client
      * side router libraries.
      **/
     renderAnchor: PropTypes.func,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -30,6 +87,7 @@ export default class Tab extends React.Component {
     tabIndex: 0,
     href: '#',
     selected: false,
+    prefix: 'bx',
     onClick: () => {},
     onKeyDown: () => {},
   };
@@ -60,17 +118,18 @@ export default class Tab extends React.Component {
       onClick,
       onKeyDown,
       renderAnchor,
+      prefix,
       ...other
     } = this.props;
 
     const classes = classNames(
-      'bx--tabs__nav-item',
-      { 'bx--tabs__nav-item--selected': selected },
+      `${prefix}--tabs__nav-item`,
+      { [`${prefix}--tabs__nav-item--selected`]: selected },
       className
     );
 
     const anchorProps = {
-      className: 'bx--tabs__nav-link',
+      className: `${prefix}--tabs__nav-link`,
       href,
       role: 'tab',
       tabIndex,

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -14,13 +14,13 @@ const Table = props => {
     );
     didWarnAboutDeprecation = true;
   }
-  const { children, className, containerClassName, ...other } = props;
+  const { children, className, containerClassName, prefix, ...other } = props;
 
-  const tableClasses = classNames(className, 'bx--responsive-table');
+  const tableClasses = classNames(className, `${prefix}--responsive-table`);
 
   const tableContainerClasses = classNames(
     containerClassName,
-    'bx--responsive-table-container'
+    `${prefix}--responsive-table-container`
   );
 
   return (
@@ -39,9 +39,29 @@ const Table = props => {
 };
 
 Table.propTypes = {
+  /**
+   * Provide the contents of your Table
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to the <table> node
+   */
   className: PropTypes.string,
+
+  /**
+   * Specify an optional className to be applied to the container node
+   */
   containerClassName: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Table.defaultProps = {
+  prefix: 'bx',
 };
 
 export default Table;

--- a/src/components/TableBody/TableBody.js
+++ b/src/components/TableBody/TableBody.js
@@ -29,9 +29,9 @@ const handleRowStriping = rows => {
 };
 
 const TableBody = props => {
-  const { children, className, ...other } = props;
+  const { children, className, prefix, ...other } = props;
 
-  const tableBodyClasses = classNames(className, 'bx--table-body');
+  const tableBodyClasses = classNames(className, `${prefix}--table-body`);
 
   const childArray = React.Children.toArray(children);
   const childrenWithProps = handleRowStriping(childArray);
@@ -44,8 +44,24 @@ const TableBody = props => {
 };
 
 TableBody.propTypes = {
+  /**
+   * Provide the contents of your TableBody
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to your TableBody
+   */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableBody.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableBody;

--- a/src/components/TableData/TableData.js
+++ b/src/components/TableData/TableData.js
@@ -11,12 +11,13 @@ const TableData = props => {
     iconClassName,
     expanded,
     iconDescription,
+    prefix,
     ...other
   } = props;
 
   const tableDataClasses = classNames(className);
 
-  const iconClasses = classNames(iconClassName, 'bx--table-expand__svg');
+  const iconClasses = classNames(iconClassName, `${prefix}--table-expand__svg`);
 
   const style = expanded
     ? {
@@ -47,7 +48,14 @@ const TableData = props => {
 };
 
 TableData.propTypes = {
+  /**
+   * Provide the contents of your TableData.
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to your TableData.
+   */
   className: PropTypes.string,
 
   /**
@@ -64,10 +72,16 @@ TableData.propTypes = {
    * The expanded state for expando cell. `undefined` for regular cells.
    */
   expanded: PropTypes.bool,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 TableData.defaultProps = {
   iconDescription: 'expand row',
+  prefix: 'bx',
 };
 
 export default TableData;

--- a/src/components/TableHead/TableHead.js
+++ b/src/components/TableHead/TableHead.js
@@ -3,9 +3,9 @@ import React from 'react';
 import classNames from 'classnames';
 
 const TableHead = props => {
-  const { children, className, ...other } = props;
+  const { children, className, prefix, ...other } = props;
 
-  const tableHeadClasses = classNames(className, 'bx--table-head');
+  const tableHeadClasses = classNames(className, `${prefix}--table-head`);
 
   return (
     <thead {...other} className={tableHeadClasses}>
@@ -15,8 +15,24 @@ const TableHead = props => {
 };
 
 TableHead.propTypes = {
+  /**
+   * Provide the contents of your TableHead
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to your TableHead
+   */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TableHead.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TableHead;

--- a/src/components/TableHeader/TableHeader.js
+++ b/src/components/TableHeader/TableHeader.js
@@ -12,12 +12,13 @@ const TableHeader = props => {
     sortDir,
     iconDescriptionAscending,
     iconDescriptionDescending,
+    prefix,
     ...other
   } = props;
 
-  const tableHeaderClasses = classNames(className, 'bx--table-header');
+  const tableHeaderClasses = classNames(className, `${prefix}--table-header`);
 
-  const iconClasses = classNames(iconClassName, 'bx--table-sort__svg');
+  const iconClasses = classNames(iconClassName, `${prefix}--table-sort__svg`);
 
   let sortContent;
   if (sortDir) {
@@ -48,7 +49,14 @@ const TableHeader = props => {
 };
 
 TableHeader.propTypes = {
+  /**
+   * Provide the contents of your TableHeader.
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to your TableHeader.
+   */
   className: PropTypes.string,
 
   /**
@@ -70,11 +78,17 @@ TableHeader.propTypes = {
    * The sorting direction, `DESC` or `ASC`.
    */
   sortDir: PropTypes.string,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 TableHeader.defaultProps = {
   iconDescriptionAscending: 'ascending sort',
   iconDescriptionDescending: 'descending sort',
+  prefix: 'bx',
 };
 
 export default TableHeader;

--- a/src/components/TableRow/TableRow.js
+++ b/src/components/TableRow/TableRow.js
@@ -3,11 +3,11 @@ import React from 'react';
 import classNames from 'classnames';
 
 const TableRow = props => {
-  const { even, header, className, children, ...other } = props;
+  const { even, header, className, children, prefix, ...other } = props;
 
-  const tableRowClasses = classNames(className, 'bx--table-row', {
-    'bx--parent-row': !header,
-    'bx--parent-row--even': even,
+  const tableRowClasses = classNames(className, `${prefix}--table-row`, {
+    [`${prefix}--parent-row`]: !header,
+    [`${prefix}--parent-row--even`]: even,
   });
 
   return (
@@ -18,14 +18,35 @@ const TableRow = props => {
 };
 
 TableRow.propTypes = {
+  /**
+   * Specify whether your TableRow should be used as a header row
+   */
   header: PropTypes.bool,
+
+  /**
+   * Specify an optional className to be applied to your TableRow
+   */
   className: PropTypes.string,
+
+  /**
+   * Provide the contents of your TableRow
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify whether the TableRow is at an even position
+   */
   even: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 TableRow.defaultProps = {
   header: false,
+  prefix: 'bx',
 };
 
 export default TableRow;

--- a/src/components/TableRowExpanded/TableRowExpanded.js
+++ b/src/components/TableRowExpanded/TableRowExpanded.js
@@ -3,13 +3,21 @@ import React from 'react';
 import classNames from 'classnames';
 
 const TableRowExpanded = props => {
-  const { children, className, even, colSpan, expanded, ...other } = props;
+  const {
+    children,
+    className,
+    even,
+    colSpan,
+    expanded,
+    prefix,
+    ...other
+  } = props;
 
   const tableRowClasses = classNames({
     [className]: className,
-    'bx--table-row': true,
-    'bx--expandable-row': true,
-    'bx--expandable-row--even': even,
+    [`${prefix}--table-row`]: true,
+    [`${prefix}--expandable-row`]: true,
+    [`${prefix}--expandable-row--even`]: even,
   });
 
   if (!expanded) {
@@ -24,15 +32,40 @@ const TableRowExpanded = props => {
 };
 
 TableRowExpanded.propTypes = {
+  /**
+   * Provide the contents of your TableRowExpanded
+   */
   children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to your TableRowExpanded
+   */
   className: PropTypes.string,
+
+  /**
+   * Specify the `colspan` of your TableRowExpanded
+   */
   colSpan: PropTypes.number,
+
+  /**
+   * Specify whether your TableRowExpanded is activated
+   */
   expanded: PropTypes.bool,
+
+  /**
+   * Specify whether your TableRowExpanded is at an even position
+   */
   even: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 TableRowExpanded.defaultProps = {
   expanded: false,
+  prefix: 'bx',
 };
 
 export default TableRowExpanded;

--- a/src/components/Tabs/Tabs.Skeleton.js
+++ b/src/components/Tabs/Tabs.Skeleton.js
@@ -1,23 +1,37 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class TabsSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
+    const { prefix } = this.props;
     const tab = (
-      <li className="bx--tabs__nav-item">
-        <div className="bx--tabs__nav-link">&nbsp;</div>
+      <li className={`${prefix}--tabs__nav-item`}>
+        <div className={`${prefix}--tabs__nav-link`}>&nbsp;</div>
       </li>
     );
     return (
-      <nav className="bx--tabs bx--skeleton">
-        <div className="bx--tabs-trigger">
-          <div className="bx--tabs-trigger-text">&nbsp;</div>
+      <nav className={`${prefix}--tabs ${prefix}--skeleton`}>
+        <div className={`${prefix}--tabs-trigger`}>
+          <div className={`${prefix}--tabs-trigger-text`}>&nbsp;</div>
           <svg width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
             <path d="M10 0L5 5 0 0z" />
           </svg>
         </div>
-        <ul className="bx--tabs__nav bx--tabs__nav--hidden">
-          <li className="bx--tabs__nav-item bx--tabs__nav-item--selected">
-            <div className="bx--tabs__nav-link"> &nbsp;</div>
+        <ul className={`${prefix}--tabs__nav ${prefix}--tabs__nav--hidden`}>
+          <li
+            className={`${prefix}--tabs__nav-item ${prefix}--tabs__nav-item--selected`}>
+            <div className={`${prefix}--tabs__nav-link`}> &nbsp;</div>
           </li>
           {tab}
           {tab}

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -70,6 +70,11 @@ export default class Tabs extends React.Component {
      * for the dropdown menu of items
      */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -78,6 +83,7 @@ export default class Tabs extends React.Component {
     triggerHref: '#',
     selected: 0,
     ariaLabel: 'listbox',
+    prefix: 'bx',
   };
 
   state = {
@@ -179,6 +185,7 @@ export default class Tabs extends React.Component {
       triggerHref,
       role,
       onSelectionChange,
+      prefix,
       ...other
     } = this.props;
 
@@ -212,9 +219,9 @@ export default class Tabs extends React.Component {
     });
 
     const classes = {
-      tabs: classNames('bx--tabs', className),
-      tablist: classNames('bx--tabs__nav', {
-        'bx--tabs__nav--hidden': this.state.dropdownHidden,
+      tabs: classNames(`${prefix}--tabs`, className),
+      tablist: classNames(`${prefix}--tabs__nav`, {
+        [`${prefix}--tabs__nav--hidden`]: this.state.dropdownHidden,
       }),
     };
 
@@ -228,12 +235,12 @@ export default class Tabs extends React.Component {
             role="listbox"
             aria-label={ariaLabel}
             tabIndex={0}
-            className="bx--tabs-trigger"
+            className={`${prefix}--tabs-trigger`}
             onClick={this.handleDropdownClick}
             onKeyPress={this.handleDropdownClick}>
             <a
               tabIndex={-1}
-              className="bx--tabs-trigger-text"
+              className={`${prefix}--tabs-trigger-text`}
               href={triggerHref}
               onClick={this.handleDropdownClick}>
               {selectedLabel}

--- a/src/components/Tag/Tag.Skeleton.js
+++ b/src/components/Tag/Tag.Skeleton.js
@@ -1,7 +1,20 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class TagSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
-    return <span className="bx--tag bx--skeleton" />;
+    const { prefix } = this.props;
+    return <span className={`${prefix}--tag ${prefix}--skeleton`} />;
   }
 }

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -14,9 +14,9 @@ const TYPES = {
   'third-party': 'Third-Party',
 };
 
-const Tag = ({ children, className, type, ...other }) => {
-  const tagClass = `bx--tag--${type}`;
-  const tagClasses = classNames('bx--tag', tagClass, className);
+const Tag = ({ children, className, type, prefix, ...other }) => {
+  const tagClass = `${prefix}--tag--${type}`;
+  const tagClasses = classNames(`${prefix}--tag`, tagClass, className);
   return (
     <span className={tagClasses} {...other}>
       {children || TYPES[type]}
@@ -39,6 +39,15 @@ Tag.propTypes = {
    * Specify the type of the <Tag>
    */
   type: PropTypes.oneOf(Object.keys(TYPES)).isRequired,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Tag.defaultProps = {
+  prefix: 'bx',
 };
 
 export const types = Object.keys(TYPES);

--- a/src/components/TextArea/TextArea.Skeleton.js
+++ b/src/components/TextArea/TextArea.Skeleton.js
@@ -1,22 +1,34 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TextAreaSkeleton = ({ hideLabel, id }) => {
+const TextAreaSkeleton = ({ hideLabel, id, prefix }) => {
   const label = hideLabel ? null : (
     // eslint-disable-next-line jsx-a11y/label-has-for
-    <label className="bx--label bx--skeleton" htmlFor={id} />
+    <label className={`${prefix}--label ${prefix}--skeleton`} htmlFor={id} />
   );
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
-      <div className="bx--skeleton bx--text-area" />
+      <div className={`${prefix}--skeleton ${prefix}--text-area`} />
     </div>
   );
 };
 
 TextAreaSkeleton.propTypes = {
+  /**
+   * Specify whether the label should be hidden, or not
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TextAreaSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TextAreaSkeleton;

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -13,6 +13,7 @@ const TextArea = ({
   invalidText,
   helperText,
   light,
+  prefix,
   ...other
 }) => {
   const textareaProps = {
@@ -29,11 +30,11 @@ const TextArea = ({
     },
   };
 
-  const textareaClasses = classNames('bx--text-area', className, {
-    'bx--text-area--light': light,
+  const textareaClasses = classNames(`${prefix}--text-area`, className, {
+    [`${prefix}--text-area--light`]: light,
   });
-  const labelClasses = classNames('bx--label', {
-    'bx--visually-hidden': hideLabel,
+  const labelClasses = classNames(`${prefix}--label`, {
+    [`${prefix}--visually-hidden`]: hideLabel,
   });
 
   const label = labelText ? (
@@ -43,7 +44,7 @@ const TextArea = ({
   ) : null;
 
   const error = invalid ? (
-    <div className="bx--form-requirement">{invalidText}</div>
+    <div className={`${prefix}--form-requirement`}>{invalidText}</div>
   ) : null;
 
   const input = invalid ? (
@@ -58,11 +59,11 @@ const TextArea = ({
   );
 
   const helper = helperText ? (
-    <div className="bx--form__helper-text">{helperText}</div>
+    <div className={`${prefix}--form__helper-text`}>{helperText}</div>
   ) : null;
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
       {input}
       {helper}
@@ -155,6 +156,11 @@ TextArea.propTypes = {
    * Specify whether you want the light version of this control
    */
   light: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 TextArea.defaultProps = {
@@ -168,6 +174,7 @@ TextArea.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  prefix: 'bx',
 };
 
 export default TextArea;

--- a/src/components/TextInput/TextInput.Skeleton.js
+++ b/src/components/TextInput/TextInput.Skeleton.js
@@ -1,22 +1,34 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TextInputSkeleton = ({ hideLabel, id }) => {
+const TextInputSkeleton = ({ hideLabel, id, prefix }) => {
   const label = hideLabel ? null : (
     // eslint-disable-next-line jsx-a11y/label-has-for
-    <label className="bx--label bx--skeleton" htmlFor={id} />
+    <label className={`${prefix}--label ${prefix}--skeleton`} htmlFor={id} />
   );
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
-      <div className="bx--skeleton bx--text-input" />
+      <div className={`${prefix}--skeleton ${prefix}--text-input`} />
     </div>
   );
 };
 
 TextInputSkeleton.propTypes = {
+  /**
+   * Specify whether the label should be hidden, or not
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+TextInputSkeleton.defaultProps = {
+  prefix: 'bx',
 };
 
 export default TextInputSkeleton;

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 const TextInput = ({
   labelText,
-  className,
+  prefix,
+  className = `${prefix}--text__input`,
   id,
   placeholder,
   type,
@@ -34,11 +35,11 @@ const TextInput = ({
   };
 
   const errorId = id + '-error-msg';
-  const textInputClasses = classNames('bx--text-input', className, {
-    'bx--text-input--light': light,
+  const textInputClasses = classNames(`${prefix}--text-input`, className, {
+    [`${prefix}--text-input--light`]: light,
   });
-  const labelClasses = classNames('bx--label', {
-    'bx--visually-hidden': hideLabel,
+  const labelClasses = classNames(`${prefix}--label`, {
+    [`${prefix}--visually-hidden`]: hideLabel,
   });
 
   const label = labelText ? (
@@ -48,7 +49,7 @@ const TextInput = ({
   ) : null;
 
   const error = invalid ? (
-    <div className="bx--form-requirement" id={errorId}>
+    <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
     </div>
   ) : null;
@@ -67,11 +68,11 @@ const TextInput = ({
   );
 
   const helper = helperText ? (
-    <div className="bx--form__helper-text">{helperText}</div>
+    <div className={`${prefix}--form__helper-text`}>{helperText}</div>
   ) : null;
 
   return (
-    <div className="bx--form-item">
+    <div className={`${prefix}--form-item`}>
       {label}
       {input}
       {helper}
@@ -81,28 +82,91 @@ const TextInput = ({
 };
 
 TextInput.propTypes = {
+  /**
+   * Specify an optional className to be applied to the <input> node
+   */
   className: PropTypes.string,
+
+  /**
+   * Optionally provide the default value of the <input>
+   */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Specify whether the <input> should be disabled
+   */
   disabled: PropTypes.bool,
+
+  /**
+   * Specify a custom `id` for the <input>
+   */
   id: PropTypes.string.isRequired,
+
+  /**
+   * Provide the text that will be read by a screen reader when visiting this
+   * control
+   */
   labelText: PropTypes.node.isRequired,
+
+  /**
+   * Optionally provide an `onChange` handler that is called whenever <input>
+   * is updated
+   */
   onChange: PropTypes.func,
+
+  /**
+   * Optionally provide an `onClick` handler that is called whenever the
+   * <input> is clicked
+   */
   onClick: PropTypes.func,
+
+  /**
+   * Specify the placeholder attribute for the <input>
+   */
   placeholder: PropTypes.string,
+
+  /**
+   * Specify the type of the <input>
+   */
   type: PropTypes.string,
+
+  /**
+   * Specify the value of the <input>
+   */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Specify whether you want the underlying label to be visually hidden
+   */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify whether the control is currently invalid
+   */
   invalid: PropTypes.bool,
+
+  /**
+   * Provide the text that is displayed when the control is in an invalid state
+   */
   invalidText: PropTypes.string,
+
+  /**
+   * Provide text that is used alongside the control label for additional help
+   */
   helperText: PropTypes.node,
+
   /**
    * `true` to use the light version.
    */
   light: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 TextInput.defaultProps = {
-  className: 'bx--text__input',
   disabled: false,
   type: 'text',
   onChange: () => {},
@@ -111,6 +175,7 @@ TextInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  prefix: 'bx',
 };
 
 export default TextInput;

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -7,13 +7,29 @@ import Icon from '../Icon';
 
 export class Tile extends Component {
   static propTypes = {
+    /**
+     * The child nodes.
+     */
     children: PropTypes.node,
+
+    /**
+     * The CSS class names.
+     */
     className: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
   };
 
   render() {
-    const { children, className, ...other } = this.props;
-    const tileClasses = classNames('bx--tile', className);
+    const { children, className, prefix, ...other } = this.props;
+    const tileClasses = classNames(`${prefix}--tile`, className);
 
     return (
       <div className={tileClasses} {...other}>
@@ -46,12 +62,18 @@ export class ClickableTile extends Component {
      * The rel property for the link.
      */
     rel: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     clicked: false,
     handleClick: () => {},
     handleKeyDown: () => {},
+    prefix: 'bx',
   };
 
   handleClick = evt => {
@@ -98,14 +120,15 @@ export class ClickableTile extends Component {
       handleClick, // eslint-disable-line
       handleKeyDown, // eslint-disable-line
       clicked, // eslint-disable-line
+      prefix,
       ...other
     } = this.props;
 
     const classes = classNames(
-      'bx--tile',
-      'bx--tile--clickable',
+      `${prefix}--tile`,
+      `${prefix}--tile--clickable`,
       {
-        'bx--tile--is-clicked': this.state.clicked,
+        [`${prefix}--tile--is-clicked`]: this.state.clicked,
       },
       className
     );
@@ -168,6 +191,11 @@ export class SelectableTile extends Component {
      * The description of the checkmark icon.
      */
     iconDescription: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -175,6 +203,7 @@ export class SelectableTile extends Component {
     title: 'title',
     iconDescription: 'Tile checkmark',
     selected: false,
+    prefix: 'bx',
     handleClick: () => {},
     handleKeyDown: () => {},
   };
@@ -234,10 +263,15 @@ export class SelectableTile extends Component {
       className,
       handleClick, // eslint-disable-line
       handleKeyDown, // eslint-disable-line
+      prefix,
       ...other
     } = this.props;
 
-    const classes = classNames('bx--tile', 'bx--tile--selectable', className);
+    const classes = classNames(
+      `${prefix}--tile`,
+      `${prefix}--tile--selectable`,
+      className
+    );
 
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
@@ -254,17 +288,17 @@ export class SelectableTile extends Component {
           }}
           tabIndex={-1}
           id={id}
-          className="bx--tile-input"
+          className={`${prefix}--tile-input`}
           value={value}
           type="checkbox"
           name={name}
           title={title}
           checked={this.state.selected}
         />
-        <div className="bx--tile__checkmark">
+        <div className={`${prefix}--tile__checkmark`}>
           <Icon icon={iconCheckmarkSolid} description={iconDescription} />
         </div>
-        <div className="bx--tile-content">{children}</div>
+        <div className={`${prefix}--tile-content`}>{children}</div>
       </label>
     );
   }
@@ -274,12 +308,40 @@ export class ExpandableTile extends Component {
   state = {};
 
   static propTypes = {
+    /**
+     * The child nodes.
+     */
     children: PropTypes.node,
+
+    /**
+     * The CSS class names.
+     */
     className: PropTypes.string,
+
+    /**
+     * `true` if the tile is expanded.
+     */
     expanded: PropTypes.bool,
+
+    /**
+     * The `tabindex` attribute.
+     */
     tabIndex: PropTypes.number,
+
+    /**
+     * The description of the "collapsed" icon that can be read by screen readers.
+     */
     tileCollapsedIconText: PropTypes.string,
+
+    /**
+     * The description of the "expanded" icon that can be read by screen readers.
+     */
     tileExpandedIconText: PropTypes.string,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -289,6 +351,7 @@ export class ExpandableTile extends Component {
     handleClick: () => {},
     tileCollapsedIconText: 'Expand',
     tileExpandedIconText: 'Collapse',
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps(
@@ -370,14 +433,15 @@ export class ExpandableTile extends Component {
       expanded, // eslint-disable-line
       tileCollapsedIconText, // eslint-disable-line
       tileExpandedIconText, // eslint-disable-line
+      prefix,
       ...other
     } = this.props;
 
     const classes = classNames(
-      'bx--tile',
-      'bx--tile--expandable',
+      `${prefix}--tile`,
+      `${prefix}--tile--expandable`,
       {
-        'bx--tile--is-expanded': this.state.expanded,
+        [`${prefix}--tile--is-expanded`]: this.state.expanded,
       },
       className
     );
@@ -400,7 +464,7 @@ export class ExpandableTile extends Component {
         role="button"
         onClick={this.handleClick}
         tabIndex={tabIndex}>
-        <button className="bx--tile__chevron">
+        <button className={`${prefix}--tile__chevron`}>
           <Icon
             icon={iconChevronDown}
             description={
@@ -412,7 +476,7 @@ export class ExpandableTile extends Component {
           ref={tileContent => {
             this.tileContent = tileContent;
           }}
-          className="bx--tile-content">
+          className={`${prefix}--tile-content`}>
           {content}
         </div>
       </div>
@@ -422,24 +486,56 @@ export class ExpandableTile extends Component {
 
 export class TileAboveTheFoldContent extends Component {
   static propTypes = {
+    /**
+     * The child nodes.
+     */
     children: PropTypes.node,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
   };
 
   render() {
-    const { children } = this.props;
+    const { children, prefix } = this.props;
 
-    return <span className="bx--tile-content__above-the-fold">{children}</span>;
+    return (
+      <span className={`${prefix}--tile-content__above-the-fold`}>
+        {children}
+      </span>
+    );
   }
 }
 
 export class TileBelowTheFoldContent extends Component {
   static propTypes = {
+    /**
+     * The child nodes.
+     */
     children: PropTypes.node,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
   };
 
   render() {
-    const { children } = this.props;
+    const { children, prefix } = this.props;
 
-    return <span className="bx--tile-content__below-the-fold">{children}</span>;
+    return (
+      <span className={`${prefix}--tile-content__below-the-fold`}>
+        {children}
+      </span>
+    );
   }
 }

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -10,18 +10,51 @@ export default class TileGroup extends React.Component {
   };
 
   static propTypes = {
+    /**
+     * Provide a collection of <RadioTile> components to render in the group
+     */
     children: PropTypes.node,
+
+    /**
+     * Provide an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify the the value of <RadioTile> to be selected by default
+     */
     defaultSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * Specify the name of the underlying <input> nodes
+     */
     name: PropTypes.string.isRequired,
+
+    /**
+     * Specify whether the group is disabled
+     */
     disabled: PropTypes.bool,
+
+    /**
+     * Provide an optional `onChange` hook that is called whenever the value of
+     * the group changes
+     */
     onChange: PropTypes.func,
+
+    /**
+     * Specify the value that is currently selected in the group
+     */
     valueSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
     onChange: /* istanbul ignore next */ () => {},
-    className: 'bx--tile-group',
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ valueSelected, defaultSelected }, state) {
@@ -70,7 +103,11 @@ export default class TileGroup extends React.Component {
   };
 
   render() {
-    const { disabled, className } = this.props;
+    const {
+      disabled,
+      prefix,
+      className = `${prefix}--tile-group`,
+    } = this.props;
 
     return (
       <div className={className} disabled={disabled}>

--- a/src/components/TimePicker/TimePicker.js
+++ b/src/components/TimePicker/TimePicker.js
@@ -6,26 +6,99 @@ export default class TimePicker extends Component {
   state = {};
 
   static propTypes = {
+    /**
+     * Pass in the children that will be rendered next to the form control
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the container node
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify a custom `id` for the <input>
+     */
     id: PropTypes.string.isRequired,
+
+    /**
+     * Provide the text that will be read by a screen reader when visiting this
+     * control
+     */
     labelText: PropTypes.node,
+
+    /**
+     * Optionally provide an `onClick` handler that is called whenever the
+     * <input> is clicked
+     */
     onClick: PropTypes.func,
+
+    /**
+     * Optionally provide an `onChange` handler that is called whenever <input>
+     * is updated
+     */
     onChange: PropTypes.func,
+
+    /**
+     * Optionally provide an `onBlur` handler that is called whenever the
+     * <input> loses focus
+     */
     onBlur: PropTypes.func,
+
+    /**
+     * Specify the type of the <input>
+     */
     type: PropTypes.string,
+
+    /**
+     * Specify the regular expression working as the pattern of the time string in <input>
+     */
     pattern: PropTypes.string,
+
+    /**
+     * Specify the placeholder attribute for the <input>
+     */
     placeholder: PropTypes.string,
+
+    /**
+     * Specify the maximum length of the time string in <input>
+     */
     maxLength: PropTypes.number,
+
+    /**
+     * Specify whether the control is currently invalid
+     */
     invalid: PropTypes.bool,
+
+    /**
+     * Provide the text that is displayed when the control is in an invalid state
+     */
     invalidText: PropTypes.string,
+
+    /**
+     * Specify whether you want the underlying label to be visually hidden
+     */
     hideLabel: PropTypes.bool,
+
+    /**
+     * Specify whether the <input> should be disabled
+     */
     disabled: PropTypes.bool,
+
+    /**
+     * Specify the value of the <input>
+     */
     value: PropTypes.string,
+
     /**
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -40,6 +113,7 @@ export default class TimePicker extends Component {
     onClick: () => {},
     onBlur: () => {},
     light: false,
+    prefix: 'bx',
   };
 
   static getDerivedStateFromProps({ value }, state) {
@@ -69,6 +143,7 @@ export default class TimePicker extends Component {
       invalid,
       hideLabel,
       light,
+      prefix,
       ...other
     } = this.props;
 
@@ -106,13 +181,13 @@ export default class TimePicker extends Component {
     };
 
     const timePickerClasses = classNames({
-      'bx--time-picker': true,
-      'bx--time-picker--light': light,
+      [`${prefix}--time-picker`]: true,
+      [`${prefix}--time-picker--light`]: light,
       [className]: className,
     });
 
-    const labelClasses = classNames('bx--label', {
-      'bx--visually-hidden': hideLabel,
+    const labelClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--visually-hidden`]: hideLabel,
     });
 
     const label = labelText ? (
@@ -122,19 +197,19 @@ export default class TimePicker extends Component {
     ) : null;
 
     const error = invalid ? (
-      <div className="bx--form-requirement">{invalidText}</div>
+      <div className={`${prefix}--form-requirement`}>{invalidText}</div>
     ) : null;
 
     return (
-      <div className="bx--form-item">
+      <div className={`${prefix}--form-item`}>
         <div className={timePickerClasses}>
-          <div className="bx--time-picker__input">
+          <div className={`${prefix}--time-picker__input`}>
             {label}
             <input
               {...other}
               {...timePickerInputProps}
               data-invalid={invalid ? invalid : undefined}
-              className="bx--time-picker__input-field"
+              className={`${prefix}--time-picker__input-field`}
             />
             {error}
           </div>

--- a/src/components/TimePickerSelect/TimePickerSelect.js
+++ b/src/components/TimePickerSelect/TimePickerSelect.js
@@ -6,15 +6,56 @@ import { iconCaretDown } from 'carbon-icons';
 
 export default class TimePickerSelect extends Component {
   static propTypes = {
+    /**
+     * Provide the contents of your TimePickerSelect
+     */
     children: PropTypes.node,
+
+    /**
+     * Specify an optional className to be applied to the node containing the label and the select box
+     */
     className: PropTypes.string,
+
+    /**
+     * Specify a custom `id` for the `<select>`
+     */
     id: PropTypes.string.isRequired,
+
+    /**
+     * Specify whether you want the inline version of this control
+     */
     inline: PropTypes.bool,
+
+    /**
+     * Specify whether the control is disabled
+     */
     disabled: PropTypes.bool,
+
+    /**
+     * Optionally provide the default value of the `<select>`
+     */
     defaultValue: PropTypes.any,
+
+    /**
+     * Provide a description for the twistie icon that can be read by screen readers
+     */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * Specify whether the label should be hidden, or not
+     */
     hideLabel: PropTypes.bool,
+
+    /**
+     * Provide label text to be read by screen readers when interacting with the
+     * control
+     */
     labelText: PropTypes.node.isRequired,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -22,6 +63,7 @@ export default class TimePickerSelect extends Component {
     inline: true,
     iconDescription: 'open list of options',
     hideLabel: true,
+    prefix: 'bx',
   };
 
   render() {
@@ -34,18 +76,19 @@ export default class TimePickerSelect extends Component {
       hideLabel,
       labelText,
       inline, // eslint-disable-line
+      prefix,
       ...other
     } = this.props;
 
     const selectClasses = classNames({
-      'bx--select': true,
-      'bx--time-picker__select': true,
-      'bx--select--inline': true,
+      [`${prefix}--select`]: true,
+      [`${prefix}--time-picker__select`]: true,
+      [`${prefix}--select--inline`]: true,
       [className]: className,
     });
 
-    const labelClasses = classNames('bx--label', {
-      'bx--visually-hidden': hideLabel,
+    const labelClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--visually-hidden`]: hideLabel,
     });
 
     const label = labelText ? (
@@ -60,13 +103,13 @@ export default class TimePickerSelect extends Component {
         <select
           {...other}
           id={id}
-          className="bx--select-input"
+          className={`${prefix}--select-input`}
           disabled={disabled}>
           {children}
         </select>
         <Icon
           icon={iconCaretDown}
-          className="bx--select__arrow"
+          className={`${prefix}--select__arrow`}
           description={iconDescription}
         />
       </div>

--- a/src/components/Toggle/Toggle.Skeleton.js
+++ b/src/components/Toggle/Toggle.Skeleton.js
@@ -1,16 +1,34 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class ToggleSkeleton extends React.Component {
-  render() {
-    const { id } = this.props;
-    return (
-      <div className="bx--form-item">
-        <input type="checkbox" id={id} className="bx--toggle bx--skeleton" />
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
 
-        <label className="bx--toggle__label bx--skeleton" htmlFor={id}>
-          <span className="bx--toggle__text--left" />
-          <span className="bx--toggle__appearance" />
-          <span className="bx--toggle__text--right" />
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
+  render() {
+    const { id, prefix } = this.props;
+    return (
+      <div className={`${prefix}--form-item`}>
+        <input
+          type="checkbox"
+          id={id}
+          className={`${prefix}--toggle ${prefix}--skeleton`}
+        />
+
+        <label
+          className={`${prefix}--toggle__label ${prefix}--skeleton`}
+          htmlFor={id}>
+          <span className={`${prefix}--toggle__text--left`} />
+          <span className={`${prefix}--toggle__appearance`} />
+          <span className={`${prefix}--toggle__text--right`} />
         </label>
       </div>
     );

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -11,11 +11,12 @@ const Toggle = ({
   id,
   labelA,
   labelB,
+  prefix,
   ...other
 }) => {
   let input;
   const wrapperClasses = classNames({
-    'bx--form-item': true,
+    [`${prefix}--form-item`]: true,
     [className]: className,
   });
 
@@ -34,7 +35,7 @@ const Toggle = ({
         {...checkedProps}
         type="checkbox"
         id={id}
-        className="bx--toggle"
+        className={`${prefix}--toggle`}
         onChange={evt => {
           onChange && onChange(evt);
           onToggle(input.checked, id, evt);
@@ -44,10 +45,10 @@ const Toggle = ({
         }}
       />
 
-      <label className="bx--toggle__label" htmlFor={id}>
-        <span className="bx--toggle__text--left">{labelA}</span>
-        <span className="bx--toggle__appearance" />
-        <span className="bx--toggle__text--right">{labelB}</span>
+      <label className={`${prefix}--toggle__label`} htmlFor={id}>
+        <span className={`${prefix}--toggle__text--left`}>{labelA}</span>
+        <span className={`${prefix}--toggle__appearance`} />
+        <span className={`${prefix}--toggle__text--right`}>{labelB}</span>
       </label>
     </div>
   );
@@ -88,12 +89,18 @@ Toggle.propTypes = {
    * Specify the label for the "on" position
    */
   labelB: PropTypes.string.isRequired,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 Toggle.defaultProps = {
   defaultToggled: false,
   labelA: 'Off',
   labelB: 'On',
+  prefix: 'bx',
   onToggle: () => {},
 };
 

--- a/src/components/ToggleSmall/ToggleSmall.Skeleton.js
+++ b/src/components/ToggleSmall/ToggleSmall.Skeleton.js
@@ -1,20 +1,34 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class ToggleSmallSkeleton extends React.Component {
+  static propTypes = {
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
+  };
+
+  static defaultProps = {
+    prefix: 'bx',
+  };
+
   render() {
-    const { id } = this.props;
+    const { id, prefix } = this.props;
     return (
-      <div className="bx--form-item">
+      <div className={`${prefix}--form-item`}>
         <input
           type="checkbox"
           id={id}
-          className="bx--toggle bx--toggle--small bx--skeleton"
+          className={`${prefix}--toggle ${prefix}--toggle--small ${prefix}--skeleton`}
         />
 
-        <label className="bx--toggle__label bx--skeleton" htmlFor={id}>
-          <span className="bx--toggle__appearance">
+        <label
+          className={`${prefix}--toggle__label ${prefix}--skeleton`}
+          htmlFor={id}>
+          <span className={`${prefix}--toggle__appearance`}>
             <svg
-              className="bx--toggle__check"
+              className={`${prefix}--toggle__check`}
               width="6px"
               height="5px"
               viewBox="0 0 6 5">

--- a/src/components/ToggleSmall/ToggleSmall.js
+++ b/src/components/ToggleSmall/ToggleSmall.js
@@ -10,11 +10,12 @@ const ToggleSmall = ({
   onToggle,
   id,
   ariaLabel,
+  prefix,
   ...other
 }) => {
   let input;
   const wrapperClasses = classNames({
-    'bx--form-item': true,
+    [`${prefix}--form-item`]: true,
     [className]: className,
   });
 
@@ -33,7 +34,7 @@ const ToggleSmall = ({
         {...checkedProps}
         type="checkbox"
         id={id}
-        className="bx--toggle bx--toggle--small"
+        className={`${prefix}--toggle ${prefix}--toggle--small`}
         onChange={evt => {
           onChange && onChange(evt);
           onToggle(input.checked, id, evt);
@@ -44,10 +45,10 @@ const ToggleSmall = ({
         aria-label={ariaLabel}
       />
 
-      <label className="bx--toggle__label" htmlFor={id}>
-        <span className="bx--toggle__appearance">
+      <label className={`${prefix}--toggle__label`} htmlFor={id}>
+        <span className={`${prefix}--toggle__appearance`}>
           <svg
-            className="bx--toggle__check"
+            className={`${prefix}--toggle__check`}
             width="6px"
             height="5px"
             viewBox="0 0 6 5">
@@ -89,10 +90,16 @@ ToggleSmall.propTypes = {
    * The `aria-label` attribute for the toggle
    */
   ariaLabel: PropTypes.string.isRequired,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 ToggleSmall.defaultProps = {
   defaultToggled: false,
+  prefix: 'bx',
   onToggle: () => {},
 };
 

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import ToolbarSearch from '../ToolbarSearch';
 import classNames from 'classnames';
 
-const Toolbar = ({ children, className, ...other }) => {
-  const wrapperClasses = classNames('bx--toolbar', className);
+const Toolbar = ({ children, className, prefix, ...other }) => {
+  const wrapperClasses = classNames(`${prefix}--toolbar`, className);
 
   return (
     <div className={wrapperClasses} {...other}>
@@ -23,6 +23,15 @@ Toolbar.propTypes = {
    * Specify an optional className to be applied to the containing Toolbar node
    */
   className: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+Toolbar.defaultProps = {
+  prefix: 'bx',
 };
 
 export const ToolbarItem = ({ children, type, placeHolderText }) => {
@@ -58,8 +67,8 @@ ToolbarItem.defaultProps = {
   placeHolderText: 'Provide placeHolderText',
 };
 
-export const ToolbarTitle = ({ title }) => (
-  <li className="bx--toolbar-menu__title">{title}</li>
+export const ToolbarTitle = ({ title, prefix }) => (
+  <li className={`${prefix}--toolbar-menu__title`}>{title}</li>
 );
 
 ToolbarTitle.propTypes = {
@@ -67,10 +76,19 @@ ToolbarTitle.propTypes = {
    * Specify the title of the Toolbar
    */
   title: PropTypes.string,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
-export const ToolbarOption = ({ children }) => (
-  <li className="bx--toolbar-menu__option">{children}</li>
+ToolbarTitle.defaultProps = {
+  prefix: 'bx',
+};
+
+export const ToolbarOption = ({ children, prefix }) => (
+  <li className={`${prefix}--toolbar-menu__option`}>{children}</li>
 );
 
 ToolbarOption.propTypes = {
@@ -78,10 +96,30 @@ ToolbarOption.propTypes = {
    * Specify the contents of the ToolbarOption
    */
   children: PropTypes.node,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
-export const ToolbarDivider = () => (
-  <hr className="bx--toolbar-menu__divider" />
+ToolbarOption.defaultProps = {
+  prefix: 'bx',
+};
+
+export const ToolbarDivider = ({ prefix }) => (
+  <hr className={`${prefix}--toolbar-menu__divider`} />
 );
+
+ToolbarDivider.propTypes = {
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
+};
+
+ToolbarDivider.defaultProps = {
+  prefix: 'bx',
+};
 
 export default Toolbar;

--- a/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/src/components/ToolbarSearch/ToolbarSearch.js
@@ -46,6 +46,11 @@ export default class ToolbarSearch extends Component {
      * The ID of the `<input>`.
      */
     id: PropTypes.string,
+
+    /**
+     * The selector prefix
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -55,6 +60,7 @@ export default class ToolbarSearch extends Component {
     iconDescription: 'search',
     placeHolderText: '',
     role: 'search',
+    prefix: 'bx',
   };
 
   state = {
@@ -83,25 +89,26 @@ export default class ToolbarSearch extends Component {
       placeHolderText,
       labelText,
       role,
+      prefix,
       ...other
     } = this.props;
 
     const searchClasses = classNames({
-      'bx--search bx--search--sm bx--toolbar-search': true,
-      'bx--toolbar-search--active': this.state.expanded,
+      [`${prefix}--search ${prefix}--search--sm ${prefix}--toolbar-search`]: true,
+      [`${prefix}--toolbar-search--active`]: this.state.expanded,
       [className]: className,
     });
 
     return (
       <ClickListener onClickOutside={this.handleClickOutside}>
         <div className={searchClasses} role={role}>
-          <label htmlFor={id} className="bx--label">
+          <label htmlFor={id} className={`${prefix}--label`}>
             {labelText}
           </label>
           <input
             {...other}
             type={type}
-            className="bx--search-input"
+            className={`${prefix}--search-input`}
             id={id}
             placeholder={placeHolderText}
             ref={input => {
@@ -109,12 +116,12 @@ export default class ToolbarSearch extends Component {
             }}
           />
           <button
-            className="bx--toolbar-search__btn"
+            className={`${prefix}--toolbar-search__btn`}
             onClick={this.expandSearch}>
             <Icon
               icon={iconSearch}
               description={iconDescription}
-              className="bx--search-magnifier"
+              className={`${prefix}--search-magnifier`}
             />
           </button>
         </div>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -179,6 +179,11 @@ export default class Tooltip extends Component {
      * `true` if opening tooltip should be triggered by clicking the trigger button.
      */
     clickToOpen: PropTypes.bool,
+
+    /**
+     * The selector prefix.
+     */
+    prefix: PropTypes.string,
   };
 
   static defaultProps = {
@@ -188,6 +193,7 @@ export default class Tooltip extends Component {
     iconDescription: 'tooltip',
     triggerText: 'Provide triggerText',
     menuOffset: getMenuOffset,
+    prefix: 'bx',
   };
 
   /**
@@ -336,18 +342,22 @@ export default class Tooltip extends Component {
       // Exclude `clickToOpen` from `other` to avoid passing it along to `<div>`
       // eslint-disable-next-line no-unused-vars
       clickToOpen,
+      prefix,
       ...other
     } = this.props;
 
     const { open } = this.state;
 
     const tooltipClasses = classNames(
-      'bx--tooltip',
-      { 'bx--tooltip--shown': open },
+      `${prefix}--tooltip`,
+      { [`${prefix}--tooltip--shown`]: open },
       className
     );
 
-    const triggerClasses = classNames('bx--tooltip__trigger', triggerClassName);
+    const triggerClasses = classNames(
+      `${prefix}--tooltip__trigger`,
+      triggerClassName
+    );
     const ariaOwnsProps = !open
       ? {}
       : {
@@ -423,7 +433,7 @@ export default class Tooltip extends Component {
               onFocus={evt => this.handleMouse(evt)}
               onBlur={evt => this.handleMouse(evt)}
               onContextMenu={evt => this.handleMouse(evt)}>
-              <span className="bx--tooltip__caret" />
+              <span className={`${prefix}--tooltip__caret`} />
               {children}
             </div>
           </FloatingMenu>

--- a/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/src/components/TooltipDefinition/TooltipDefinition.js
@@ -11,20 +11,23 @@ const TooltipDefinition = ({
   children,
   direction,
   tooltipText,
+  prefix,
   ...rest
 }) => {
   const tooltipId = id || `definition-tooltip-${getInstanceId()}`;
   const definitionClassName = cx({
     [className]: !!className,
-    'bx--tooltip--definition': true,
+    [`${prefix}--tooltip--definition`]: true,
   });
   const directionClassName = cx({
-    'bx--tooltip--definition__bottom': direction === 'bottom',
-    'bx--tooltip--definition__top': direction === 'top',
+    [`${prefix}--tooltip--definition__bottom`]: direction === 'bottom',
+    [`${prefix}--tooltip--definition__top`]: direction === 'top',
   });
   return (
     <div {...rest} className={definitionClassName}>
-      <button className="bx--tooltip__trigger" aria-describedby={tooltipId}>
+      <button
+        className={`${prefix}--tooltip__trigger`}
+        aria-describedby={tooltipId}>
         {children}
       </button>
       <div
@@ -32,7 +35,7 @@ const TooltipDefinition = ({
         className={directionClassName}
         role="tooltip"
         aria-label={tooltipText}>
-        <span className="bx--tooltip__caret" />
+        <span className={`${prefix}--tooltip__caret`} />
         <p>{tooltipText}</p>
       </div>
     </div>
@@ -61,10 +64,16 @@ TooltipDefinition.propTypes = {
    * Provide the text that will be displayed in the tooltip when it is rendered.
    */
   tooltipText: PropTypes.node.isRequired,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 TooltipDefinition.defaultProps = {
   direction: 'bottom',
+  prefix: 'bx',
 };
 
 export default TooltipDefinition;

--- a/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -4,6 +4,7 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
 <TooltipDefinition
   className="custom-class"
   direction="top"
+  prefix="bx"
   tooltipText="tooltip text"
 >
   <div
@@ -36,6 +37,7 @@ exports[`TooltipDefinition should render 1`] = `
 <TooltipDefinition
   className="custom-class"
   direction="bottom"
+  prefix="bx"
   tooltipText="tooltip text"
 >
   <div

--- a/src/components/TooltipIcon/TooltipIcon.js
+++ b/src/components/TooltipIcon/TooltipIcon.js
@@ -7,16 +7,17 @@ const TooltipIcon = ({
   children,
   direction,
   tooltipText,
+  prefix,
   ...rest
 }) => {
   const tooltipClassName = cx({
     [className]: !!className,
-    'bx--tooltip-icon': true,
+    [`${prefix}--tooltip-icon`]: true,
   });
   const triggerClassName = cx({
-    'bx--tooltip__trigger': true,
-    'bx--tooltip--icon__bottom': direction === 'bottom',
-    'bx--tooltip--icon__top': direction === 'top',
+    [`${prefix}--tooltip__trigger`]: true,
+    [`${prefix}--tooltip--icon__bottom`]: direction === 'bottom',
+    [`${prefix}--tooltip--icon__top`]: direction === 'top',
   });
   return (
     <div {...rest} className={tooltipClassName}>
@@ -43,10 +44,16 @@ TooltipIcon.propTypes = {
    * Provide the text that will be displayed in the tooltip when it is rendered.
    */
   tooltipText: PropTypes.node.isRequired,
+
+  /**
+   * The selector prefix.
+   */
+  prefix: PropTypes.string,
 };
 
 TooltipIcon.defaultProps = {
   direction: 'bottom',
+  prefix: 'bx',
 };
 
 export default TooltipIcon;

--- a/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
+++ b/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
@@ -4,6 +4,7 @@ exports[`TooltipIcon should allow the user to specify the direction 1`] = `
 <TooltipIcon
   className="custom-class"
   direction="top"
+  prefix="bx"
   tooltipText="tooltip text"
 >
   <div
@@ -23,6 +24,7 @@ exports[`TooltipIcon should render 1`] = `
 <TooltipIcon
   className="custom-class"
   direction="bottom"
+  prefix="bx"
   tooltipText="tooltip text"
 >
   <div

--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -16,6 +16,7 @@ const TooltipSimple = ({
   icon,
   iconName,
   iconDescription,
+  prefix,
   ...other
 }) => {
   if (__DEV__) {
@@ -27,9 +28,12 @@ const TooltipSimple = ({
     );
     didWarnAboutDeprecation = true;
   }
-  const tooltipClasses = classNames(`bx--tooltip--simple__${position}`);
+  const tooltipClasses = classNames(`${prefix}--tooltip--simple__${position}`);
 
-  const tooltipWrapperClasses = classNames(`bx--tooltip--simple`, className);
+  const tooltipWrapperClasses = classNames(
+    `${prefix}--tooltip--simple`,
+    className
+  );
   return (
     <div className={tooltipWrapperClasses}>
       {showIcon ? (
@@ -64,18 +68,49 @@ const TooltipSimple = ({
 };
 
 TooltipSimple.propTypes = {
+  /**
+   * The content to put into the trigger UI, except the (default) tooltip icon.
+   */
   children: PropTypes.node,
+
+  /**
+   * The CSS class names of the tooltip.
+   */
   className: PropTypes.string,
+
+  /**
+   * Where to put the tooltip, relative to the trigger UI.
+   */
   position: PropTypes.oneOf(['bottom', 'top']),
+
+  /**
+   * Contents to put into the tooltip.
+   */
   text: PropTypes.string.isRequired,
+
+  /**
+   * `true` to show the default tooltip icon.
+   */
   showIcon: PropTypes.bool,
+
+  /**
+   * The the default tooltip icon.
+   */
   icon: PropTypes.shape({
     width: PropTypes.string,
     height: PropTypes.string,
     viewBox: PropTypes.string.isRequired,
     svgData: PropTypes.object.isRequired,
   }),
+
+  /**
+   * The name of the default tooltip icon.
+   */
   iconName: PropTypes.string,
+
+  /**
+   * The description of the default tooltip icon, to be put in its SVG `<title>` element.
+   */
   iconDescription: PropTypes.string,
 };
 
@@ -84,6 +119,7 @@ TooltipSimple.defaultProps = {
   showIcon: true,
   iconDescription: 'tooltip',
   text: 'Provide text',
+  prefix: 'bx',
 };
 
 export default TooltipSimple;

--- a/src/components/UnorderedList/UnorderedList.js
+++ b/src/components/UnorderedList/UnorderedList.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const UnorderedList = ({ children, className, nested, ...other }) => {
-  const classNames = classnames('bx--list--unordered', className, {
-    'bx--list--nested': nested,
+const UnorderedList = ({ children, className, nested, prefix, ...other }) => {
+  const classNames = classnames(`${prefix}--list--unordered`, className, {
+    [`${prefix}--list--nested`]: nested,
   });
   return (
     <ul className={classNames} {...other}>
@@ -28,10 +28,16 @@ UnorderedList.propTypes = {
    * Specify whether the list is nested, or not
    */
   nested: PropTypes.bool,
+
+  /**
+   * The selector prefix
+   */
+  prefix: PropTypes.string,
 };
 
 UnorderedList.defaultProps = {
   nested: false,
+  prefix: 'bx',
 };
 
 export default UnorderedList;

--- a/src/tools/wrapComponent.js
+++ b/src/tools/wrapComponent.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 const wrapComponent = ({ name, className, type }) => {
-  const Component = props => {
-    const componentClass = cx(className, props.className);
+  const Component = ({ className: baseClassName, prefix, ...other }) => {
+    const componentClass = cx(className && className(prefix), baseClassName);
     return React.createElement(type, {
-      ...props,
+      ...other,
       // Prevent Weird quirk where `cx` will evaluate to an empty string, '',
       // and so we have empty `class` attributes in the resulting markup
       // eslint-disable-next-line no-extra-boolean-cast
@@ -16,6 +16,10 @@ const wrapComponent = ({ name, className, type }) => {
   Component.displayName = name;
   Component.propTypes = {
     className: PropTypes.string,
+    prefix: PropTypes.string,
+  };
+  Component.defaultProps = {
+    prefix: 'bx',
   };
   return Component;
 };


### PR DESCRIPTION
Fixes #1359.

Please see [the documentation](https://github.com/asudoh/carbon-components-react/blob/91f8e1d/docs/components.md#css-class-prefix) for how applications can use the configurable CSS prefix.

#### Changelog

**New**

* `prefix` prop for all components that use CSS classes beginning with `bx--`.