### PR TITLE
docs(Checkbox): remove duplicate id from `checked` story

### DIFF
--- a/src/components/Checkbox/Checkbox-story.js
+++ b/src/components/Checkbox/Checkbox-story.js
@@ -25,7 +25,7 @@ storiesOf('Checkbox', module)
         <fieldset className="bx--fieldset">
           <legend className="bx--label">Checkbox heading</legend>
           <Checkbox defaultChecked {...checkboxProps} id="checkbox-label-1" />
-          <Checkbox defaultChecked {...checkboxProps} id="checkbox-label-1" />
+          <Checkbox defaultChecked {...checkboxProps} id="checkbox-label-2" />
         </fieldset>
       );
     },


### PR DESCRIPTION
Closes IBM/carbon-components-react#1670

This PR will deduplicate the `id`s for the example `<Checkbox />` components in storybook

#### Changelog

**Changed**

- component `id`s in `<Checkbox />` storybook example