### PR TITLE
feat(CopyButton): support new icon strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,5 +354,5 @@
       "enzyme-to-json/serializer"
     ]
   },
-  "bundleSizeThreshold": 82000
+  "bundleSizeThreshold": 85000
 }

--- a/src/components/CopyButton/CopyButton.js
+++ b/src/components/CopyButton/CopyButton.js
@@ -3,7 +3,8 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
 import { iconCopy } from 'carbon-icons';
-import { Copy16 } from '@carbon/icons-react';
+// TODO: import { Copy16 } from '@carbon/icons-react';
+import Copy16 from '@carbon/icons-react/lib/copy/16';
 import Icon from '../Icon';
 import { componentsX } from '../../internal/FeatureFlags';
 

--- a/src/components/CopyButton/CopyButton.js
+++ b/src/components/CopyButton/CopyButton.js
@@ -3,7 +3,9 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
 import { iconCopy } from 'carbon-icons';
+import { Copy16 } from '@carbon/icons-react';
 import Icon from '../Icon';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -86,11 +88,19 @@ export default class CopyButton extends Component {
         className={classNames}
         onClick={this.handleClick}
         {...other}>
-        <Icon
-          className={`${prefix}--snippet__icon`}
-          icon={iconCopy}
-          description={iconDescription}
-        />
+        {componentsX ? (
+          <Copy16
+            className={`${prefix}--snippet__icon`}
+            aria-label={iconDescription}
+            alt={iconDescription}
+          />
+        ) : (
+          <Icon
+            className={`${prefix}--snippet__icon`}
+            icon={iconCopy}
+            description={iconDescription}
+          />
+        )}
         <div className={feedbackClassNames} data-feedback={feedback} />
       </button>
     );


### PR DESCRIPTION
Closes IBM/carbon-components-react#1673

This PR will add the new experimental CopyButton changes