### PR TITLE
feat(Accordion): close accordion item on Esc keypress

### DIFF
--- a/src/components/AccordionItem/AccordionItem-test.js
+++ b/src/components/AccordionItem/AccordionItem-test.js
@@ -136,6 +136,7 @@ describe('AccordionItem', () => {
 
   describe('Check that the keyboard toggles its open state', () => {
     let toggler;
+    let heading;
 
     beforeEach(() => {
       toggler = mount(
@@ -144,25 +145,24 @@ describe('AccordionItem', () => {
           <input className="testInput" />
         </AccordionItem>
       );
+      heading = toggler.find('button.bx--accordion__heading');
     });
 
-    it('should toggle state when using enter or space', () => {
-      expect(toggler.state().open).toEqual(false);
-      toggler.simulate('keypress', { which: 32 });
-      expect(toggler.state().open).toEqual(true);
-      toggler.simulate('keypress', { which: 13 });
-      expect(toggler.state().open).toEqual(false);
-      toggler.simulate('keypress', { which: 97 });
+    it('should close open AccordionItem when using Esc', () => {
+      toggler.setState({ open: true });
+      heading.simulate('keydown', { which: 27 });
       expect(toggler.state().open).toEqual(false);
     });
 
-    it('should not toggle if a keypress is made in a child element', () => {
+    it('should not close if Esc keypress is made in a child element', () => {
+      toggler.setState({ open: true });
       const input = toggler.find('.testInput');
-      expect(toggler.state().open).toEqual(false);
-      toggler.simulate('keypress', { which: 32 });
+      input.simulate('keydown', { which: 27 });
       expect(toggler.state().open).toEqual(true);
-      input.simulate('keypress', { which: 32 });
-      expect(toggler.state().open).toEqual(true);
+    });
+
+    afterEach(() => {
+      toggler.setState({ open: false });
     });
   });
 });

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -84,11 +84,9 @@ export default class AccordionItem extends Component {
     this.props.onHeadingClick({ isOpen: open, event: evt });
   };
 
-  handleKeyPress = evt => {
-    const isKeyPressTarget = evt.target === evt.currentTarget;
-    const isValidKeyPress = [13, 32].indexOf(evt.which) !== -1;
-
-    if (isKeyPressTarget && isValidKeyPress) {
+  handleKeyDown = evt => {
+    // Esc key
+    if (evt.which === 27 && this.state.open) {
       this.handleHeadingClick(evt);
     }
   };
@@ -116,7 +114,7 @@ export default class AccordionItem extends Component {
       <li
         className={classNames}
         onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
+        onKeyDown={this.handleKeyDown}
         role="presentation"
         {...other}>
         <Expando

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { iconChevronRight } from 'carbon-icons';
 import { settings } from 'carbon-components';
 import Icon from '../Icon';
+import { match, keys } from '../../tools/key';
 
 const { prefix } = settings;
 
@@ -85,9 +86,8 @@ export default class AccordionItem extends Component {
   };
 
   handleKeyDown = evt => {
-    // Esc key
     if (
-      evt.which === 27 &&
+      match(evt.which, keys.ESC) &&
       this.state.open &&
       evt.target.classList.contains(`${prefix}--accordion__heading`)
     ) {

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -86,7 +86,11 @@ export default class AccordionItem extends Component {
 
   handleKeyDown = evt => {
     // Esc key
-    if (evt.which === 27 && this.state.open) {
+    if (
+      evt.which === 27 &&
+      this.state.open &&
+      evt.target.classList.contains(`${prefix}--accordion__heading`)
+    ) {
       this.handleHeadingClick(evt);
     }
   };


### PR DESCRIPTION
Closes IBM/carbon-components-react#1660

This PR adds support for closing an open `AccordionItem` with the `Esc` key. The current keypress handler also does not trigger the opening and closing of `AccordionItem`s. Due to that behavior already being native to button elements, it does not look like we need to handle space bar and Enter key presses separately.

#### Changelog

**Changed**

- listen to `onKeyDown` event rather than `onKeyPress` to support `Esc` key

**Removed**

- listeners for space bar and enter key
