### PR TITLE
feat(data-table): add shouldShowBorder prop to data-table

### DIFF
--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -7,6 +7,7 @@ const readmeURL = 'https://goo.gl/dq6CEK';
 
 const props = () => ({
   short: boolean('Short variant (short)', false),
+  shouldShowBorder: boolean('Table Border variant (shouldShowBorder)', true),
 });
 
 storiesOf('DataTable', module)
@@ -36,7 +37,7 @@ storiesOf('DataTable', module)
       info: {
         text: `
           DataTable with toolbar and filtering.
-  
+
           You can find more detailed information surrounding usage of this component
           at the following url: ${readmeURL}
         `,
@@ -50,7 +51,7 @@ storiesOf('DataTable', module)
       info: {
         text: `
           DataTable with sorting
-  
+
           You can find more detailed information surrounding usage of this component
           at the following url: ${readmeURL}
         `,
@@ -64,7 +65,7 @@ storiesOf('DataTable', module)
       info: {
         text: `
           DataTable with selection
-  
+
           You can find more detailed information surrounding usage of this component
           at the following url: ${readmeURL}
         `,
@@ -78,7 +79,7 @@ storiesOf('DataTable', module)
       info: {
         text: `
             DataTable with expansion
-    
+
             You can find more detailed information surrounding usage of this component
             at the following url: ${readmeURL}
           `,
@@ -94,15 +95,15 @@ storiesOf('DataTable', module)
             Uses <TableToolbar> alongside <TableBatchActions> and <TableBatchAction>
             to create the toolbar and placeholder for where the batch action menu will
             be displayed.
-    
+
             You can use the \`getBatchActionProps\` prop getter on the
             <TableBatchActions> component to have it wire up the ghost menu for you.
-    
+
             Individual <TableBatchAction> components take in any kind of event handler
             prop that you would expect to use, like \`onClick\`. You can use these
             alongside the \`selectedRows\` property in your \`render\` prop function
             to pass along this info to your batch action handler.
-    
+
             You can find more detailed information surrounding usage of this component
             at the following url: ${readmeURL}
           `,

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -95,6 +95,11 @@ export default class DataTable extends React.Component {
      * Optional boolean to create a short data table.
      */
     short: PropTypes.bool,
+
+    /**
+     * Optional boolean to remove borders from data table.
+     */
+    shouldShowBorder: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -103,6 +108,7 @@ export default class DataTable extends React.Component {
     locale: 'en',
     translateWithId,
     short: false,
+    shouldShowBorder: true,
   };
 
   static translationKeys = Object.values(translationKeys);
@@ -249,9 +255,10 @@ export default class DataTable extends React.Component {
    * Helper utility to get the Table Props.
    */
   getTableProps = () => {
-    const { short } = this.props;
+    const { short, shouldShowBorder } = this.props;
     return {
       short,
+      shouldShowBorder,
     };
   };
 

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -2,10 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-export const Table = ({ zebra, className, children, short, ...other }) => {
+export const Table = ({
+  zebra,
+  className,
+  children,
+  short,
+  shouldShowBorder,
+  ...other
+}) => {
   const componentClass = cx('bx--data-table-v2', className, {
     'bx--data-table-v2--zebra': zebra,
     'bx--data-table-v2--short': short,
+    'bx--data-table-v2--no-border': !shouldShowBorder,
   });
   return (
     <table {...other} className={componentClass}>
@@ -29,11 +37,17 @@ Table.propTypes = {
    * `true` for short data table.
    */
   short: PropTypes.bool,
+
+  /**
+   * `true` for data table without borders.
+   */
+  shouldShowBorder: PropTypes.bool,
 };
 
 Table.defaultProps = {
   zebra: true,
   short: false,
+  shouldShowBorder: true,
 };
 
 export default Table;

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -54,6 +54,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
           >
             <Table
               short={false}
+              shouldShowBorder={true}
               zebra={true}
             >
               <TableHead>
@@ -97,6 +98,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
   }
   rows={Array []}
   short={false}
+  shouldShowBorder={true}
   sortRow={[Function]}
   translateWithId={[Function]}
 >
@@ -113,6 +115,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
       </h4>
       <Table
         short={false}
+        shouldShowBorder={true}
         zebra={true}
       >
         <table
@@ -459,6 +462,7 @@ exports[`DataTable selection should render 1`] = `
           >
             <Table
               short={false}
+              shouldShowBorder={true}
               zebra={true}
             >
               <TableHead>
@@ -566,6 +570,7 @@ exports[`DataTable selection should render 1`] = `
     ]
   }
   short={false}
+  shouldShowBorder={true}
   sortRow={[Function]}
   translateWithId={[Function]}
 >
@@ -582,6 +587,7 @@ exports[`DataTable selection should render 1`] = `
       </h4>
       <Table
         short={false}
+        shouldShowBorder={true}
         zebra={true}
       >
         <table
@@ -1187,6 +1193,7 @@ exports[`DataTable should render 1`] = `
             </TableToolbar>
             <Table
               short={false}
+              shouldShowBorder={true}
               zebra={true}
             >
               <TableHead>
@@ -1265,6 +1272,7 @@ exports[`DataTable should render 1`] = `
     ]
   }
   short={false}
+  shouldShowBorder={true}
   sortRow={[Function]}
   translateWithId={[Function]}
 >
@@ -1708,6 +1716,7 @@ exports[`DataTable should render 1`] = `
       </TableToolbar>
       <Table
         short={false}
+        shouldShowBorder={true}
         zebra={true}
       >
         <table

--- a/src/components/DataTable/__tests__/__snapshots__/Table-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/Table-test.js.snap
@@ -4,6 +4,7 @@ exports[`DataTable.Table should render 1`] = `
 <Table
   className="custom-class"
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableBody-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableBody-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableBody should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableCell-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableCell-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableCell should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandHeader-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableExpandHeader should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableExpandRow should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableHead-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHead-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableHead should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableHeader should have an active and ascending class if sorting by ASC 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table
@@ -37,6 +38,7 @@ exports[`DataTable.TableHeader should have an active and ascending class if sort
 exports[`DataTable.TableHeader should have an active class if it is the sort header and the sort state is not NONE 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table
@@ -71,6 +73,7 @@ exports[`DataTable.TableHeader should have an active class if it is the sort hea
 exports[`DataTable.TableHeader should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table
@@ -105,6 +108,7 @@ exports[`DataTable.TableHeader should render 1`] = `
 exports[`DataTable.TableHeader should render 2`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableRow-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableRow should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableSelectAll should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DataTable.TableSelectRow should render 1`] = `
 <Table
   short={false}
+  shouldShowBorder={true}
   zebra={true}
 >
   <table

--- a/src/components/DataTable/stories/default.js
+++ b/src/components/DataTable/stories/default.js
@@ -21,11 +21,12 @@ import DataTable, {
 } from '../../DataTable';
 import { batchActionClick, initialRows, headers } from './shared';
 
-export default ({ short }) => (
+export default ({ short, shouldShowBorder }) => (
   <DataTable
     rows={initialRows}
     headers={headers}
     short={short}
+    shouldShowBorder={shouldShowBorder}
     render={({
       rows,
       headers,


### PR DESCRIPTION
Adds a prop to data table to toggle the no-border modifier class for users that want to apply the bx--data-table-v2--no-border class.

Loosely related to: IBM/carbon-components#1436