### PR TITLE
feat(Notification): add experimental notification

### DIFF
--- a/src/components/Notification/Notification-story.js
+++ b/src/components/Notification/Notification-story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import Notification, {
   ToastNotification,
@@ -14,9 +13,8 @@ const kinds = {
   'Success (success)': 'success',
   'Warning (warning)': 'warning',
 };
-
 const notificationProps = () => ({
-  kind: select('The notification kind (kind)', kinds, 'error'),
+  kind: select('The notification kind (kind)', kinds, 'info'),
   role: text('ARIA role (role)', 'alert'),
   title: text('Title (title)', 'Notification title'),
   subtitle: text('Subtitle (subtitle)', 'Subtitle text goes here.'),

--- a/src/components/Notification/Notification-test.js
+++ b/src/components/Notification/Notification-test.js
@@ -42,7 +42,7 @@ describe('NotificationButton', () => {
 
       it('icon should have correct className by default', () => {
         const icon = wrapper.find('Icon');
-        expect(icon.hasClass('bx--toast-notification__icon')).toBe(true);
+        expect(icon.hasClass('bx--toast-notification__close-icon')).toBe(true);
       });
     });
 
@@ -198,14 +198,22 @@ describe('InlineNotification', () => {
       expect(inline.find(Icon).some({ icon: iconErrorSolid })).toBe(true);
     });
 
+    // removed because of a11y warning icon workaround, depending on TODO: for @carbon/icons-react
+    // it('renders warning notification with matching kind and <icon name=""> values', () => {
+    //   inline.setProps({ kind: 'warning' });
+    //   expect(inline.find(Icon).some({ icon: iconWarningSolid })).toBe(true);
+    // });
+
     it('renders warning notification with matching kind and <icon name=""> values', () => {
       inline.setProps({ kind: 'warning' });
-      expect(inline.find(Icon).some({ icon: iconWarningSolid })).toBe(true);
+      expect(
+        inline.children('.bx--inline-notification__details').exists()
+      ).toBe(true);
     });
 
-    it('renders info notification with matching kind and <icon name=""> values', () => {
+    it('renders info notification with matching kind value but without <icon name="">', () => {
       inline.setProps({ kind: 'info' });
-      expect(inline.find(Icon).some({ icon: iconInfoSolid })).toBe(true);
+      expect(inline.find(Icon).some({ icon: iconInfoSolid })).toBe(false);
     });
 
     it('renders HTML for inline notifications when caption does not exist', () => {

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -9,6 +9,8 @@ import {
   iconWarningSolid,
 } from 'carbon-icons';
 import Icon from '../Icon';
+// temporary workaround for a11y warning icon. TODO: for @carbon/icons-react
+import a11yIconWarningSolid from './a11yIconWarningSolid';
 
 export class NotificationButton extends Component {
   static propTypes = {
@@ -185,44 +187,12 @@ export class ToastNotification extends Component {
       { [`bx--toast-notification--${this.props.kind}`]: this.props.kind },
       className
     );
-    const a11yWarningIcon = (
-      <svg
-        class={`bx--${notificationType}-notification__icon`}
-        width="20"
-        height="20"
-        xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <path
-            d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
-            id="a"
-          />
-          <path
-            d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z"
-            id="b"
-          />
-        </defs>
-        <g fill="none" fill-rule="evenodd">
-          <path
-            d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
-            fill="#FDD13A"
-          />
-          <g>
-            <path
-              d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z"
-              fill="#171717"
-              fill-rule="nonzero"
-            />
-          </g>
-          <path d="M0 0h20v20H0z" />
-        </g>
-      </svg>
-    );
     const NotificationIcon = kind => {
       switch (kind) {
         case 'info':
           return null;
         case 'warning':
-          return a11yWarningIcon;
+          return a11yIconWarningSolid(notificationType);
         default:
           return (
             <Icon
@@ -318,45 +288,12 @@ export class InlineNotification extends Component {
       className
     );
 
-    // temporary workaround for a11y warning icon. TODO: for @carbon/icons-react
-    const a11yWarningIcon = (
-      <svg
-        class={`bx--${notificationType}-notification__icon`}
-        width="20"
-        height="20"
-        xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <path
-            d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
-            id="a"
-          />
-          <path
-            d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z"
-            id="b"
-          />
-        </defs>
-        <g fill="none" fill-rule="evenodd">
-          <path
-            d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
-            fill="#FDD13A"
-          />
-          <g>
-            <path
-              d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z"
-              fill="#171717"
-              fill-rule="nonzero"
-            />
-          </g>
-          <path d="M0 0h20v20H0z" />
-        </g>
-      </svg>
-    );
     const NotificationIcon = kind => {
       switch (kind) {
         case 'info':
           return null;
         case 'warning':
-          return a11yWarningIcon;
+          return a11yIconWarningSolid(notificationType);
         default:
           return (
             <Icon

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -190,6 +190,12 @@ export class ToastNotification extends Component {
 
     return (
       <div {...other} role={role} kind={kind} className={classes}>
+        <Icon
+          description={this.props.iconDescription}
+          className="bx--toast-notification__icon"
+          aria-label="close"
+          icon={this.useIcon(kind)}
+        />
         <NotificationTextDetails
           title={title}
           subtitle={subtitle}

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -52,7 +52,7 @@ export class NotificationButton extends Component {
     );
 
     const iconClasses = classNames({
-      'bx--toast-notification-icon': notificationType === 'toast',
+      'bx--toast-notification__close-icon': notificationType === 'toast',
       'bx--inline-notification__close-icon': notificationType === 'inline',
     });
 

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -42,7 +42,6 @@ export class NotificationButton extends Component {
       notificationType,
       ...other
     } = this.props;
-
     const buttonClasses = classNames(
       {
         'bx--toast-notification__close-button': notificationType === 'toast',
@@ -50,12 +49,10 @@ export class NotificationButton extends Component {
       },
       className
     );
-
     const iconClasses = classNames({
-      'bx--toast-notification__icon': notificationType === 'toast',
+      'bx--toast-notification-icon': notificationType === 'toast',
       'bx--inline-notification__close-icon': notificationType === 'inline',
     });
-
     return (
       <button {...other} type={type} className={buttonClasses}>
         <Icon
@@ -77,17 +74,14 @@ export class NotificationTextDetails extends Component {
     caption: PropTypes.node,
     notificationType: PropTypes.oneOf(['toast', 'inline']),
   };
-
   static defaultProps = {
     title: 'title',
     subtitle: 'subtitle',
     caption: 'caption',
     notificationType: 'toast',
   };
-
   render() {
     const { title, subtitle, caption, notificationType, ...other } = this.props;
-
     if (notificationType === 'toast') {
       return (
         <div {...other} className="bx--toast-notification__details">
@@ -97,7 +91,6 @@ export class NotificationTextDetails extends Component {
         </div>
       );
     }
-
     if (notificationType === 'inline') {
       return (
         <div {...other} className="bx--inline-notification__text-wrapper">
@@ -158,7 +151,6 @@ export class ToastNotification extends Component {
   useIcon = kindProp =>
     ({
       error: iconErrorSolid,
-      info: iconInfoSolid,
       success: iconCheckmarkSolid,
       warning: iconWarningSolid,
     }[kindProp]);
@@ -190,12 +182,14 @@ export class ToastNotification extends Component {
 
     return (
       <div {...other} role={role} kind={kind} className={classes}>
-        <Icon
-          description={this.props.iconDescription}
-          className="bx--toast-notification__icon"
-          aria-label="close"
-          icon={this.useIcon(kind)}
-        />
+        {kind === 'info' ? null : (
+          <Icon
+            description={this.props.iconDescription}
+            className="bx--toast-notification__icon"
+            aria-label="close"
+            icon={this.useIcon(kind)}
+          />
+        )}
         <NotificationTextDetails
           title={title}
           subtitle={subtitle}
@@ -248,7 +242,6 @@ export class InlineNotification extends Component {
   useIcon = kindProp =>
     ({
       error: iconErrorSolid,
-      info: iconInfoSolid,
       success: iconCheckmarkSolid,
       warning: iconWarningSolid,
     }[kindProp]);
@@ -280,12 +273,14 @@ export class InlineNotification extends Component {
     return (
       <div {...other} role={role} kind={kind} className={classes}>
         <div className="bx--inline-notification__details">
-          <Icon
-            description={this.props.iconDescription}
-            className="bx--inline-notification__icon"
-            aria-label="close"
-            icon={this.useIcon(kind)}
-          />
+          {kind === 'info' ? null : (
+            <Icon
+              description={this.props.iconDescription}
+              className="bx--inline-notification__icon"
+              aria-label="close"
+              icon={this.useIcon(kind)}
+            />
+          )}
           <NotificationTextDetails
             title={title}
             subtitle={subtitle}
@@ -294,6 +289,7 @@ export class InlineNotification extends Component {
         </div>
         {!hideCloseButton && (
           <NotificationButton
+            iconDescription={iconDescription}
             notificationType={notificationType}
             onClick={this.handleCloseButtonClick}
           />

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -152,14 +152,13 @@ export class ToastNotification extends Component {
     ({
       error: iconErrorSolid,
       success: iconCheckmarkSolid,
-      warning: iconWarningSolid,
+      warning: iconErrorSolid,
     }[kindProp]);
 
   render() {
     if (!this.state.open) {
       return null;
     }
-
     const {
       role,
       notificationType,
@@ -173,23 +172,64 @@ export class ToastNotification extends Component {
       hideCloseButton,
       ...other
     } = this.props;
-
     const classes = classNames(
       'bx--toast-notification',
       { [`bx--toast-notification--${this.props.kind}`]: this.props.kind },
       className
     );
+    const a11yWarningIcon = (
+      <svg
+        class={`bx--${notificationType}-notification__icon`}
+        width="20"
+        height="20"
+        xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <path
+            d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
+            id="a"
+          />
+          <path
+            d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z"
+            id="b"
+          />
+        </defs>
+        <g fill="none" fill-rule="evenodd">
+          <path
+            d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
+            fill="#FDD13A"
+          />
+          <g>
+            <path
+              d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z"
+              fill="#171717"
+              fill-rule="nonzero"
+            />
+          </g>
+          <path d="M0 0h20v20H0z" />
+        </g>
+      </svg>
+    );
+    const NotificationIcon = kind => {
+      switch (kind) {
+        case 'info':
+          return null;
+        case 'warning':
+          return a11yWarningIcon;
+        default:
+          return (
+            <Icon
+              description={this.props.iconDescription}
+              className="bx--toast-notification__icon"
+              aria-label="close"
+              icon={this.useIcon(kind)}
+            />
+          );
+      }
+    };
 
     return (
       <div {...other} role={role} kind={kind} className={classes}>
-        {kind === 'info' ? null : (
-          <Icon
-            description={this.props.iconDescription}
-            className="bx--toast-notification__icon"
-            aria-label="close"
-            icon={this.useIcon(kind)}
-          />
-        )}
+        {NotificationIcon(kind)}
         <NotificationTextDetails
           title={title}
           subtitle={subtitle}
@@ -270,17 +310,61 @@ export class InlineNotification extends Component {
       className
     );
 
-    return (
-      <div {...other} role={role} kind={kind} className={classes}>
-        <div className="bx--inline-notification__details">
-          {kind === 'info' ? null : (
+    // temporary workaround for a11y warning icon. TODO: for @carbon/icons-react
+    const a11yWarningIcon = (
+      <svg
+        class={`bx--${notificationType}-notification__icon`}
+        width="20"
+        height="20"
+        xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <path
+            d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
+            id="a"
+          />
+          <path
+            d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z"
+            id="b"
+          />
+        </defs>
+        <g fill="none" fill-rule="evenodd">
+          <path
+            d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
+            fill="#FDD13A"
+          />
+          <g>
+            <path
+              d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z"
+              fill="#171717"
+              fill-rule="nonzero"
+            />
+          </g>
+          <path d="M0 0h20v20H0z" />
+        </g>
+      </svg>
+    );
+    const NotificationIcon = kind => {
+      switch (kind) {
+        case 'info':
+          return null;
+        case 'warning':
+          return a11yWarningIcon;
+        default:
+          return (
             <Icon
               description={this.props.iconDescription}
-              className="bx--inline-notification__icon"
+              className="bx--toast-notification__icon"
               aria-label="close"
               icon={this.useIcon(kind)}
             />
-          )}
+          );
+      }
+    };
+
+    return (
+      <div {...other} role={role} kind={kind} className={classes}>
+        <div className="bx--inline-notification__details">
+          {NotificationIcon(kind)}
           <NotificationTextDetails
             title={title}
             subtitle={subtitle}

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -42,6 +42,7 @@ export class NotificationButton extends Component {
       notificationType,
       ...other
     } = this.props;
+
     const buttonClasses = classNames(
       {
         'bx--toast-notification__close-button': notificationType === 'toast',
@@ -49,10 +50,12 @@ export class NotificationButton extends Component {
       },
       className
     );
+
     const iconClasses = classNames({
       'bx--toast-notification-icon': notificationType === 'toast',
       'bx--inline-notification__close-icon': notificationType === 'inline',
     });
+
     return (
       <button {...other} type={type} className={buttonClasses}>
         <Icon
@@ -74,12 +77,14 @@ export class NotificationTextDetails extends Component {
     caption: PropTypes.node,
     notificationType: PropTypes.oneOf(['toast', 'inline']),
   };
+
   static defaultProps = {
     title: 'title',
     subtitle: 'subtitle',
     caption: 'caption',
     notificationType: 'toast',
   };
+
   render() {
     const { title, subtitle, caption, notificationType, ...other } = this.props;
     if (notificationType === 'toast') {
@@ -91,6 +96,7 @@ export class NotificationTextDetails extends Component {
         </div>
       );
     }
+
     if (notificationType === 'inline') {
       return (
         <div {...other} className="bx--inline-notification__text-wrapper">
@@ -152,13 +158,14 @@ export class ToastNotification extends Component {
     ({
       error: iconErrorSolid,
       success: iconCheckmarkSolid,
-      warning: iconErrorSolid,
+      warning: iconWarningSolid,
     }[kindProp]);
 
   render() {
     if (!this.state.open) {
       return null;
     }
+
     const {
       role,
       notificationType,
@@ -172,6 +179,7 @@ export class ToastNotification extends Component {
       hideCloseButton,
       ...other
     } = this.props;
+
     const classes = classNames(
       'bx--toast-notification',
       { [`bx--toast-notification--${this.props.kind}`]: this.props.kind },
@@ -353,7 +361,7 @@ export class InlineNotification extends Component {
           return (
             <Icon
               description={this.props.iconDescription}
-              className="bx--toast-notification__icon"
+              className="bx--inline-notification__icon"
               aria-label="close"
               icon={this.useIcon(kind)}
             />

--- a/src/components/Notification/a11yIconWarningSolid.js
+++ b/src/components/Notification/a11yIconWarningSolid.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const a11yWarningIcon = notificationType => (
+  <svg
+    class={`bx--${notificationType}-notification__icon`}
+    width="20"
+    height="20"
+    xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <path
+        d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
+        id="a"
+      />
+      <path
+        d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z"
+        id="b"
+      />
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+      <path
+        d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
+        fill="#FDD13A"
+      />
+      <g>
+        <path
+          d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z"
+          fill="#171717"
+          fill-rule="nonzero"
+        />
+      </g>
+      <path d="M0 0h20v20H0z" />
+    </g>
+  </svg>
+);
+
+export default a11yWarningIcon;


### PR DESCRIPTION
TODO:

* [x] fix failing test due to a11y warning icon workaround

---

Closes IBM/carbon-components-react#1532

This PR will add support for the experimental `<InlineNotification />` and `<ToastNotification />` components

#### Changelog

**New**

* add support for experimental `<Notification />` component

**Changed**

* fixed notification icons not appearing for `<ToastNotification />`
* conditionally render icons based on notification type (based on new notification guidelines)

---

An open question: is there a reason for separating the inline and toast notification components rather than consolidating them in a common `<Notification />` component? It seems aside from `timeout`, `caption`, and minor markup changes, the majority of the code is shared between the two types of notifications. Would it be worth deduplicating this code?