### PR TITLE
feat(ComposedModal): support selectorPrimaryFocus prop

### DIFF
--- a/src/components/ComposedModal/ComposedModal-story.js
+++ b/src/components/ComposedModal/ComposedModal-story.js
@@ -10,10 +10,14 @@ import ComposedModal, {
 import Button from '../Button';
 
 const props = {
-  composedModal: () => ({
-    open: boolean('Open (open in <ComposedModal>)', true),
+  composedModal: (includeOpen = true) => ({
+    open: includeOpen ? boolean('Open (open in <ComposedModal>)', true) : null,
     onKeyDown: action('onKeyDown'),
     danger: boolean('Danger mode (danger)', false),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      '[data-modal-primary-focus]'
+    ),
   }),
   modalHeader: () => ({
     label: text('Optional Label (label in <ModalHeader>)', 'Optional Label'),
@@ -99,6 +103,46 @@ storiesOf('ComposedModal', module)
       info: {
         text: `
             Alternatively, you can just use the Modal components as wrapper elements and figure the children out yourself. We do suggest for the header you utilize the built in props for label and title though, for the footer it's mostly a composed element so creating the two buttons yourself (using the Button component) is probably the most straight-forward pattern.
+          `,
+      },
+    }
+  )
+  .add(
+    'Example usage with trigger button',
+    () => {
+      class ComposedModalExample extends React.Component {
+        state = { open: false };
+        toggleModal = open => this.setState({ open });
+        render() {
+          const { open } = this.state;
+          return (
+            <>
+              <Button onClick={() => this.toggleModal(true)}>
+                Launch composed modal
+              </Button>
+              <ComposedModal
+                {...props.composedModal()}
+                open={open}
+                onClose={() => this.toggleModal(false)}>
+                <ModalHeader {...props.modalHeader()} />
+                <ModalBody>
+                  <p className="bx--modal-content__text">
+                    Please see ModalWrapper for more examples and demo of the
+                    functionality.
+                  </p>
+                </ModalBody>
+                <ModalFooter {...props.modalFooter()} />
+              </ComposedModal>
+            </>
+          );
+        }
+      }
+      return <ComposedModalExample />;
+    },
+    {
+      info: {
+        text: `
+            An example ComposedModal with a trigger button
           `,
       },
     }

--- a/src/components/ComposedModal/ComposedModal-test.js
+++ b/src/components/ComposedModal/ComposedModal-test.js
@@ -148,7 +148,7 @@ describe('<ComposedModal />', () => {
   });
 
   it('changes the open state upon change in props', () => {
-    const wrapper = shallow(<ComposedModal open />);
+    const wrapper = mount(<ComposedModal open />);
     expect(wrapper.state().open).toEqual(true);
     wrapper.setProps({ open: false });
     expect(wrapper.state().open).toEqual(false);

--- a/src/components/ComposedModal/ComposedModal-test.js
+++ b/src/components/ComposedModal/ComposedModal-test.js
@@ -186,4 +186,27 @@ describe('<ComposedModal />', () => {
     button.simulate('click');
     expect(wrapper.state().open).toEqual(true);
   });
+
+  it('should focus on the primary actionable button in ModalFooter by default', () => {
+    mount(
+      <ComposedModal open>
+        <ModalFooter primaryButtonText="Save" />
+      </ComposedModal>
+    );
+    expect(
+      document.activeElement.classList.contains('bx--btn--primary')
+    ).toEqual(true);
+  });
+
+  it('should focus on the element that matches selectorPrimaryFocus', () => {
+    mount(
+      <ComposedModal open selectorPrimaryFocus=".bx--modal-close">
+        <ModalHeader label="Optional Label" title="Example" />
+        <ModalFooter primaryButtonText="Save" />
+      </ComposedModal>
+    );
+    expect(
+      document.activeElement.classList.contains('bx--modal-close')
+    ).toEqual(true);
+  });
 });

--- a/src/components/ComposedModal/__snapshots__/ComposedModal-test.js.snap
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal-test.js.snap
@@ -4,11 +4,14 @@ exports[`<ComposedModal /> renders 1`] = `
 <ComposedModal
   onKeyDown={[Function]}
   open={true}
+  selectorPrimaryFocus="[data-modal-primary-focus]"
 >
   <div
     className="bx--modal is-visible"
+    onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
+    onTransitionEnd={[Function]}
     open={true}
     role="presentation"
     tabIndex={-1}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -112,8 +112,8 @@ export default class Modal extends Component {
     selectorsFloatingMenus: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * Specify a CSS selector that matches the DOM element that should be focused
-     * when the Modal becomes open
+     * Specify a CSS selector that matches the DOM element that should
+     * be focused when the Modal opens
      */
     selectorPrimaryFocus: PropTypes.string,
   };
@@ -181,6 +181,12 @@ export default class Modal extends Component {
     }
   };
 
+  focusModal = () => {
+    if (this.outerModal.current) {
+      this.outerModal.current.focus();
+    }
+  };
+
   handleBlur = evt => {
     // Keyboard trap
     if (
@@ -201,12 +207,6 @@ export default class Modal extends Component {
       this.beingOpen = false;
     }
   }
-
-  focusModal = () => {
-    if (this.outerModal.current) {
-      this.outerModal.current.focus();
-    }
-  };
 
   focusButton = focusContainerElement => {
     const primaryFocusElement = focusContainerElement.querySelector(


### PR DESCRIPTION
Closes IBM/carbon-components-react#1623

This PR adds support for the `selectorPrimaryFocus` prop on `<ComposedModal>` to match `<Modal>` and `<ModalWrapper>`

Related: #980 #1124 #1621 #1633

#### Changelog

**New**

- focus management methods (many shared with `<Modal>`)
- pass ref for primary focusable element to `<ComposedModal>`s using `<ModalFooter>`
- storybook example `<ComposedModal>` with trigger button

**Changed**

- declare `<Modal>` methods before they are called