### PR TITLE
fix(FileUploaderButton): handle container div onClick

### DIFF
--- a/package.json
+++ b/package.json
@@ -352,5 +352,5 @@
       "enzyme-to-json/serializer"
     ]
   },
-  "bundleSizeThreshold": 80000
+  "bundleSizeThreshold": 81000
 }

--- a/src/components/FileUploader/FileUploader-test.js
+++ b/src/components/FileUploader/FileUploader-test.js
@@ -22,7 +22,7 @@ describe('FileUploaderButton', () => {
 
   describe('Renders as expected with default props', () => {
     it('renders with expected className', () => {
-      expect(mountWrapper.children().hasClass('bx--btn')).toBe(true);
+      expect(mountWrapper.find('label').hasClass('bx--btn')).toBe(true);
     });
 
     it('renders with given className', () => {

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -141,16 +141,19 @@ export class FileUploaderButton extends Component {
     this.uid = this.props.id || uid();
 
     return (
-      <div
-        role="button"
-        tabIndex={tabIndex || 0}
-        className={classes}
-        onKeyDown={evt => {
-          if (evt.which === 13 || evt.which === 32) {
-            this.input.click();
-          }
-        }}>
-        <label htmlFor={this.uid} role={role} {...other}>
+      <>
+        <label
+          role="button"
+          tabIndex={tabIndex || 0}
+          className={classes}
+          onKeyDown={evt => {
+            if (evt.which === 13 || evt.which === 32) {
+              this.input.click();
+            }
+          }}
+          htmlFor={this.uid}
+          role={role}
+          {...other}>
           {this.state.labelText}
         </label>
         <input
@@ -167,7 +170,7 @@ export class FileUploaderButton extends Component {
             evt.target.value = null;
           }}
         />
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Closes IBM/carbon-components-react#1564

Currently the only way to activate the `<input type="file">` on the `<FileUploaderButton />` is by clicking the button label. This PR will allow the user to click any part of the `<FileUploaderButton />` to bring up the file upload prompt.

#### Changelog

**New**

* add `onClick` handler for container `<div>`
* add `onClick` handler for file input `<label>`

**Changed**

* stop propagation of event if file input label is clicked