### PR TITLE
refactor(Tabs): prefix `tab-content` class

### DIFF
--- a/src/components/Tabs/Tabs-test.js
+++ b/src/components/Tabs/Tabs-test.js
@@ -104,22 +104,22 @@ describe('Tabs', () => {
     );
 
     it('renders expected className', () => {
-      const tabContentClass = 'tab-content';
+      const tabContentClass = 'bx--tab-content';
       expect(
         wrapper
-          .find('.tab-content')
+          .find('.bx--tab-content')
           .first()
           .hasClass(tabContentClass)
       ).toBe(true);
     });
 
     it('renders content children as expected', () => {
-      expect(wrapper.find('.tab-content').length).toEqual(2);
+      expect(wrapper.find('.bx--tab-content').length).toEqual(2);
     });
 
     it('renders hidden props with boolean value', () => {
       const hiddenProp = wrapper
-        .find('.tab-content')
+        .find('.bx--tab-content')
         .first()
         .props().hidden;
       expect(typeof hiddenProp).toBe('boolean');
@@ -127,7 +127,7 @@ describe('Tabs', () => {
 
     it('renders selected props with boolean value', () => {
       const selectedProp = wrapper
-        .find('.tab-content')
+        .find('.bx--tab-content')
         .first()
         .props().hidden;
       expect(typeof selectedProp).toBe('boolean');

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -230,7 +230,7 @@ export default class Tabs extends React.Component {
 
       return (
         <TabContent
-          className="tab-content"
+          className={`${prefix}--tab-content`}
           aria-hidden={!selected}
           hidden={!selected}
           selected={selected}>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1790

This PR adds our CSS prefix to the `TabContent` component's class name and modifies the tests to expect the updated class