### PR TITLE
feat(Tooltip): add experimental tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { settings } from 'carbon-components';
 
 import {
   withKnobs,
@@ -10,6 +11,7 @@ import {
 } from '@storybook/addon-knobs';
 import Tooltip from '../Tooltip';
 
+const { prefix } = settings;
 const directions = {
   'Bottom (bottom)': 'bottom',
   'Left (left)': 'left',
@@ -39,16 +41,21 @@ storiesOf('Tooltip', module)
     () => (
       <div style={{ marginTop: '2rem' }}>
         <Tooltip {...props.withIcon()}>
-          <p className="bx--tooltip__label">Tooltip subtitle</p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
+            This is some tooltip text. This box shows the maximum amount of text
+            that should appear inside. If more room is needed please use a modal
+            instead.
           </p>
+          <div className={`${prefix}--tooltip__footer`}>
+            <a href="/" className={`${prefix}--link`}>
+              Learn More
+            </a>
+            <button
+              className={`${prefix}--btn ${prefix}--btn--primary`}
+              type="button">
+              Create
+            </button>
+          </div>
         </Tooltip>
       </div>
     ),
@@ -66,16 +73,21 @@ storiesOf('Tooltip', module)
     () => (
       <div style={{ marginTop: '2rem' }}>
         <Tooltip {...props.withoutIcon()}>
-          <p className="bx--tooltip__label">Tooltip subtitle</p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
+            This is some tooltip text. This box shows the maximum amount of text
+            that should appear inside. If more room is needed please use a modal
+            instead.
           </p>
+          <div className={`${prefix}--tooltip__footer`}>
+            <a href="/" className={`${prefix}--link`}>
+              Learn More
+            </a>
+            <button
+              className={`${prefix}--btn ${prefix}--btn--primary`}
+              type="button">
+              Create
+            </button>
+          </div>
         </Tooltip>
       </div>
     ),

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -4,6 +4,8 @@ import debounce from 'lodash.debounce';
 import Icon from '../Icon';
 import classNames from 'classnames';
 import { iconInfoGlyph } from 'carbon-icons';
+// TODO: import { Information } from '@carbon/icons-react';
+import Information from '@carbon/icons-react/lib/information/16';
 import { settings } from 'carbon-components';
 import FloatingMenu, {
   DIRECTION_LEFT,
@@ -12,6 +14,7 @@ import FloatingMenu, {
   DIRECTION_BOTTOM,
 } from '../../internal/FloatingMenu';
 import ClickListener from '../../internal/ClickListener';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -364,7 +367,8 @@ export default class Tooltip extends Component {
     );
 
     const triggerClasses = classNames(
-      `${prefix}--tooltip__trigger`,
+      { [`${prefix}--tooltip__trigger`]: !componentsX },
+      { [`${prefix}--tooltip__label`]: componentsX },
       triggerClassName
     );
     const ariaOwnsProps = !open
@@ -381,6 +385,7 @@ export default class Tooltip extends Component {
               {triggerText}
               <div
                 id={triggerId}
+                className={componentsX ? `${prefix}--tooltip__trigger` : null}
                 role="button"
                 tabIndex={tabIndex}
                 onClick={this.handleMouse}
@@ -393,15 +398,26 @@ export default class Tooltip extends Component {
                 aria-label={iconDescription}
                 aria-expanded={open}
                 {...ariaOwnsProps}>
-                <Icon
-                  icon={!icon && !iconName ? iconInfoGlyph : icon}
-                  name={iconName}
-                  description={iconDescription}
-                  iconTitle={iconTitle}
-                  iconRef={node => {
-                    this.triggerEl = node;
-                  }}
-                />
+                {componentsX ? (
+                  <Information
+                    name={iconName}
+                    alt={iconDescription}
+                    aria-label={iconDescription}
+                    ref={node => {
+                      this.triggerEl = node;
+                    }}
+                  />
+                ) : (
+                  <Icon
+                    icon={!icon && !iconName ? iconInfoGlyph : icon}
+                    name={iconName}
+                    description={iconDescription}
+                    iconTitle={iconTitle}
+                    iconRef={node => {
+                      this.triggerEl = node;
+                    }}
+                  />
+                )}
               </div>
             </div>
           ) : (

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -383,12 +383,12 @@ export default class Tooltip extends Component {
                 id={triggerId}
                 role="button"
                 tabIndex={tabIndex}
-                onClick={evt => this.handleMouse(evt)}
-                onKeyDown={evt => this.handleKeyPress(evt)}
-                onMouseOver={evt => this.handleMouse(evt)}
-                onMouseOut={evt => this.handleMouse(evt)}
-                onFocus={evt => this.handleMouse(evt)}
-                onBlur={evt => this.handleMouse(evt)}
+                onClick={this.handleMouse}
+                onKeyDown={this.handleKeyPress}
+                onMouseOver={this.handleMouse}
+                onMouseOut={this.handleMouse}
+                onFocus={this.handleMouse}
+                onBlur={this.handleMouse}
                 aria-haspopup="true"
                 aria-label={iconDescription}
                 aria-expanded={open}
@@ -412,10 +412,10 @@ export default class Tooltip extends Component {
               ref={node => {
                 this.triggerEl = node;
               }}
-              onMouseOver={evt => this.handleMouse(evt)}
-              onMouseOut={evt => this.handleMouse(evt)}
-              onFocus={evt => this.handleMouse(evt)}
-              onBlur={evt => this.handleMouse(evt)}
+              onMouseOver={this.handleMouse}
+              onMouseOut={this.handleMouse}
+              onFocus={this.handleMouse}
+              onBlur={this.handleMouse}
               aria-haspopup="true"
               aria-expanded={open}
               {...ariaOwnsProps}
@@ -439,11 +439,11 @@ export default class Tooltip extends Component {
               {...other}
               data-floating-menu-direction={direction}
               aria-labelledby={triggerId}
-              onMouseOver={evt => this.handleMouse(evt)}
-              onMouseOut={evt => this.handleMouse(evt)}
-              onFocus={evt => this.handleMouse(evt)}
-              onBlur={evt => this.handleMouse(evt)}
-              onContextMenu={evt => this.handleMouse(evt)}>
+              onMouseOver={this.handleMouse}
+              onMouseOut={this.handleMouse}
+              onFocus={this.handleMouse}
+              onBlur={this.handleMouse}
+              onContextMenu={this.handleMouse}>
               <span className={`${prefix}--tooltip__caret`} />
               {children}
             </div>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -401,7 +401,7 @@ export default class Tooltip extends Component {
                 {componentsX ? (
                   <Information
                     name={iconName}
-                    alt={iconDescription}
+                    aria-labelledby={triggerId}
                     aria-label={iconDescription}
                     ref={node => {
                       this.triggerEl = node;

--- a/src/components/TooltipIcon/TooltipIcon-story.js
+++ b/src/components/TooltipIcon/TooltipIcon-story.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-
+import { Filter16 } from '@carbon/icons-react';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import TooltipIcon from '../TooltipIcon';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const directions = {
   'Bottom (bottom)': 'bottom',
@@ -20,11 +21,15 @@ storiesOf('TooltipIcon', module)
     'default',
     () => (
       <TooltipIcon {...props()}>
-        <svg width="16" height="12" viewBox="0 0 16 12">
-          <g fillRule="nonzero">
-            <path d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
-          </g>
-        </svg>
+        {componentsX ? (
+          <Filter16 />
+        ) : (
+          <svg width="16" height="12" viewBox="0 0 16 12">
+            <g fillRule="nonzero">
+              <path d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
+            </g>
+          </svg>
+        )}
       </TooltipIcon>
     ),
     {


### PR DESCRIPTION
Closes IBM/carbon-components-react#1707

This PR will support the new icon strategy in the experimental tooltip (related: https://github.com/IBM/carbon-elements/issues/228, https://github.com/IBM/carbon-elements/pull/231)