### PR TITLE
feat(tools): add keyCode values and helper

### DIFF
--- a/src/tools/__tests__/keyCode-test.js
+++ b/src/tools/__tests__/keyCode-test.js
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { keyCodes, matches } from '../keyCode';
+
+// Used for the case of not matching
+const EQUAL_SIGN_KEY_CODE = 187;
+
+describe('keyCodes', () => {
+  describe('matches', () => {
+    let inputNode;
+    let eventListener;
+
+    beforeEach(() => {
+      inputNode = document.createElement('input');
+      inputNode.setAttribute('type', 'text');
+
+      eventListener = jest.fn();
+      inputNode.addEventListener('keydown', eventListener);
+
+      document.body.appendChild(inputNode);
+    });
+
+    afterEach(() => {
+      inputNode.removeEventListener('keydown', eventListener);
+      inputNode.parentNode.removeChild(inputNode);
+    });
+
+    it.each(Object.keys(keyCodes))('should match when using %s', key => {
+      const eventToMatch = new KeyboardEvent('keydown', {
+        keyCode: keyCodes[key],
+      });
+      inputNode.dispatchEvent(eventToMatch);
+      expect(matches(eventListener.mock.calls[0][0], [keyCodes[key]])).toBe(
+        true
+      );
+    });
+
+    it('should not match if no key code provided matches the event', () => {
+      const eventToNotMatch = new KeyboardEvent('keydown', {
+        keyCode: EQUAL_SIGN_KEY_CODE,
+      });
+      inputNode.dispatchEvent(eventToNotMatch);
+      expect(
+        matches(eventListener.mock.calls[0][0], [keyCodes.ENTER, keyCodes.UP])
+      ).toBe(false);
+    });
+
+    it('should match the first valid key code given', () => {
+      const eventToMatch = new KeyboardEvent('keydown', {
+        keyCode: keyCodes.UP,
+      });
+      inputNode.dispatchEvent(eventToMatch);
+      expect(
+        matches(eventListener.mock.calls[0][0], [keyCodes.ENTER, keyCodes.UP])
+      ).toBe(true);
+    });
+  });
+});

--- a/src/tools/keyCode.js
+++ b/src/tools/keyCode.js
@@ -1,6 +1,6 @@
 export const keyCodes = {
   TAB: 9,
-  RETURN: 13,
+  ENTER: 13,
   ESC: 27,
   SPACE: 32,
   PAGEUP: 33,

--- a/src/tools/keyCode.js
+++ b/src/tools/keyCode.js
@@ -1,0 +1,33 @@
+export const keyCodes = {
+  TAB: 9,
+  RETURN: 13,
+  ESC: 27,
+  SPACE: 32,
+  PAGEUP: 33,
+  PAGEDOWN: 34,
+  END: 35,
+  HOME: 36,
+  // These correspond to arrow keys, often expressed as ArrowXyz in the `key`
+  // field.
+  LEFT: 37,
+  UP: 38,
+  RIGHT: 39,
+  DOWN: 40,
+};
+
+/**
+ * Check to see if at least one key code matches the key code of the
+ * given event.
+ *
+ * @param {Event} event
+ * @param {Array<Number>} keyCodesToMatch
+ * @returns {boolean}
+ */
+export function matches(event, keyCodesToMatch) {
+  for (let i = 0; i < keyCodesToMatch.length; i++) {
+    if (keyCodesToMatch[i] === event.keyCode) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Adds a `matches` helper and `keyCodes` constant for making it easier to match keyboard events. Right now it uses `keyCode`, in the future we should support `key` and then `keyCode` as a fallback 😄 

#### Changelog

**New**

* `keyCode` module and tests
  * `keyCodes` constant to be used for asserting keyboard event values
  * `matches` for checking if an event would match at least one provided key code

**Changed**

**Removed**
