### PR TITLE
feat(Modal): focus primary focus element after component mount

### DIFF
--- a/src/components/Modal/Modal-story.js
+++ b/src/components/Modal/Modal-story.js
@@ -25,6 +25,10 @@ const props = () => ({
     'Secondary button text (secondaryButtonText)',
     'Secondary Button'
   ),
+  selectorPrimaryFocus: text(
+    'Primary focus element selector (selectorPrimaryFocus)',
+    '[data-modal-primary-focus]'
+  ),
   iconDescription: text(
     'Close icon description (iconDescription)',
     'Close the modal'

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -221,12 +221,12 @@ export default class Modal extends Component {
     }
   };
 
-  componentDidMount = () => {
+  componentDidMount() {
     if (!this.props.open) {
       return;
     }
     this.focusButton(this.innerModal.current);
-  };
+  }
 
   handleTransitionEnd = evt => {
     if (

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -208,8 +208,8 @@ export default class Modal extends Component {
     }
   };
 
-  focusButton = evt => {
-    const primaryFocusElement = evt.currentTarget.querySelector(
+  focusButton = focusContainerElement => {
+    const primaryFocusElement = focusContainerElement.querySelector(
       this.props.selectorPrimaryFocus
     );
     if (primaryFocusElement) {
@@ -221,13 +221,20 @@ export default class Modal extends Component {
     }
   };
 
+  componentDidMount = () => {
+    if (!this.props.open) {
+      return;
+    }
+    this.focusButton(this.innerModal.current);
+  };
+
   handleTransitionEnd = evt => {
     if (
       this.outerModal.current.offsetWidth &&
       this.outerModal.current.offsetHeight &&
       this.beingOpen
     ) {
-      this.focusButton(evt);
+      this.focusButton(evt.currentTarget);
       this.beingOpen = false;
     }
   };


### PR DESCRIPTION
Closes IBM/carbon-components-react#1616

`<Modal />` currently does not focus the primary focus element after initial render. This PR adds a check to the `componentDidMount` life cycle method to call focus on the primary focus element.

#### Changelog

**New**

- `componentDidMount` method for calling focus on primary focus element after render