### PR TITLE
fix(DatePicker): avoid rendering extra icons for experimental DatePicker

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -14,6 +14,7 @@ import rangePlugin from 'flatpickr/dist/plugins/rangePlugin';
 import { settings } from 'carbon-components';
 import DatePickerInput from '../DatePickerInput';
 import Icon from '../Icon';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -443,16 +444,14 @@ export default class DatePicker extends Component {
     });
 
     const datePickerIcon =
-      datePickerType === 'range' ? (
+      !componentsX && datePickerType === 'range' ? (
         <Icon
           name="calendar"
           className={`${prefix}--date-picker__icon`}
           description={iconDescription}
           onClick={this.openCalendar}
         />
-      ) : (
-        ''
-      );
+      ) : null;
 
     const childArray = React.Children.toArray(children);
     const childrenWithProps = childArray.map((child, index) => {

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import Icon from '../Icon';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -76,16 +77,14 @@ export default class DatePickerInput extends Component {
     });
 
     const datePickerIcon =
-      datePickerType === 'single' ? (
+      !componentsX && datePickerType === 'single' ? (
         <Icon
           name="calendar"
           className={`${prefix}--date-picker__icon`}
           description={iconDescription}
           onClick={openCalendar}
         />
-      ) : (
-        ''
-      );
+      ) : null;
 
     const label = labelText ? (
       <label htmlFor={id} className={labelClasses}>

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -9,6 +9,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+// TODO: import { Calendar16 } from '@carbon/icons-react/';
+import Calendar16 from '@carbon/icons-react/lib/calendar/16';
 import Icon from '../Icon';
 import { componentsX } from '../../internal/FeatureFlags';
 
@@ -76,15 +78,29 @@ export default class DatePickerInput extends Component {
       [`${prefix}--visually-hidden`]: hideLabel,
     });
 
-    const datePickerIcon =
-      !componentsX && datePickerType === 'single' ? (
+    const datePickerIcon = (() => {
+      if (datePickerType !== 'single') {
+        return;
+      }
+      if (componentsX) {
+        return (
+          <Calendar16
+            className={`${prefix}--date-picker__icon`}
+            aria-label={iconDescription}
+            onClick={openCalendar}
+            role="img"
+          />
+        );
+      }
+      return (
         <Icon
           name="calendar"
           className={`${prefix}--date-picker__icon`}
           description={iconDescription}
           onClick={openCalendar}
         />
-      ) : null;
+      );
+    })();
 
     const label = labelText ? (
       <label htmlFor={id} className={labelClasses}>


### PR DESCRIPTION
The vanilla experimental date picker is displaying the SVG icons as a background image. To match this approach, we can avoid using the `<Icon>` component in the React DatePicker

**Changed**

- conditionally render `<Icon>` based on feature flag state