### PR TITLE
feat(TextInput): allow TextInput to handle refs like a native input e…

### DIFF
--- a/src/components/Checkbox/Checkbox-test.js
+++ b/src/components/Checkbox/Checkbox-test.js
@@ -106,6 +106,35 @@ describe('Checkbox', () => {
   });
 });
 
+describe('refs', () => {
+  it('should accept refs', () => {
+    class MyComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.myRef = React.createRef();
+        this.focus = this.focus.bind(this);
+      }
+      focus() {
+        this.myRef.current.focus();
+      }
+      render() {
+        return (
+          <Checkbox
+            id="test"
+            labelText="testlabel"
+            hideLabel
+            ref={this.myRef}
+          />
+        );
+      }
+    }
+    const wrapper = mount(<MyComponent />);
+    expect(document.activeElement.type).toBeUndefined();
+    wrapper.instance().focus();
+    expect(document.activeElement.type).toEqual('checkbox');
+  });
+});
+
 describe('CheckboxSkeleton', () => {
   describe('Renders as expected', () => {
     const wrapper = mount(<CheckboxSkeleton />);

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -21,6 +21,7 @@ const Checkbox = ({
   hideLabel,
   wrapperClassName,
   title = '',
+  forwardRef: ref,
   ...other
 }) => {
   let input;
@@ -40,16 +41,19 @@ const Checkbox = ({
         {...other}
         type="checkbox"
         onChange={evt => {
-          onChange(input.checked, id, evt);
+          onChange(evt.target.checked, id, evt);
         }}
         className={`${prefix}--checkbox`}
         id={id}
-        ref={el => {
-          input = el;
-          if (input) {
-            input.indeterminate = indeterminate;
-          }
-        }}
+        ref={
+          ref ||
+          (el => {
+            input = el;
+            if (input) {
+              input.indeterminate = indeterminate;
+            }
+          })
+        }
       />
       <label htmlFor={id} className={labelClasses} title={title || null}>
         <span className={innerLabelClasses}>{labelText}</span>
@@ -122,4 +126,6 @@ Checkbox.defaultProps = {
   indeterminate: false,
 };
 
-export default Checkbox;
+export default React.forwardRef((props, ref) => (
+  <Checkbox {...props} forwardRef={ref} />
+));

--- a/src/components/Select/Select-test.js
+++ b/src/components/Select/Select-test.js
@@ -28,7 +28,8 @@ describe('Select', () => {
 
     const selectContainer = wrapper.find('.bx--form-item > div');
     const label = wrapper.find('label');
-    const select = wrapper.find('select');
+    const selectWrapper = () => wrapper.find('Select');
+    const select = () => wrapper.find('select');
     const helper = wrapper.find('.bx--form__helper-text');
 
     describe('selectContainer', () => {
@@ -54,7 +55,9 @@ describe('Select', () => {
       });
 
       it('has the expected default iconDescription', () => {
-        expect(wrapper.props().iconDescription).toEqual('open list of options');
+        expect(selectWrapper().props().iconDescription).toEqual(
+          'open list of options'
+        );
       });
 
       it('adds new iconDescription when passed via props', () => {
@@ -70,38 +73,38 @@ describe('Select', () => {
       });
 
       it('should specify light select as expected', () => {
-        expect(wrapper.props().light).toEqual(false);
+        expect(selectWrapper().props().light).toEqual(false);
         wrapper.setProps({ light: true });
-        expect(wrapper.props().light).toEqual(true);
+        expect(selectWrapper().props().light).toEqual(true);
       });
     });
 
     describe('select', () => {
       it('renders a select', () => {
-        expect(select.length).toEqual(1);
+        expect(selectWrapper().length).toEqual(1);
       });
 
       it('has the expected classes', () => {
-        expect(select.hasClass('bx--select-input')).toEqual(true);
+        expect(select().hasClass('bx--select-input')).toEqual(true);
       });
 
       it('has the expected id', () => {
-        expect(select.props().id).toEqual('testing');
+        expect(selectWrapper().props().id).toEqual('testing');
       });
 
       it('should set defaultValue as expected', () => {
         wrapper.setProps({ defaultValue: 'select-1' });
-        expect(wrapper.find('select').props().defaultValue).toEqual('select-1');
+        expect(select().props().defaultValue).toEqual('select-1');
       });
 
       it('should set disabled as expected', () => {
-        expect(select.props().disabled).toEqual(undefined);
+        expect(selectWrapper().props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(wrapper.find('select').props().disabled).toEqual(true);
+        expect(selectWrapper().props().disabled).toEqual(true);
       });
 
       it('renders children as expected', () => {
-        expect(select.props().children.length).toEqual(2);
+        expect(selectWrapper().props().children.length).toEqual(2);
       });
     });
 
@@ -163,6 +166,28 @@ describe('Select', () => {
     it('has the expected classes', () => {
       expect(selectContainer.hasClass('bx--select--inline')).toEqual(true);
     });
+  });
+});
+
+describe('refs', () => {
+  it('should accept refs', () => {
+    class MyComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.myRef = React.createRef();
+        this.focus = this.focus.bind(this);
+      }
+      focus() {
+        this.myRef.current.focus();
+      }
+      render() {
+        return <Select id="test" labelText="testlabel" ref={this.myRef} />;
+      }
+    }
+    const wrapper = mount(<MyComponent />);
+    expect(document.activeElement.type).toBeUndefined();
+    wrapper.instance().focus();
+    expect(document.activeElement.type).toEqual('select-one');
   });
 });
 

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -30,6 +30,7 @@ const Select = ({
   invalidText,
   helperText,
   light,
+  forwardRef: ref,
   ...other
 }) => {
   const selectClasses = classNames({
@@ -68,7 +69,8 @@ const Select = ({
           className={`${prefix}--select-input`}
           disabled={disabled || undefined}
           data-invalid={invalid || undefined}
-          aria-invalid={invalid || undefined}>
+          aria-invalid={invalid || undefined}
+          ref={ref}>
           {children}
         </select>
         {componentsX ? (
@@ -179,4 +181,6 @@ Select.defaultProps = {
   light: false,
 };
 
-export default Select;
+export default React.forwardRef((props, ref) => (
+  <Select {...props} forwardRef={ref} />
+));

--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -27,6 +27,28 @@ describe('TextInput', () => {
       it('renders as expected', () => {
         expect(textInput().length).toBe(1);
       });
+      
+      it('should accept refs', () => {
+        class MyComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.textInput = React.createRef();
+            this.focus = this.focus.bind(this);
+          }
+          focus() {
+            this.textInput.current.focus();
+          }
+          render() {
+            return (
+              <TextInput id="test" labelText="testlabel" ref={this.textInput} />
+            );
+          }
+        }
+        const wrapper = mount(<MyComponent />);
+        expect(document.activeElement.type).toBeUndefined();
+        wrapper.instance().focus();
+        expect(document.activeElement.type).toEqual('text');
+      });
 
       it('has the expected classes', () => {
         expect(textInput().hasClass('bx--text-input')).toEqual(true);
@@ -128,7 +150,7 @@ describe('TextInput', () => {
         />
       );
 
-      const input = wrapper.find('input');
+      const input = wrapper.dive().find('input');
 
       it('should not invoke onClick', () => {
         input.simulate('click');
@@ -154,7 +176,7 @@ describe('TextInput', () => {
         />
       );
 
-      const input = wrapper.find('input');
+      const input = wrapper.dive().find('input');
       const eventObject = {
         target: {
           defaultValue: 'test',

--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -27,7 +27,7 @@ describe('TextInput', () => {
       it('renders as expected', () => {
         expect(textInput().length).toBe(1);
       });
-      
+
       it('should accept refs', () => {
         class MyComponent extends React.Component {
           constructor(props) {

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -25,6 +25,7 @@ const TextInput = ({
   invalidText,
   helperText,
   light,
+  forwardRef: ref,
   ...other
 }) => {
   const textInputProps = {
@@ -41,6 +42,7 @@ const TextInput = ({
     },
     placeholder,
     type,
+    ref,
   };
 
   const errorId = id + '-error-msg';
@@ -181,4 +183,6 @@ TextInput.defaultProps = {
   light: false,
 };
 
-export default TextInput;
+export default React.forwardRef((props, ref) => (
+  <TextInput {...props} forwardRef={ref} />
+));


### PR DESCRIPTION
Closes IBM/carbon-components-react#1191

added ability to forward refs
