### PR TITLE
fix(Notification): remove icon for ToastNotification

### DIFF
--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -297,25 +297,9 @@ export class ToastNotification extends Component {
       },
       className
     );
-    const NotificationIcon = kind => {
-      switch (kind) {
-        case 'warning':
-          return a11yIconWarningSolid(prefix, notificationType);
-        default:
-          return (
-            <Icon
-              description={this.props.iconDescription}
-              className={`${prefix}--toast-notification__icon`}
-              aria-label="close"
-              icon={this.useIcon(kind)}
-            />
-          );
-      }
-    };
 
     return (
       <div {...other} role={role} kind={kind} className={classes}>
-        {NotificationIcon(kind)}
         <NotificationTextDetails
           title={title}
           subtitle={subtitle}


### PR DESCRIPTION
Closes IBM/carbon-components-react#1614

This PR removes the icon which was mistakenly added to `<ToastNotification>`

#### Changelog

**Removed**

- `<ToastNotifcation>` icon
