### PR TITLE
chore(project): add dev engine check

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "sideEffects": false,
+  "devEngines": {
+    "node": "8.x",
+    "yarn": "1.x"
+  },
   "scripts": {
     "build": "node scripts/build.js",
     "build-storybook": "build-storybook",
@@ -14,6 +18,7 @@
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
     "lint": "eslint src",
+    "postinstall": "node scripts/check-dev-engines.js package.json",
     "precommit": "lint-staged",
     "prepublish": "yarn build",
     "prettier": "prettier --write \"**/*.{scss,css,js,md}\"",

--- a/scripts/check-dev-engines.js
+++ b/scripts/check-dev-engines.js
@@ -1,0 +1,100 @@
+/**
+ * Inspired by:
+ * https://github.com/facebook/fbjs/blob/8d416cbc0d6d37998afb9fb4f0af2c878f89726b/packages/fbjs-scripts/node/check-dev-engines.js#L1
+ */
+'use strict';
+
+const fs = require('fs');
+const assert = require('assert');
+const exec = require('child_process').exec;
+const semver = require('semver');
+const f = require('util').format;
+
+// Make sure we have a package.json to parse. Take it as the first argument
+// (actually the 3rd for argv).
+assert(
+  process.argv.length >= 3,
+  'Expected to receive a package.json file argument to parse'
+);
+
+const packageFilePath = process.argv[2];
+let packageData;
+try {
+  const packageFile = fs.readFileSync(packageFilePath, { encoding: 'utf-8' });
+  packageData = JSON.parse(packageFile);
+} catch (e) {
+  assert(
+    false,
+    f(
+      'Expected to be able to parse %s as JSON but we got this error instead: %s',
+      packageFilePath,
+      e
+    )
+  );
+}
+
+const devEngines = packageData.devEngines;
+
+if (devEngines.node !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.node),
+    f('devEngines.node (%s) is not a valid semver range', devEngines.node)
+  );
+  // Then actually check that our version satisfies
+  const nodeVersion = process.versions.node;
+  assert(
+    semver.satisfies(nodeVersion, devEngines.node),
+    f(
+      'Current node version is not supported for development, expected "%s" to satisfy "%s".',
+      nodeVersion,
+      devEngines.node
+    )
+  );
+}
+
+if (devEngines.npm !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.npm),
+    f('devEngines.npm (%s) is not a valid semver range', devEngines.npm)
+  );
+
+  // Then actually check that our version satisfies
+  exec('npm --version', function(err, stdout, stderr) {
+    assert(err === null, f('Failed to get npm version... %s'), stderr);
+
+    const npmVersion = stdout.trim();
+    assert(
+      semver.satisfies(npmVersion, devEngines.npm),
+      f(
+        'Current npm version is not supported for development, expected "%s" to satisfy "%s".',
+        npmVersion,
+        devEngines.npm
+      )
+    );
+  });
+}
+
+if (devEngines.yarn !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.yarn),
+    f('devEngines.yarn (%s) is not a valid semver range', devEngines.yarn)
+  );
+
+  // Then actually check that our version satisfies
+  exec('yarn --version', function(err, stdout, stderr) {
+    assert(err === null, f('Failed to get yarn version... %s'), stderr);
+
+    const yarnVersion = stdout.trim();
+    assert(
+      semver.satisfies(yarnVersion, devEngines.yarn),
+      f(
+        'Current yarn version is not supported for development, expected "%s" to satisfy "%s".',
+        yarnVersion,
+        devEngines.yarn
+      )
+    );
+  });
+}


### PR DESCRIPTION
Closes IBM/carbon-components-react#1462

Add support for `devEngines` field and a `postinstall` script that verifies the environment satisfies those requirements. Inspired by the usage in Facebook projects:

https://github.com/facebook/react/blob/master/package.json#L99

Source: https://github.com/facebook/fbjs/blob/master/packages/fbjs-scripts/node/check-dev-engines.js

#### Changelog

**New**

* `scripts/check-dev-engines.js` for verifying `yarn`, `npm`, and `node` if they are defined in `devEngines`

**Changed**

* `package.json` now specifies `devEngines.node` and `devEngines.yarn`

**Removed**
