### PR TITLE
fix(Toggle): Use uncontrolled Toggle in Storybook

### DIFF
--- a/src/components/Toggle/Toggle-story.js
+++ b/src/components/Toggle/Toggle-story.js
@@ -2,13 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, text } from '@storybook/addon-knobs';
 import Toggle from '../Toggle';
 import ToggleSkeleton from '../Toggle/Toggle.Skeleton';
 
 const toggleProps = () => ({
   className: 'some-class',
-  toggled: boolean('Toggled (toggled)', false),
   labelA: text('Label for untoggled state (labelA)', 'Off'),
   labelB: text('Label for toggled state (labelB)', 'On'),
   onChange: action('onChange'),
@@ -18,13 +17,31 @@ const toggleProps = () => ({
 storiesOf('Toggle', module)
   .addDecorator(withKnobs)
   .add(
-    'Default',
+    'toggled',
     withInfo({
       text: `
         Toggles are controls that are used to quickly switch between two possible states. The example below shows
         an uncontrolled Toggle component. To use the Toggle component as a controlled component, set the toggled property.
         Setting the toggled property will allow you to change the value dynamically, whereas setting the defaultToggled
-        prop will only set the value initially.
+        prop will only set the value initially. This example has defaultToggled set to true.
+      `,
+    })(() => (
+      <Toggle
+        defaultToggled
+        {...toggleProps()}
+        className="some-class"
+        id="toggle-1"
+      />
+    ))
+  )
+  .add(
+    'untoggled',
+    withInfo({
+      text: `
+        Toggles are controls that are used to quickly switch between two possible states. The example below shows
+        an uncontrolled Toggle component. To use the Toggle component as a controlled component, set the toggled property.
+        Setting the toggled property will allow you to change the value dynamically, whereas setting the defaultToggled
+        prop will only set the value initially. This example has defaultToggled set to false.
       `,
     })(() => <Toggle {...toggleProps()} className="some-class" id="toggle-1" />)
   )

--- a/src/components/ToggleSmall/ToggleSmall-story.js
+++ b/src/components/ToggleSmall/ToggleSmall-story.js
@@ -2,13 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, text } from '@storybook/addon-knobs';
 import ToggleSmall from '../ToggleSmall';
 import ToggleSmallSkeleton from '../ToggleSmall/ToggleSmall.Skeleton';
 
 const toggleProps = () => ({
   className: 'some-class',
-  toggled: boolean('Toggled (toggled)', false),
   ariaLabel: text('ARIA label (ariaLabel)', 'Label Name'),
   onChange: action('onChange'),
   onToggle: action('onToggle'),
@@ -17,14 +16,33 @@ const toggleProps = () => ({
 storiesOf('ToggleSmall', module)
   .addDecorator(withKnobs)
   .add(
-    'Default',
+    'toggled',
     withInfo({
       text: `
         Toggles are controls that are used to quickly switch between two possible states. The example below shows
         an uncontrolled Toggle component. To use the Toggle component as a controlled component, set the toggled property.
         Setting the toggled property will allow you to change the value dynamically, whereas setting the defaultToggled
-        prop will only set the value initially. Small toggles may be used when there is not enough space for a regular sized toggle. This issue is most
-        commonly found in tables.
+        prop will only set the value initially. This example has defaultToggled set to true. Small toggles may be used
+        when there is not enough space for a regular sized toggle. This issue is most commonly found in tables.
+      `,
+    })(() => (
+      <ToggleSmall
+        defaultToggled
+        {...toggleProps()}
+        className="some-class"
+        id="toggle-1"
+      />
+    ))
+  )
+  .add(
+    'untoggled',
+    withInfo({
+      text: `
+        Toggles are controls that are used to quickly switch between two possible states. The example below shows
+        an uncontrolled Toggle component. To use the Toggle component as a controlled component, set the toggled property.
+        Setting the toggled property will allow you to change the value dynamically, whereas setting the defaultToggled
+        prop will only set the value initially. This example has defaultToggled set to false. Small toggles may be used
+        when there is not enough space for a regular sized toggle. This issue is most commonly found in tables.
       `,
     })(() => (
       <ToggleSmall {...toggleProps()} className="some-class" id="toggle-1" />


### PR DESCRIPTION
Closes IBM/carbon-components-react#1524

The Toggle control in the Storybook was a controlled component, which made it not work interactively. The text in the small Toggle example refers to an uncontrolled component and the Checkbox examples use an uncontrolled component with different examples for the defaultChecked prop so I modeled the Toggles in the same way.

#### Changelog

**Changed**

* Toggle and ToggleSmall stories use an uncontrolled component
