### PR TITLE
docs(InlineLoading): add full UX example

### DIFF
--- a/src/components/InlineLoading/InlineLoading-story.js
+++ b/src/components/InlineLoading/InlineLoading-story.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
+
+import Button from '../Button';
 import InlineLoading from '../InlineLoading';
 
 const props = () => ({
@@ -24,12 +26,75 @@ storiesOf('InlineLoading', module)
     'Inline loading',
     withInfo({
       text: `
-        Inline Loading spinners are used when create, updating, or deleting an item.
-        They help notify users that their change is underway. Inline Loading has three states, LOADING, SUCCESS.
+        Inline Loading spinners are used when creating, updating, or deleting an item.
+        They help notify users that their change is underway, with different states for 'loading' and 'success'.
       `,
     })(() => (
       <div>
         <InlineLoading {...props()} />
       </div>
     ))
+  )
+  .add(
+    'UX example',
+    withInfo({
+      text: `
+        This is a full example of how to levarage the <InlineLoading /> component to create a nice user experience when submitting a form.
+
+        For the full source code of this example, check out the 'story' panel below.
+      `,
+    })(() => {
+      class MockSubmission extends PureComponent {
+        state = {
+          submitting: false,
+          success: false,
+        };
+
+        handleSubmit() {
+          this.setState({ submitting: true });
+
+          // Instead of making a real request, we mock it with a timer
+          setTimeout(() => {
+            this.setState({ submitting: false, success: true });
+
+            // To make submittable again, we reset the state after a bit so the user gets completion feedback
+            setTimeout(() => this.setState({ success: false }), 1500);
+          }, 2000);
+        }
+
+        render() {
+          const { children } = this.props;
+          const { submitting, success } = this.state;
+
+          const handleSubmit = this.handleSubmit.bind(this);
+
+          return children({
+            handleSubmit,
+            submitting,
+            success,
+          });
+        }
+      }
+
+      return (
+        <MockSubmission>
+          {({ handleSubmit, submitting, success }) => (
+            <div style={{ display: 'flex', width: '300px' }}>
+              <Button kind="secondary" disabled={submitting || success}>
+                Cancel
+              </Button>
+              {submitting || success ? (
+                <InlineLoading
+                  style={{ marginLeft: '1rem' }}
+                  description="Submitting..."
+                  success={success}
+                />
+              ) : (
+                <Button onClick={handleSubmit}>Submit</Button>
+              )}
+            </div>
+          )}
+        </MockSubmission>
+      );
+    })
   );


### PR DESCRIPTION
![screen recording 2018-10-21 at 06 11 pm](https://user-images.githubusercontent.com/17710824/47276507-fe112e80-d57c-11e8-8719-62b82f4c9733.gif)

This adds a full, mock example to the story for the `<InlineLoading />` component.

Previously, I feel like it was easy to miss the purpose of the component or how to use it properly. Being able to see it in a UX flow will hopefully give the consumer a better understanding of how to use the component in context.

#### Changelog

**New**

* Adds a 'full' example to the storybook for the `<InlineLoading />` component.

**Changed**

* N/A

**Removed**

* N/A
