### PR TITLE
fix: Add double quotes to babelrc keys

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -3,10 +3,10 @@
     [
       "@babel/preset-env",
       {
-        targets: {
-          browsers: ["last 1 versions", "Firefox ESR"],
-        },
-      },
+        "targets": {
+          "browsers": ["last 1 versions", "Firefox ESR"]
+        }
+      }
     ],
     "@babel/preset-react"
   ],


### PR DESCRIPTION
Closes IBM/carbon-components-react#1497