### PR TITLE
fix(FloatingMenu): changes scrollY to pageYOffset for IE

### DIFF
--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -255,7 +255,7 @@ class FloatingMenu extends React.Component {
             refPosition,
             direction: menuDirection,
             offset,
-            scrollY: window.scrollY,
+            scrollY: window.pageYOffset,
           }),
         });
       }


### PR DESCRIPTION
> Note: this PR is against v5 branch

scrollY is not available in IE but pageYOffset is an alias. The 6.x.x floating menu uses pageYOffset