### PR TITLE
fix(Tag): remove boolean logic from rendering children

### DIFF
--- a/src/components/Tag/Tag-story.js
+++ b/src/components/Tag/Tag-story.js
@@ -18,18 +18,16 @@ storiesOf('Tag', module)
   .add(
     'Default',
     () => (
-      <div>
-        <Tag
-          className="some-class"
-          type={select(
-            'Tag type (type)',
-            types,
-            componentsX ? 'basic' : 'experimental'
-          )}
-          disabled={boolean('Disabled (disabled)', false)}>
-          {text('Content (children)', 'This is not a tag')}
-        </Tag>
-      </div>
+      <Tag
+        className="some-class"
+        type={select(
+          'Tag type (type)',
+          types,
+          componentsX ? 'basic' : 'experimental'
+        )}
+        disabled={boolean('Disabled (disabled)', false)}>
+        {text('Content (children)', 'This is not a tag')}
+      </Tag>
     ),
     {
       info: {

--- a/src/components/Tag/Tag-test.js
+++ b/src/components/Tag/Tag-test.js
@@ -10,13 +10,6 @@ describe('Tag', () => {
       expect(tag.hasClass('bx--tag')).toEqual(true);
       expect(tag.hasClass('bx--tag--beta')).toEqual(true);
     });
-
-    it('should provide a default label based on the type', () => {
-      const tag = shallow(<Tag type="beta" />);
-      expect(tag.text()).toEqual('Beta');
-      tag.setProps({ type: 'ibm' });
-      expect(tag.text()).toEqual('IBM');
-    });
   });
 
   it('should allow for a custom label', () => {

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -36,7 +36,7 @@ const Tag = ({ children, className, type, ...other }) => {
   const tagClasses = classNames(`${prefix}--tag`, tagClass, className);
   return (
     <span className={tagClasses} {...other}>
-      {children}
+      {children !== null && children !== undefined ? children : TYPES[type]}
     </span>
   );
 };

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -36,7 +36,7 @@ const Tag = ({ children, className, type, ...other }) => {
   const tagClasses = classNames(`${prefix}--tag`, tagClass, className);
   return (
     <span className={tagClasses} {...other}>
-      {children || TYPES[type]}
+      {children}
     </span>
   );
 };


### PR DESCRIPTION
Closes IBM/carbon-components-react#1720

This PR removes some boolean logic which was preventing the `children` of the `<Tag>` component from rendering when it was a falsey value like `0`. It appears like initially the logic was implemented to always render a value, but since `props.children` is not a required prop, it should be fine to have nothing render if no children are passed into the `<Tag>`

alternatively, we can set a default value on `children` rather than displaying the `type` value by default, which may cause problems when users migrate from v9 to v10 too since the type values are changing