### PR TITLE
feat(inlineloading): added new prop alignTextLeft

### DIFF
--- a/src/components/InlineLoading/InlineLoading-story.js
+++ b/src/components/InlineLoading/InlineLoading-story.js
@@ -25,6 +25,7 @@ const props = () => ({
     1500
   ),
   onSuccess: action('onSuccess'),
+  alignTextLeft: boolean('Align text to the left of the spinner', false),
 });
 
 storiesOf('InlineLoading', module)
@@ -105,7 +106,7 @@ storiesOf('InlineLoading', module)
       info: {
         text: `
             This is a full example of how to levarage the <InlineLoading /> component to create a nice user experience when submitting a form.
-    
+
             For the full source code of this example, check out the 'story' panel below.
           `,
       },

--- a/src/components/InlineLoading/InlineLoading-test.js
+++ b/src/components/InlineLoading/InlineLoading-test.js
@@ -59,7 +59,12 @@ describe('Loading', () => {
     });
 
     it('should render the loading spinner first by default', () => {
-      expect(wrapper.find('.bx--inline-loading').childAt(0).hasClass('bx--inline-loading__animation')).toEqual(true)
+      expect(
+        wrapper
+          .find('.bx--inline-loading')
+          .childAt(0)
+          .hasClass('bx--inline-loading__animation')
+      ).toEqual(true);
     });
   });
 
@@ -93,10 +98,17 @@ describe('Loading', () => {
   });
 
   describe('alignTextLeft prop should render properly', () => {
-    const wrapper = mount(<InlineLoading description="Loading Things..." alignTextLeft />);
-    
+    const wrapper = mount(
+      <InlineLoading description="Loading Things..." alignTextLeft />
+    );
+
     it('should render the text first', () => {
-      expect(wrapper.find('.bx--inline-loading').childAt(0).hasClass('bx--inline-loading__text')).toEqual(true)
+      expect(
+        wrapper
+          .find('.bx--inline-loading')
+          .childAt(0)
+          .hasClass('bx--inline-loading__text')
+      ).toEqual(true);
     });
-  })
+  });
 });

--- a/src/components/InlineLoading/InlineLoading-test.js
+++ b/src/components/InlineLoading/InlineLoading-test.js
@@ -57,6 +57,10 @@ describe('Loading', () => {
         'Loading Things...'
       );
     });
+
+    it('should render the loading spinner first by default', () => {
+      expect(wrapper.find('.bx--inline-loading').childAt(0).hasClass('bx--inline-loading__animation')).toEqual(true)
+    });
   });
 
   describe('Success state should render properly', () => {
@@ -87,4 +91,12 @@ describe('Loading', () => {
       );
     });
   });
+
+  describe('alignTextLeft prop should render properly', () => {
+    const wrapper = mount(<InlineLoading description="Loading Things..." alignTextLeft />);
+    
+    it('should render the text first', () => {
+      expect(wrapper.find('.bx--inline-loading').childAt(0).hasClass('bx--inline-loading__text')).toEqual(true)
+    });
+  })
 });

--- a/src/components/InlineLoading/InlineLoading.js
+++ b/src/components/InlineLoading/InlineLoading.js
@@ -40,6 +40,11 @@ export default class InlineLoading extends React.Component {
      * Provide a delay for the `setTimeout` for success
      */
     successDelay: PropTypes.number,
+
+    /**
+     * Align text to the left of the loading spinner
+     */
+     alignTextLeft: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -54,6 +59,7 @@ export default class InlineLoading extends React.Component {
       description,
       onSuccess,
       successDelay,
+      alignTextLeft,
       ...other
     } = this.props;
 
@@ -87,6 +93,19 @@ export default class InlineLoading extends React.Component {
       <p className={`${prefix}--inline-loading__text`}>{description}</p>
     );
 
+    // Return text first
+    if (alignTextLeft) {
+      return (
+        <div className={loadingClasses} {...other}>
+          {description && loadingText}
+          <div className={`${prefix}--inline-loading__animation`}>
+            {getLoading()}
+          </div>
+        </div>
+      );
+    }
+
+    // Default text to the right
     return (
       <div className={loadingClasses} {...other}>
         <div className={`${prefix}--inline-loading__animation`}>

--- a/src/components/InlineLoading/InlineLoading.js
+++ b/src/components/InlineLoading/InlineLoading.js
@@ -44,7 +44,7 @@ export default class InlineLoading extends React.Component {
     /**
      * Align text to the left of the loading spinner
      */
-     alignTextLeft: PropTypes.bool,
+    alignTextLeft: PropTypes.bool,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Closes IBM/carbon-components#1659

Probably should've had the issue be in the react repo, my bad!

This adds a prop to the InlineLoading component to render the text before the loading spinner for contextual a better visual pattern when the contextual loading area is right aligned on the page.