### PR TITLE
fix(AccordionItem): add aria-expanded and use tab role

### DIFF
--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -8,11 +8,7 @@ const { prefix } = settings;
 const Accordion = ({ children, className, ...other }) => {
   const classNames = classnames(`${prefix}--accordion`, className);
   return (
-    <ul
-      className={classNames}
-      role="tablist"
-      aria-multiselectable="true"
-      {...other}>
+    <ul className={classNames} {...other}>
       {children}
     </ul>
   );

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -8,7 +8,7 @@ const { prefix } = settings;
 const Accordion = ({ children, className, ...other }) => {
   const classNames = classnames(`${prefix}--accordion`, className);
   return (
-    <ul className={classNames} {...other}>
+    <ul {...other} className={classNames}>
       {children}
     </ul>
   );

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -129,7 +129,6 @@ export default class AccordionItem extends Component {
             icon={iconChevronRight}
             description={iconDescription}
             role={null} // eslint-disable-line jsx-a11y/aria-role
-            aria-hidden={true}
           />
           <div className={`${prefix}--accordion__title`}>{title}</div>
         </Expando>

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -121,8 +121,8 @@ export default class AccordionItem extends Component {
         {...other}>
         <Expando
           type="button"
+          aria-expanded={this.state.open}
           className={`${prefix}--accordion__heading`}
-          role="tab"
           onClick={this.handleHeadingClick}>
           <Icon
             className={`${prefix}--accordion__arrow`}

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -128,6 +128,8 @@ export default class AccordionItem extends Component {
             className={`${prefix}--accordion__arrow`}
             icon={iconChevronRight}
             description={iconDescription}
+            role={null} // eslint-disable-line jsx-a11y/aria-role
+            aria-hidden={true}
           />
           <div className={`${prefix}--accordion__title`}>{title}</div>
         </Expando>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1650

This PR uses a more appropriate `role` for `<AccordionItem>`s with respect to our current markup and includes the `aria-expanded` on the component. This change is meant to support screen readers but exposes a potential larger issue with the elements used to construct our `<Accordion>`s

#### Changelog

**Changed**

- use `tab` role for `<AccordionItem>` to correspond with the `role` on `<Accordion>`
- tie `aria-expanded` state to component open/closed state