### PR TITLE
feat(OverflowMenuItem): renders an anchor when passed href

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/src/components/OverflowMenu/OverflowMenu-story.js
@@ -91,6 +91,59 @@ storiesOf('OverflowMenu', module)
     }
   )
   .add(
+    'with links',
+    () => {
+      const overflowMenuItemProps = {
+        ...props.menuItem(),
+        href: 'https://www.ibm.com',
+      };
+      return (
+        <OverflowMenu {...props.menu()}>
+          <OverflowMenuItem
+            {...overflowMenuItemProps}
+            itemText="Option 1"
+            primaryFocus={true}
+          />
+          <OverflowMenuItem
+            {...overflowMenuItemProps}
+            itemText="Option 2 is an example of a really long string and how we recommend handling this"
+            requireTitle
+          />
+          <OverflowMenuItem {...overflowMenuItemProps} itemText="Option 3" />
+          <OverflowMenuItem {...overflowMenuItemProps} itemText="Option 4" />
+          <OverflowMenuItem
+            {...overflowMenuItemProps}
+            itemText={
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}>
+                Add <Icon icon={iconAdd} style={{ height: '12px' }} />
+              </div>
+            }
+          />
+          <OverflowMenuItem
+            {...overflowMenuItemProps}
+            itemText="Danger option"
+            hasDivider
+            isDelete
+          />
+        </OverflowMenu>
+      );
+    },
+    {
+      info: {
+        text: `
+            Overflow Menu is used when additional options are available to the user and there is a space constraint.
+            Create Overflow Menu Item components for each option on the menu.
+
+            When given \`href\` props, menu items render as <a> tags to facilitate usability.
+          `,
+      },
+    }
+  )
+  .add(
     'custom trigger',
     () => {
       const overflowMenuItemProps = props.menuItem();

--- a/src/components/OverflowMenuItem/OverflowMenuItem-test.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem-test.js
@@ -38,5 +38,14 @@ describe('OverflowMenuItem', () => {
 
       expect(wrapper.hasClass('bx--overflow-menu--divider')).toEqual(true);
     });
+
+    it('renders an anchor when passed href', () => {
+      const wrapper = shallowRender({
+        itemText: 'testing',
+        href: 'testing',
+      });
+
+      expect(wrapper.find('a').length).toBe(1);
+    });
   });
 });

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -6,6 +6,7 @@ import { settings } from 'carbon-components';
 const { prefix } = settings;
 
 const OverflowMenuItem = ({
+  href,
   className,
   itemText,
   hasDivider,
@@ -39,27 +40,31 @@ const OverflowMenuItem = ({
     closeMenu();
   };
 
-  const primaryFocusProp = (({ primaryFocus, floatingMenu }) => {
-    if (!primaryFocus) {
-      return {};
-    }
-    return floatingMenu
-      ? { 'data-floating-menu-primary-focus': true }
-      : { 'data-overflow-menu-primary-focus': true };
-  })({ primaryFocus, floatingMenu });
+  let primaryFocusProp = {};
+  if (primaryFocus && floatingMenu) {
+    primaryFocusProp = { 'data-floating-menu-primary-focus': true };
+  } else if (primaryFocus) {
+    primaryFocusProp = { 'data-overflow-menu-primary-focus': true };
+  }
+
+  const itemProps = {
+    ...other,
+    ...primaryFocusProp,
+    className: overflowMenuBtnClasses,
+    disabled,
+    onClick: handleClick,
+    title: requireTitle ? itemText : null,
+    tabIndex: disabled ? -1 : 0,
+    href,
+  };
 
   const item = (
     <li className={overflowMenuItemClasses} role="menuitem">
-      <button
-        {...other}
-        {...primaryFocusProp}
-        className={overflowMenuBtnClasses}
-        disabled={disabled}
-        onClick={handleClick}
-        title={requireTitle ? itemText : null}
-        tabIndex={disabled ? -1 : 0}>
-        {itemText}
-      </button>
+      {href ? (
+        <a {...itemProps}>{itemText}</a>
+      ) : (
+        <button {...itemProps}>{itemText}</button>
+      )}
     </li>
   );
 
@@ -81,6 +86,11 @@ OverflowMenuItem.propTypes = {
    * The text in the menu item.
    */
   itemText: PropTypes.node.isRequired,
+
+  /**
+   * If given, overflow item will render as a link with the given href
+   */
+  href: PropTypes.string,
 
   /**
    * `true` to make this menu item a divider.

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -47,28 +47,23 @@ const OverflowMenuItem = ({
     primaryFocusProp = { 'data-overflow-menu-primary-focus': true };
   }
 
-  const itemProps = {
-    ...other,
-    ...primaryFocusProp,
-    className: overflowMenuBtnClasses,
-    disabled,
-    onClick: handleClick,
-    title: requireTitle ? itemText : null,
-    tabIndex: disabled ? -1 : 0,
-    href,
-  };
+  const TagToUse = href ? 'a' : 'button';
 
-  const item = (
+  return (
     <li className={overflowMenuItemClasses} role="menuitem">
-      {href ? (
-        <a {...itemProps}>{itemText}</a>
-      ) : (
-        <button {...itemProps}>{itemText}</button>
-      )}
+      <TagToUse
+        {...other}
+        {...primaryFocusProp}
+        href={href}
+        className={overflowMenuBtnClasses}
+        disabled={disabled}
+        onClick={handleClick}
+        title={requireTitle ? itemText : null}
+        tabIndex={disabled ? -1 : 0}>
+        {itemText}
+      </TagToUse>
     </li>
   );
-
-  return item;
 };
 
 OverflowMenuItem.propTypes = {


### PR DESCRIPTION
when an href is passed to an overflowmenuitem it will render an anchor tag instead of a button, so
users can bookmark/hover/etc.

The styling doesn't look quite right because as links the overflow menu items always have underlines... I can make a corresponding change to the `carbon-components` as well

Closes IBM/carbon-components-react#1619

#### Changelog

**New**

- OverflowMenuItem renders `<a>` when passed `href`