### PR TITLE
Fix number input controls misalignment

### DIFF
--- a/src/components/NumberInput/NumberInput-test.js
+++ b/src/components/NumberInput/NumberInput-test.js
@@ -103,6 +103,9 @@ describe('NumberInput', () => {
         expect(wrapper.find('label').hasClass('bx--visually-hidden')).toEqual(
           true
         );
+        expect(
+          wrapper.find('.bx--number').hasClass('bx--number--nolabel')
+        ).toEqual(true);
       });
 
       describe('initial rendering', () => {

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -148,6 +148,7 @@ export default class NumberInput extends Component {
     const numberInputClasses = classNames('bx--number', className, {
       'bx--number--light': light,
       'bx--number--helpertext': helperText,
+      'bx--number--nolabel': hideLabel,
     });
 
     const props = {


### PR DESCRIPTION
Closes #1506 

Fix input controls misalignment issue in NumberInput component
Ref: [#1312](https://github.com/IBM/carbon-components/issues/1312)

#### Changelog

**New**

* Add `bx--number--nolabel` class when label is hidden
