### PR TITLE
fix(CodeSnippet): inline type was missing onClick handler

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet-test.js
+++ b/src/components/CodeSnippet/CodeSnippet-test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import CodeSnippet from '../CodeSnippet';
 import CodeSnippetSkeleton from '../CodeSnippet/CodeSnippet.Skeleton';
-import { shallow } from 'enzyme';
+import Copy from '../Copy';
+import CopyButton from '../CopyButton';
+import { shallow, mount } from 'enzyme';
 
 describe('Code Snippet', () => {
   describe('Renders as expected', () => {
@@ -22,6 +24,24 @@ describe('Code Snippet', () => {
 
     it('should all for custom classes to be applied', () => {
       expect(snippet.hasClass('some-class')).toEqual(true);
+    });
+  });
+
+  describe('Triggers appropriate events', () => {
+    it('should call the click handler', () => {
+      const onClick = jest.fn();
+      const clickWrapper = mount(<CodeSnippet onClick={onClick} />);
+      clickWrapper.find(CopyButton).simulate('click');
+      expect(onClick).toBeCalled();
+    });
+
+    it('should call the click handler with type="inline"', () => {
+      const onClick = jest.fn();
+      const clickWrapper = mount(
+        <CodeSnippet type={'inline'} onClick={onClick} />
+      );
+      clickWrapper.find(Copy).simulate('click');
+      expect(onClick).toBeCalled();
     });
   });
 });

--- a/src/components/CodeSnippet/CodeSnippet.js
+++ b/src/components/CodeSnippet/CodeSnippet.js
@@ -172,6 +172,7 @@ export default class CodeSnippet extends Component {
     if (type === 'inline') {
       return (
         <Copy
+          onClick={onClick}
           className={codeSnippetClasses}
           aria-label={copyLabel}
           feedback={feedback}>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1527

On the type="inline" variant of the CodeSnippet the Copy button was missing the onClick handler.

#### Changelog

**Changed**

* CodeSnippet: Added onClick handler for Copy button when type="inline"
