### PR TITLE
docs: Update commit message instructions and links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Want to contribute to this repository? Please read below first:
 * [Doc Fixes](#doc-fixes)
 * [Submission Guidelines](#submission-guidelines)
 * [Coding Standards](#coding-standards)
-* [Commit Message Guidelines](#commit-message-guidlines)
+* [Commit Message Guidelines](#commit-message-guidelines)
 * [Testing](#testing)
 
 ## Issues and Bugs
@@ -121,7 +121,11 @@ If you decide to not install a linter addon, or cannot, you can run `yarn lint` 
 
 ## Commit Message Guidelines
 
-We use commit message guidelines based on the [Angular Commit Conventions](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit).
+We use commit message guidelines based on the [Angular Commit Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits).
+
+Please stick to the following format: `git commit -m "<type>(<scope>): <message>"`
+* Replace `<type>` with one of following: feat, fix, docs, style, refactor, perf, test, chore, revert.
+* The `(<scope>)` is optional and could be anything specifying the place of the commit change.
 
 After the commit message has been submitted, it is checked by [`husky`](https://www.npmjs.com/package/husky) and [`validate-commit-msg`](https://www.npmjs.com/package/validate-commit-msg) to ensure it is syntactically correct.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -124,6 +124,7 @@ If you decide to not install a linter addon, or cannot, you can run `yarn lint` 
 We use commit message guidelines based on the [Angular Commit Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits).
 
 Please stick to the following format: `git commit -m "<type>(<scope>): <message>"`
+
 * Replace `<type>` with one of following: feat, fix, docs, style, refactor, perf, test, chore, revert.
 * The `(<scope>)` is optional and could be anything specifying the place of the commit change.
 


### PR DESCRIPTION
Fixes the internal and external links. Add the most significant requirements to our own docs.