### PR TITLE
feat(InlineCheckbox): allow optional tooltip

### DIFF
--- a/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/src/components/InlineCheckbox/InlineCheckbox.js
@@ -42,6 +42,10 @@ export default class InlineCheckbox extends React.Component {
      * Provide a handler that is invoked on the key down event for the control
      */
     onKeyDown: PropTypes.func,
+    /**
+     * Provide an optional tooltip for the InlineCheckbox
+     */
+    title: PropTypes.string,
   };
 
   componentDidMount() {
@@ -68,6 +72,7 @@ export default class InlineCheckbox extends React.Component {
       name,
       onClick,
       onKeyDown,
+      title = undefined,
     } = this.props;
     const inputProps = {
       id,
@@ -99,6 +104,7 @@ export default class InlineCheckbox extends React.Component {
             htmlFor={id}
             className="bx--checkbox-label"
             aria-label={ariaLabel}
+            title={title}
           />
         }
       </>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1500

This PR allows the user to provide an optional `title` to serve as a tooltip for the `<InlineCheckbox>` component

#### Changelog

**New**

* `title` prop for `<InlineCheckbox>`