### PR TITLE
fix(datepicker): apply datepickerinput props properly

### DIFF
--- a/src/components/DatePicker/DatePicker-story.js
+++ b/src/components/DatePicker/DatePicker-story.js
@@ -139,7 +139,7 @@ storiesOf('DatePicker', module)
   .add(
     'range with calendar and min/max dates',
     () => {
-      const datePickerInputProps = props.datePicker();
+      const datePickerInputProps = props.datePickerInput();
       return (
         <DatePicker
           {...props.datePicker()}


### PR DESCRIPTION
Closes IBM/carbon-components-react#1637

## Changed

- fix typo so that the `DatePickerInput` props from the main prop object can be applied correctly to this story

### Before:

![screen shot 2018-12-11 at 5 01 06 pm](https://user-images.githubusercontent.com/9057921/49835958-926e6500-fd66-11e8-8dfb-a7375711941f.png)


### After:

![screen shot 2018-12-11 at 5 02 14 pm](https://user-images.githubusercontent.com/9057921/49835962-9601ec00-fd66-11e8-9c99-3ccdd5ee8b0d.png)
