### PR TITLE
fix: Don't pass isSelected to tr dom node.

### DIFF
--- a/src/components/DataTable/TableRow.js
+++ b/src/components/DataTable/TableRow.js
@@ -9,7 +9,7 @@ const TableRow = props => {
     'bx--data-table-v2--selected': props.isSelected,
   });
   const cleanProps = {
-    ...omit(props, ['ariaLabel', 'onExpand', 'isExpanded']),
+    ...omit(props, ['ariaLabel', 'onExpand', 'isExpanded', 'isSelected']),
     className: className || undefined,
   };
   return <tr {...cleanProps} />;


### PR DESCRIPTION
Closes IBM/carbon-components-react#1398

#### Changelog

**New**

* Add isSelected to list of omitted props passed to tr dom elements.
