### PR TITLE
fix(FileUploader): remove label tabIndex

### DIFF
--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -45,7 +45,7 @@ const props = {
         false
       ),
       role: text('ARIA role of the button (role)', ''),
-      tabIndex: number('Tab index (tabIndex)', -1),
+      tabIndex: number('Tab index (tabIndex)', 0),
       onChange: action('onChange'),
     };
   },

--- a/src/components/FileUploader/FileUploader-test.js
+++ b/src/components/FileUploader/FileUploader-test.js
@@ -22,7 +22,7 @@ describe('FileUploaderButton', () => {
 
   describe('Renders as expected with default props', () => {
     it('renders with expected className', () => {
-      expect(mountWrapper.children().hasClass('bx--file')).toBe(true);
+      expect(mountWrapper.children().hasClass('bx--btn')).toBe(true);
     });
 
     it('renders with given className', () => {

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -130,7 +130,7 @@ export class FileUploaderButton extends Component {
       ...other
     } = this.props;
     const classes = classNames({
-      'bx--file': true,
+      'bx--btn': true,
       [className]: className,
     });
 
@@ -140,15 +140,14 @@ export class FileUploaderButton extends Component {
       <div
         role="button"
         tabIndex="0"
-        className={classes}
+        className={`bx--btn--${buttonKind} ${classes}`}
         onKeyDown={evt => {
           if (evt.which === 13 || evt.which === 32) {
             this.input.click();
           }
         }}>
         <label
-          className={`bx--btn bx--btn--${buttonKind}`}
-          tabIndex={tabIndex}
+          tabIndex={tabIndex || null}
           htmlFor={this.uid}
           role={role}
           {...other}>

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -131,6 +131,7 @@ export class FileUploaderButton extends Component {
     } = this.props;
     const classes = classNames({
       'bx--btn': true,
+      [`bx--btn--${buttonKind}`]: true,
       [className]: className,
     });
 
@@ -140,7 +141,7 @@ export class FileUploaderButton extends Component {
       <div
         role="button"
         tabIndex="0"
-        className={`bx--btn--${buttonKind} ${classes}`}
+        className={classes}
         onKeyDown={evt => {
           if (evt.which === 13 || evt.which === 32) {
             this.input.click();

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -140,18 +140,14 @@ export class FileUploaderButton extends Component {
     return (
       <div
         role="button"
-        tabIndex="0"
+        tabIndex={tabIndex || 0}
         className={classes}
         onKeyDown={evt => {
           if (evt.which === 13 || evt.which === 32) {
             this.input.click();
           }
         }}>
-        <label
-          tabIndex={tabIndex || null}
-          htmlFor={this.uid}
-          role={role}
-          {...other}>
+        <label htmlFor={this.uid} role={role} {...other}>
           {this.state.labelText}
         </label>
         <input


### PR DESCRIPTION
Closes IBM/carbon-components-react#1334

The FileUploaderButton was allowing users to focus both on the wrapper `div` and the `label` using the keyboard

#### Changelog

**Changed**

* moved the button styles off of `<FileUploaderButton>`'s `label` and placed it on the wrapper `div` instead
* set the value of the `label`'s `tabIndex` to `null` if the prop value is falsy so that it won't be focusable