### PR TITLE
 fix(ModalWrapper): pass `selectorPrimaryFocus` prop through to `<Modal>`

### DIFF
--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -20,6 +20,10 @@ const props = () => ({
   ),
   modalLabel: text('The modal label (optional) (modalLabel)', 'Label'),
   modalHeading: text('The modal heading (modalHeading)', 'Modal'),
+  selectorPrimaryFocus: text(
+    'Primary focus element selector (selectorPrimaryFocus)',
+    '[data-modal-primary-focus]'
+  ),
   primaryButtonText: text(
     'The text in the primary button (primaryButtonText)',
     'Save'
@@ -106,8 +110,7 @@ storiesOf('ModalWrapper', module)
         <TextInput
           id="test2"
           placeholder="Hint text here"
-          label="Text Input:"
-          data-modal-primary-focus
+          labelText="Text Input:"
         />
         <br />
         <Select id="select-1" labelText="Select">

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -31,6 +31,7 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: 'Cancel',
     triggerButtonKind: 'primary',
     disabled: false,
+    selectorPrimaryFocus: '[data-modal-primary-focus]',
     onKeyDown: () => {},
   };
 
@@ -69,11 +70,13 @@ export default class ModalWrapper extends React.Component {
       disabled,
       handleSubmit, // eslint-disable-line no-unused-vars
       shouldCloseAfterSubmit, // eslint-disable-line no-unused-vars
+      selectorPrimaryFocus,
       ...other
     } = this.props;
 
     const props = {
       ...other,
+      selectorPrimaryFocus,
       open: this.state.isOpen,
       onRequestClose: this.handleClose,
       onRequestSubmit: this.handleOnRequestSubmit,

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -12,6 +12,7 @@ exports[`ModalWrapper should render 1`] = `
   onKeyDown={[Function]}
   primaryButtonText="Save"
   secondaryButtonText="Cancel"
+  selectorPrimaryFocus="[data-modal-primary-focus]"
   shouldCloseAfterSubmit={true}
   triggerButtonKind="primary"
 >


### PR DESCRIPTION
Closes IBM/carbon-components-react#1632

This PR exposes the `selectorPrimaryFocus` prop on `<ModalWrapper>` in order to pass it through to `<Modal>` for configuration

#### Changelog

**New**

- add `selectorPrimaryFocus` prop on `<ModalWrapper>`

**Changed**

- updated Storybook examples