### PR TITLE
fix: Adds an aria-label to the div surrounding the tooltip icon, reso…

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -390,6 +390,7 @@ export default class Tooltip extends Component {
                 onFocus={evt => this.handleMouse(evt)}
                 onBlur={evt => this.handleMouse(evt)}
                 aria-haspopup="true"
+                aria-label={iconDescription}
                 aria-expanded={open}
                 {...ariaOwnsProps}>
                 <Icon


### PR DESCRIPTION
…lves #1697.

Closes IBM/carbon-components-react #1697 

This is a small change to add the `aria-label` attribute in the parent div element when it is an interactive element.