### PR TITLE
fix(Tooltip): assign "tooltip" role to Tooltips without clickable icons

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -406,7 +406,8 @@ export default class Tooltip extends Component {
               onBlur={evt => this.handleMouse(evt)}
               aria-haspopup="true"
               aria-expanded={open}
-              {...ariaOwnsProps}>
+              {...ariaOwnsProps}
+              role="tooltip">
               {triggerText}
             </div>
           )}


### PR DESCRIPTION
Closes IBM/carbon-components-react#1154

according to user reports, `aria-expanded` is not a valid attribute for `div`s without the proper `role` attribute assigned. This PR will add `role="tooltip"` to  `<Tooltip>`s without clickable icons, similar to how https://github.com/IBM/carbon-components-react/pull/532 adds `role="button"` to our `<Tooltip>` components with icons.

#### Changelog

**Changed**

* add `tooltip` role to `<Tooltip>`s without icons