### PR TITLE
Pass function reference instead of direct call

### DIFF
--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -594,14 +594,14 @@ In practice, this looks like the following:
       <TableToolbar>
         {/* make sure to apply getBatchActionProps so that the bar renders */}
         <TableBatchActions {...getBatchActionProps()}>
-          {/* inside of you batch actinos, you can include selectedRows */}
-          <TableBatchAction onClick={batchActionClick(selectedRows)}>
+          {/* inside of your batch actions, you can include selectedRows */}
+          <TableBatchAction onClick={() => batchActionClick(selectedRows)}>
             Ghost
           </TableBatchAction>
-          <TableBatchAction onClick={batchActionClick(selectedRows)}>
+          <TableBatchAction onClick={() => batchActionClick(selectedRows)}>
             Ghost
           </TableBatchAction>
-          <TableBatchAction onClick={batchActionClick(selectedRows)}>
+          <TableBatchAction onClick={() => batchActionClick(selectedRows)}>
             Ghost
           </TableBatchAction>
         </TableBatchActions>


### PR DESCRIPTION
As discussed on slack, we should pass a reference rather than making a call otherwise the function gets called at render time even without calling the batch action.
