### PR TITLE
fix(MultiSelect): prevent modification of disabled multiselect actions

### DIFF
--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -16,12 +16,16 @@ const ListBoxSelection = ({
   clearSelection,
   selectionCount,
   translateWithId: t,
+  disabled,
 }) => {
   const className = cx({
     [`${prefix}--list-box__selection`]: true,
     [`${prefix}--list-box__selection--multi`]: selectionCount,
   });
   const handleOnClick = event => {
+    if (disabled) {
+      return;
+    }
     // If we have a mult-select badge, clicking it shouldn't open the menu back
     // up. However, if we have a clear badge then we want the click to have this
     // behavior.
@@ -31,6 +35,9 @@ const ListBoxSelection = ({
     clearSelection(event);
   };
   const handleOnKeyDown = event => {
+    if (disabled) {
+      return;
+    }
     // When a user hits ENTER, we'll clear the selection
     if (event.keyCode === 13) {
       clearSelection(event);

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -16,16 +16,12 @@ const ListBoxSelection = ({
   clearSelection,
   selectionCount,
   translateWithId: t,
-  disabled,
 }) => {
   const className = cx({
     [`${prefix}--list-box__selection`]: true,
     [`${prefix}--list-box__selection--multi`]: selectionCount,
   });
   const handleOnClick = event => {
-    if (disabled) {
-      return;
-    }
     // If we have a mult-select badge, clicking it shouldn't open the menu back
     // up. However, if we have a clear badge then we want the click to have this
     // behavior.
@@ -35,9 +31,6 @@ const ListBoxSelection = ({
     clearSelection(event);
   };
   const handleOnKeyDown = event => {
-    if (disabled) {
-      return;
-    }
     // When a user hits ENTER, we'll clear the selection
     if (event.keyCode === 13) {
       clearSelection(event);

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -16,11 +16,9 @@ const ListBoxSelection = ({
   clearSelection,
   selectionCount,
   translateWithId: t,
-  disabled,
 }) => {
   const className = cx({
     [`${prefix}--list-box__selection`]: true,
-    [`${prefix}--list-box__selection--disabled`]: disabled,
     [`${prefix}--list-box__selection--multi`]: selectionCount,
   });
   const handleOnClick = event => {

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -16,9 +16,11 @@ const ListBoxSelection = ({
   clearSelection,
   selectionCount,
   translateWithId: t,
+  disabled,
 }) => {
   const className = cx({
     [`${prefix}--list-box__selection`]: true,
+    [`${prefix}--list-box__selection--disabled`]: disabled,
     [`${prefix}--list-box__selection--multi`]: selectionCount,
   });
   const handleOnClick = event => {

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -207,6 +207,7 @@ export default class MultiSelect extends React.Component {
                     <ListBox.Selection
                       clearSelection={!disabled ? clearSelection : noop}
                       selectionCount={selectedItem.length}
+                      disabled={disabled}
                     />
                   )}
                   <span className={`${prefix}--list-box__label`}>{label}</span>

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -174,6 +174,7 @@ export default class MultiSelect extends React.Component {
     });
     return (
       <Selection
+        disabled={disabled}
         onChange={this.handleOnChange}
         initialSelectedItems={initialSelectedItems}
         render={({ selectedItems, onItemChange, clearSelection }) => (

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -206,6 +206,7 @@ export default class MultiSelect extends React.Component {
                     <ListBox.Selection
                       clearSelection={!disabled ? clearSelection : noop}
                       selectionCount={selectedItem.length}
+                      disabled={disabled}
                     />
                   )}
                   <span className={`${prefix}--list-box__label`}>{label}</span>

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -236,6 +236,7 @@ export default class MultiSelect extends React.Component {
                             title={useTitleInItem ? itemText : null}
                             name={itemText}
                             checked={isChecked}
+                            disabled={disabled}
                             readOnly={true}
                             tabIndex="-1"
                             labelText={itemText}

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -207,7 +207,6 @@ export default class MultiSelect extends React.Component {
                     <ListBox.Selection
                       clearSelection={!disabled ? clearSelection : noop}
                       selectionCount={selectedItem.length}
-                      disabled={disabled}
                     />
                   )}
                   <span className={`${prefix}--list-box__label`}>{label}</span>

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -43,6 +43,7 @@ exports[`MultiSelect should render 1`] = `
   type="default"
 >
   <Selection
+    disabled={false}
     initialSelectedItems={Array []}
     onChange={[Function]}
     render={[Function]}

--- a/src/internal/Selection.js
+++ b/src/internal/Selection.js
@@ -46,6 +46,9 @@ export default class Selection extends React.Component {
     }));
   };
   handleOnItemChange = item => {
+    if (this.props.disabled) {
+      return;
+    }
     const { selectedItems } = this.state;
 
     let selectedIndex;

--- a/src/internal/Selection.js
+++ b/src/internal/Selection.js
@@ -29,6 +29,9 @@ export default class Selection extends React.Component {
     });
 
   handleClearSelection = () => {
+    if (this.props.disabled) {
+      return;
+    }
     this.internalSetState({
       selectedItems: [],
     });

--- a/src/internal/__tests__/Selection-test.js
+++ b/src/internal/__tests__/Selection-test.js
@@ -72,4 +72,19 @@ describe('Selection', () => {
     wrapper.find('#clear-selection').simulate('click');
     expect(wrapper.state('selectedItems')).toEqual([]);
   });
+
+  it('should disallow selection when disabled', () => {
+    const wrapper = mount(
+      <Selection
+        {...mockProps}
+        render={({ onItemChange }) => (
+          <button onClick={() => onItemChange(1)} />
+        )}
+        disabled
+      />
+    );
+    expect(wrapper.state('selectedItems').length).toBe(0);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state('selectedItems').length).toBe(0);
+  });
 });


### PR DESCRIPTION
Closes #1592
Closes #1596 

This PR will prevent users from modifying `<MultiSelect>` actions while the component is disabled.

#### Changelog

**New**

- disabled styles for `<ListBox.Selection>`, dependent on https://github.com/IBM/carbon-components/pull/1508

**Changed**

- break out of `<Selection>` event handlers when component is disabled
