### PR TITLE
feat(ModalWrapper): add icon option to trigger button

### DIFF
--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -1,14 +1,26 @@
 import React from 'react';
+import { iconAddSolid, iconSearch } from 'carbon-icons';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
 import ModalWrapper from '../ModalWrapper';
 import TextInput from '../TextInput';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
 import RadioButtonGroup from '../RadioButtonGroup';
 import RadioButton from '../RadioButton';
+
+const icons = {
+  None: 'None',
+  'Add with filled circle (iconAddSolid from `carbon-icons`)': 'iconAddSolid',
+  'Search (iconSearch from `carbon-icons`)': 'iconSearch',
+};
+
+const iconMap = {
+  iconAddSolid,
+  iconSearch,
+};
 
 const props = () => ({
   className: 'some-class',
@@ -18,6 +30,7 @@ const props = () => ({
     'The text in the trigger button (buttonTriggerText)',
     'Launch Modal'
   ),
+  triggerButtonIcon: iconMap[select('Icon (icon)', icons, 'none')],
   modalLabel: text('The modal label (optional) (modalLabel)', 'Label'),
   modalHeading: text('The modal heading (modalHeading)', 'Modal'),
   selectorPrimaryFocus: text(

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -22,6 +22,8 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
     disabled: PropTypes.bool,
+    triggerButtonIcon: PropTypes.string,
+    triggerButtonIconDescription: PropTypes.string,
     triggerButtonKind: ButtonTypes.buttonKind,
     shouldCloseAfterSubmit: PropTypes.bool,
   };
@@ -29,6 +31,7 @@ export default class ModalWrapper extends React.Component {
   static defaultProps = {
     primaryButtonText: 'Save',
     secondaryButtonText: 'Cancel',
+    triggerButtonIconDescription: 'Provide icon description if icon is used',
     triggerButtonKind: 'primary',
     disabled: false,
     selectorPrimaryFocus: '[data-modal-primary-focus]',
@@ -66,6 +69,8 @@ export default class ModalWrapper extends React.Component {
       onKeyDown,
       buttonTriggerText,
       buttonTriggerClassName,
+      triggerButtonIcon,
+      triggerButtonIconDescription,
       triggerButtonKind,
       disabled,
       handleSubmit, // eslint-disable-line no-unused-vars
@@ -95,6 +100,8 @@ export default class ModalWrapper extends React.Component {
           className={buttonTriggerClassName}
           disabled={disabled}
           kind={triggerButtonKind}
+          icon={triggerButtonIcon}
+          iconDescription={triggerButtonIconDescription}
           onClick={this.handleOpen}
           inputref={this.triggerButton}>
           {buttonTriggerText}

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -14,6 +14,7 @@ exports[`ModalWrapper should render 1`] = `
   secondaryButtonText="Cancel"
   selectorPrimaryFocus="[data-modal-primary-focus]"
   shouldCloseAfterSubmit={true}
+  triggerButtonIconDescription="Provide icon description if icon is used"
   triggerButtonKind="primary"
 >
   <div


### PR DESCRIPTION
This PR will add icon option to the trigger button of ModalWrapper.
In the Story, I used the same select of icons, which is in the Button-Story.