### PR TITLE
fix: We are now marking the overflow menu element as an Aria menu ins…

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -537,7 +537,7 @@ export default class OverflowMenu extends Component {
       <ClickListener onClickOutside={this.handleClickOutside}>
         <div
           {...other}
-          role="button"
+          role="menu"
           aria-haspopup
           aria-expanded={this.state.open}
           className={overflowMenuClasses}


### PR DESCRIPTION
…tead of button, resolves #1699.

Just changing the role to menu.