### PR TITLE
[WIP] fix: assign class names based on form item labels

### DIFF
--- a/src/components/FormItem/FormItem-story.js
+++ b/src/components/FormItem/FormItem-story.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-
 import FormItem from './FormItem';
 import NumberInput from '../NumberInput';
+import { componentsX } from '../../internal/FeatureFlags';
 
 storiesOf('FormItem', module).add(
   'Default',
   () => (
     <FormItem>
-      <NumberInput id="number-input-1" />
+      {componentsX ? (
+        <NumberInput id="number-input-1" />
+      ) : (
+        <NumberInput id="number-input-1" hideLabel />
+      )}
     </FormItem>
   ),
   {

--- a/src/components/NumberInput/NumberInput-story.js
+++ b/src/components/NumberInput/NumberInput-story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-
 import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import NumberInput from '../NumberInput';
 import NumberInputSkeleton from '../NumberInput/NumberInput.Skeleton';
@@ -10,7 +9,6 @@ const props = () => ({
   className: 'some-class',
   id: 'tj-input',
   label: text('Label (label)', 'Number Input label'),
-  hideLabel: boolean('No label (hideLabel)', false),
   min: number('Minimum value (min)', 0),
   max: number('Maximum value (max)', 100),
   value: number('Value (value)', 50),

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -4,6 +4,7 @@ import { iconCaretUp, iconCaretDown } from 'carbon-icons';
 import Icon from '../Icon';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -110,7 +111,7 @@ export default class NumberInput extends Component {
     disabled: false,
     hideLabel: false,
     iconDescription: 'choose a number',
-    label: ' ',
+    label: '',
     onChange: () => {},
     onClick: () => {},
     step: 1,
@@ -210,7 +211,7 @@ export default class NumberInput extends Component {
     const numberInputClasses = classNames(`${prefix}--number`, className, {
       [`${prefix}--number--light`]: light,
       [`${prefix}--number--helpertext`]: helperText,
-      [`${prefix}--number--nolabel`]: hideLabel,
+      [`${prefix}--number--nolabel`]: componentsX ? !label : hideLabel,
     });
 
     const props = {
@@ -241,9 +242,11 @@ export default class NumberInput extends Component {
       <div className={`${prefix}--form__helper-text`}>{helperText}</div>
     ) : null;
 
-    const labelClasses = classNames(`${prefix}--label`, {
-      [`${prefix}--visually-hidden`]: hideLabel,
-    });
+    const labelClasses = componentsX
+      ? `${prefix}--label`
+      : classNames(`${prefix}--label`, {
+          [`${prefix}--visually-hidden`]: hideLabel,
+        });
 
     const labelText = label ? (
       <label htmlFor={id} className={labelClasses}>
@@ -252,43 +255,41 @@ export default class NumberInput extends Component {
     ) : null;
 
     return (
-      <div className={`${prefix}--form-item`}>
-        <div className={numberInputClasses} {...inputWrapperProps}>
-          <div className={`${prefix}--number__controls`}>
-            <button
-              className={`${prefix}--number__control-btn up-icon`}
-              {...buttonProps}
-              onClick={evt => this.handleArrowClick(evt, 'up')}>
-              <Icon
-                className="up-icon"
-                icon={iconCaretUp}
-                description={this.props.iconDescription}
-                viewBox="0 0 10 5"
-              />
-            </button>
-            <button
-              className={`${prefix}--number__control-btn down-icon`}
-              {...buttonProps}
-              onClick={evt => this.handleArrowClick(evt, 'down')}>
-              <Icon
-                className="down-icon"
-                icon={iconCaretDown}
-                viewBox="0 0 10 5"
-                description={this.props.iconDescription}
-              />
-            </button>
-          </div>
-          {labelText}
-          <input
-            type="number"
-            pattern="[0-9]*"
-            {...other}
-            {...props}
-            ref={this._handleInputRef}
-          />
-          {error}
-          {helper}
+      <div className={numberInputClasses} {...inputWrapperProps}>
+        {labelText}
+        <input
+          type="number"
+          pattern="[0-9]*"
+          {...other}
+          {...props}
+          ref={this._handleInputRef}
+        />
+        <div className={`${prefix}--number__controls`}>
+          <button
+            className={`${prefix}--number__control-btn up-icon`}
+            {...buttonProps}
+            onClick={evt => this.handleArrowClick(evt, 'up')}>
+            <Icon
+              className="up-icon"
+              icon={iconCaretUp}
+              description={this.props.iconDescription}
+              viewBox="0 0 10 5"
+            />
+          </button>
+          <button
+            className={`${prefix}--number__control-btn down-icon`}
+            {...buttonProps}
+            onClick={evt => this.handleArrowClick(evt, 'down')}>
+            <Icon
+              className="down-icon"
+              icon={iconCaretDown}
+              viewBox="0 0 10 5"
+              description={this.props.iconDescription}
+            />
+          </button>
         </div>
+        {error}
+        {helper}
       </div>
     );
   }

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -9,7 +9,6 @@ const TextArea = ({
   className,
   id,
   labelText,
-  hideLabel,
   onChange,
   onClick,
   invalid,
@@ -37,7 +36,7 @@ const TextArea = ({
     [`${prefix}--text-area--light`]: light,
   });
   const labelClasses = classNames(`${prefix}--label`, {
-    [`${prefix}--visually-hidden`]: hideLabel,
+    [`${prefix}--visually-hidden`]: !labelText,
   });
 
   const label = labelText ? (
@@ -155,11 +154,6 @@ TextArea.propTypes = {
   helperText: PropTypes.node,
 
   /**
-   * Specify whether you want the underlying label to be visually hidden
-   */
-  hideLabel: PropTypes.bool,
-
-  /**
    * Specify whether you want the light version of this control
    */
   light: PropTypes.bool,
@@ -176,6 +170,7 @@ TextArea.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  labelText: '',
 };
 
 export default TextArea;

--- a/src/components/TextArea/Textarea-story.js
+++ b/src/components/TextArea/Textarea-story.js
@@ -10,7 +10,6 @@ const TextAreaProps = () => ({
   className: 'some-class',
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
-  hideLabel: boolean('No label (hideLabel)', false),
   labelText: text('Label text (labelText)', 'Text Area label'),
   invalid: boolean('Show form validation UI (invalid)', false),
   invalidText: text(

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -20,7 +20,6 @@ const TextInputProps = () => ({
   placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
   light: boolean('Light variant (light)', false),
   disabled: boolean('Disabled (disabled)', false),
-  hideLabel: boolean('No label (hideLabel)', false),
   invalid: boolean('Show form validation UI (invalid)', false),
   invalidText: text(
     'Form validation UI content (invalidText)',

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -13,7 +13,6 @@ const TextInput = ({
   type,
   onChange,
   onClick,
-  hideLabel,
   invalid,
   invalidText,
   helperText,
@@ -41,7 +40,7 @@ const TextInput = ({
     [`${prefix}--text-input--light`]: light,
   });
   const labelClasses = classNames(`${prefix}--label`, {
-    [`${prefix}--visually-hidden`]: hideLabel,
+    [`${prefix}--visually-hidden`]: !labelText,
   });
 
   const label = labelText ? (
@@ -138,11 +137,6 @@ TextInput.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
-   * Specify whether you want the underlying label to be visually hidden
-   */
-  hideLabel: PropTypes.bool,
-
-  /**
    * Specify whether the control is currently invalid
    */
   invalid: PropTypes.bool,
@@ -171,6 +165,7 @@ TextInput.defaultProps = {
   invalid: false,
   invalidText: '',
   helperText: '',
+  labelText: '',
   light: false,
 };
 


### PR DESCRIPTION
Closes IBM/carbon-components-react#1662

Related/depends on: #1654

This PR will remove the `hideLabel` prop across the library in favor of rendering `<label>`s based on the text content of labels

#### Changelog

**Changed**

- `<NumberInput>`