### PR TITLE
feat(Toggle): add experimental toggle

### DIFF
--- a/src/components/Toggle/Toggle-story.js
+++ b/src/components/Toggle/Toggle-story.js
@@ -7,6 +7,7 @@ import ToggleSkeleton from '../Toggle/Toggle.Skeleton';
 
 const toggleProps = () => ({
   className: 'some-class',
+  labelText: text('Label for toggle button input', ''),
   labelA: text('Label for untoggled state (labelA)', 'Off'),
   labelB: text('Label for toggled state (labelB)', 'On'),
   onChange: action('onChange'),

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -12,6 +12,7 @@ const Toggle = ({
   onChange,
   onToggle,
   id,
+  labelText,
   labelA,
   labelB,
   ...other
@@ -30,7 +31,7 @@ const Toggle = ({
     checkedProps.defaultChecked = defaultToggled;
   }
 
-  return (
+  const ToggleBody = () => (
     <div className={wrapperClasses}>
       <input
         {...other}
@@ -53,6 +54,15 @@ const Toggle = ({
         <span className={`${prefix}--toggle__text--right`}>{labelB}</span>
       </label>
     </div>
+  );
+
+  return labelText ? (
+    <fieldset className={`${prefix}--fieldset`}>
+      <legend className={`${prefix}--label`}>{labelText}</legend>
+      <ToggleBody />
+    </fieldset>
+  ) : (
+    <ToggleBody />
   );
 };
 
@@ -95,6 +105,7 @@ Toggle.propTypes = {
 
 Toggle.defaultProps = {
   defaultToggled: false,
+  label: '',
   labelA: 'Off',
   labelB: 'On',
   onToggle: () => {},

--- a/src/components/ToggleSmall/ToggleSmall-story.js
+++ b/src/components/ToggleSmall/ToggleSmall-story.js
@@ -8,6 +8,8 @@ import ToggleSmallSkeleton from '../ToggleSmall/ToggleSmall.Skeleton';
 const toggleProps = () => ({
   className: 'some-class',
   ariaLabel: text('ARIA label (ariaLabel)', 'Label Name'),
+  labelA: text('Label for untoggled state (labelA)', 'Off'),
+  labelB: text('Label for toggled state (labelB)', 'On'),
   onChange: action('onChange'),
   onToggle: action('onToggle'),
 });

--- a/src/components/ToggleSmall/ToggleSmall.js
+++ b/src/components/ToggleSmall/ToggleSmall.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -49,13 +50,15 @@ const ToggleSmall = ({
 
       <label className={`${prefix}--toggle__label`} htmlFor={id}>
         <span className={`${prefix}--toggle__appearance`}>
-          <svg
-            className={`${prefix}--toggle__check`}
-            width="6px"
-            height="5px"
-            viewBox="0 0 6 5">
-            <path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z" />
-          </svg>
+          {componentsX ? null : (
+            <svg
+              className={`${prefix}--toggle__check`}
+              width="6px"
+              height="5px"
+              viewBox="0 0 6 5">
+              <path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z" />
+            </svg>
+          )}
         </span>
       </label>
     </div>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1692

This PR will add the new experimental toggle and small toggle changes

currently blocked by sketch license expiring and being unable to check sketch file for whether or not `<ToggleSmall>` maintains the check mark SVG in the experimental version