### PR TITLE
feat(TextInput): allow TextInput to handle refs like a native component

### DIFF
--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -27,6 +27,27 @@ describe('TextInput', () => {
       it('renders as expected', () => {
         expect(textInput().length).toBe(1);
       });
+      it('should accept refs', () => {
+        class MyComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.textInput = React.createRef();
+            this.focus = this.focus.bind(this);
+          }
+          focus() {
+            this.textInput.current.focus();
+          }
+          render() {
+            return (
+              <TextInput id="test" labelText="testlabel" ref={this.textInput} />
+            );
+          }
+        }
+        const wrapper = mount(<MyComponent />);
+        expect(document.activeElement.type).toBeUndefined();
+        wrapper.instance().focus();
+        expect(document.activeElement.type).toEqual('text');
+      });
 
       it('has the expected classes', () => {
         expect(textInput().hasClass('bx--text-input')).toEqual(true);
@@ -128,7 +149,7 @@ describe('TextInput', () => {
         />
       );
 
-      const input = wrapper.find('input');
+      const input = wrapper.dive().find('input');
 
       it('should not invoke onClick', () => {
         input.simulate('click');
@@ -154,7 +175,7 @@ describe('TextInput', () => {
         />
       );
 
-      const input = wrapper.find('input');
+      const input = wrapper.dive().find('input');
       const eventObject = {
         target: {
           defaultValue: 'test',

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -25,6 +25,7 @@ const TextInput = ({
   invalidText,
   helperText,
   light,
+  forwardRef: ref,
   ...other
 }) => {
   const textInputProps = {
@@ -41,6 +42,7 @@ const TextInput = ({
     },
     placeholder,
     type,
+    ref,
   };
 
   const errorId = id + '-error-msg';
@@ -181,4 +183,6 @@ TextInput.defaultProps = {
   light: false,
 };
 
-export default TextInput;
+export default React.forwardRef((props, ref) => (
+  <TextInput {...props} forwardRef={ref} />
+));


### PR DESCRIPTION
Closes IBM/carbon-components-react#1768

#### Changelog

- added ability to forwardRefs
