### PR TITLE
fix(number-input): add helpertext class when helper text is present

### DIFF
--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -147,6 +147,7 @@ export default class NumberInput extends Component {
 
     const numberInputClasses = classNames('bx--number', className, {
       'bx--number--light': light,
+      'bx--number--helpertext': helperText,
     });
 
     const props = {


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-react/issues/1533

Adds `bx--number--helpertext` when `helperText` is present
