### PR TITLE
chore: reorder storybook addons to show story first

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,9 +1,9 @@
-import '@storybook/addon-actions/register';
+import '@storybook/addon-storysource/register';
 import '@storybook/addon-knobs/register';
+import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
 import '@storybook/addon-a11y/register';
 import '@storybook/addon-options/register';
-import '@storybook/addon-storysource/register';
 
 // Community addons
 import 'storybook-readme/register';


### PR DESCRIPTION
Storybook 4 doesn't appear to show the component name in the show info tab anymore. This re-orders the add-ons to show "story" first when someone view a component to hopefully reduce some confusion 

<img width="533" alt="screen shot 2018-11-09 at 8 20 51 am" src="https://user-images.githubusercontent.com/2753488/48267654-82c2d000-e3f8-11e8-84e5-2a7f5304bed1.png">


Side note: will `chore:` trigger a re-release of the storybook or do I need to set to `fix` ?