### PR TITLE
fix(Modal): avoid NPE with null check

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -219,9 +219,9 @@ export default class Modal extends Component {
   }
 
   focusButton = focusContainerElement => {
-    const primaryFocusElement = focusContainerElement.querySelector(
-      this.props.selectorPrimaryFocus
-    );
+    const primaryFocusElement = focusContainerElement
+      ? focusContainerElement.querySelector(this.props.selectorPrimaryFocus)
+      : null;
     if (primaryFocusElement) {
       primaryFocusElement.focus();
       return;


### PR DESCRIPTION
Closes IBM/carbon-components-react#1751

This PR avoids a NPE in `<Modal />` by performing a null check on the focus button before chaining the `.querySelector` method