### PR TITLE
fix(Modal): add aria-modal attribute

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -302,7 +302,8 @@ export default class Modal extends Component {
         ref={this.innerModal}
         role="dialog"
         className={`${prefix}--modal-container`}
-        aria-label={modalAriaLabel}>
+        aria-label={modalAriaLabel}
+        aria-modal="true">
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}
           {modalLabel && (

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -90,6 +90,7 @@ exports[`ModalWrapper should render 1`] = `
         tabIndex={-1}
       >
         <div
+          aria-modal="true"
           className="bx--modal-container"
           role="dialog"
         >


### PR DESCRIPTION
Closes IBM/carbon-components-react#1752

This PR adds the `aria-modal` attribute to the `<Modal />` component in accordance with W3C guidelines