### PR TITLE
feat(ListBoxMenuIcon): support translatable SVG icon title

### DIFF
--- a/src/components/ListBox/ListBoxMenuIcon.js
+++ b/src/components/ListBox/ListBoxMenuIcon.js
@@ -40,7 +40,9 @@ const ListBoxMenuIcon = ({ isOpen, translateWithId: t }) => {
   return (
     <div className={className}>
       {componentsX ? (
-        <ChevronDown16 name="chevron--down" />
+        <ChevronDown16 name="chevron--down" aria-label={description}>
+          <title>{description}</title>
+        </ChevronDown16>
       ) : (
         <Icon
           icon={iconCaretDown}

--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -54,8 +54,11 @@ const props = () => ({
   ),
   onChange: action('onChange'),
   listBoxMenuIconTranslationIds: object(
-    'Listbox menu icon translation IDs (listBoxMenuIconTranslationIds)',
-    { 'close.menu': 'Close menu', 'open.menu': 'Open menu' }
+    'Listbox menu icon translation IDs (for translateWithId callback)',
+    {
+      'close.menu': 'Close menu',
+      'open.menu': 'Open menu',
+    }
   ),
 });
 
@@ -64,7 +67,11 @@ storiesOf('MultiSelect', module)
   .add(
     'default',
     () => {
-      const { filterable, ...multiSelectProps } = props();
+      const {
+        filterable,
+        listBoxMenuIconTranslationIds,
+        ...multiSelectProps
+      } = props();
       const ComponentToUse = !filterable ? MultiSelect : MultiSelect.Filterable;
       const placeholder = !filterable ? undefined : defaultPlaceholder;
       return (
@@ -74,6 +81,7 @@ storiesOf('MultiSelect', module)
             items={items}
             itemToString={item => (item ? item.text : '')}
             placeholder={placeholder}
+            translateWithId={id => listBoxMenuIconTranslationIds[id]}
           />
         </div>
       );
@@ -89,7 +97,11 @@ storiesOf('MultiSelect', module)
   .add(
     'with initial selected items',
     () => {
-      const { filterable, ...multiSelectProps } = props();
+      const {
+        filterable,
+        listBoxMenuIconTranslationIds,
+        ...multiSelectProps
+      } = props();
       const ComponentToUse = !filterable ? MultiSelect : MultiSelect.Filterable;
       const placeholder = !filterable ? undefined : defaultPlaceholder;
       return (
@@ -100,6 +112,7 @@ storiesOf('MultiSelect', module)
             itemToString={item => (item ? item.text : '')}
             initialSelectedItems={[items[0], items[1]]}
             placeholder={placeholder}
+            translateWithId={id => listBoxMenuIconTranslationIds[id]}
           />
         </div>
       );

--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -9,7 +9,13 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  boolean,
+  select,
+  text,
+  object,
+} from '@storybook/addon-knobs';
 import MultiSelect from '../MultiSelect';
 
 const items = [
@@ -47,6 +53,10 @@ const props = () => ({
     'Invalid Selection'
   ),
   onChange: action('onChange'),
+  listBoxMenuIconTranslationIds: object(
+    'Listbox menu icon translation IDs (listBoxMenuIconTranslationIds)',
+    { 'close.menu': 'Close menu', 'open.menu': 'Open menu' }
+  ),
 });
 
 storiesOf('MultiSelect', module)

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -93,11 +93,9 @@ export default class MultiSelect extends React.Component {
     invalidText: PropTypes.string,
 
     /**
-     * Object containing localized alt text for the listbox menu icon
-     * listBoxMenuIconTranslationIds[close.menu] - alt text for closing listbox
-     * listBoxMenuIconTranslationIds[open.menu] - alt text for opening listbox
+     * Callback function for translating ListBoxMenuIcon SVG title
      */
-    listBoxMenuIconTranslationIds: PropTypes.object,
+    translateWithId: PropTypes.function,
   };
 
   static defaultProps = {
@@ -110,10 +108,7 @@ export default class MultiSelect extends React.Component {
     type: 'default',
     light: false,
     title: false,
-    listBoxMenuIconTranslationIds: {
-      'close.menu': 'Close menu',
-      'open.menu': 'Open menu',
-    },
+    translateWithId: () => {},
   };
 
   constructor(props) {
@@ -186,7 +181,7 @@ export default class MultiSelect extends React.Component {
       invalid,
       invalidText,
       useTitleInItem,
-      listBoxMenuIconTranslationIds,
+      translateWithId,
     } = this.props;
     const className = cx(`${prefix}--multi-select`, containerClassName, {
       [`${prefix}--list-box--light`]: light,
@@ -231,7 +226,7 @@ export default class MultiSelect extends React.Component {
                   <span className={`${prefix}--list-box__label`}>{label}</span>
                   <ListBox.MenuIcon
                     isOpen={isOpen}
-                    translateWithId={id => listBoxMenuIconTranslationIds[id]}
+                    translateWithId={translateWithId}
                   />
                 </ListBox.Field>
                 {isOpen && (

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -91,6 +91,13 @@ export default class MultiSelect extends React.Component {
      * If invalid, what is the error?
      */
     invalidText: PropTypes.string,
+
+    /**
+     * Object containing localized alt text for the listbox menu icon
+     * listBoxMenuIconTranslationIds[close.menu] - alt text for closing listbox
+     * listBoxMenuIconTranslationIds[open.menu] - alt text for opening listbox
+     */
+    listBoxMenuIconTranslationIds: PropTypes.object,
   };
 
   static defaultProps = {
@@ -103,6 +110,10 @@ export default class MultiSelect extends React.Component {
     type: 'default',
     light: false,
     title: false,
+    listBoxMenuIconTranslationIds: {
+      'close.menu': 'Close menu',
+      'open.menu': 'Open menu',
+    },
   };
 
   constructor(props) {
@@ -175,6 +186,7 @@ export default class MultiSelect extends React.Component {
       invalid,
       invalidText,
       useTitleInItem,
+      listBoxMenuIconTranslationIds,
     } = this.props;
     const className = cx(`${prefix}--multi-select`, containerClassName, {
       [`${prefix}--list-box--light`]: light,
@@ -217,7 +229,10 @@ export default class MultiSelect extends React.Component {
                     />
                   )}
                   <span className={`${prefix}--list-box__label`}>{label}</span>
-                  <ListBox.MenuIcon isOpen={isOpen} />
+                  <ListBox.MenuIcon
+                    isOpen={isOpen}
+                    translateWithId={id => listBoxMenuIconTranslationIds[id]}
+                  />
                 </ListBox.Field>
                 {isOpen && (
                   <ListBox.Menu>

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -108,7 +108,6 @@ export default class MultiSelect extends React.Component {
     type: 'default',
     light: false,
     title: false,
-    translateWithId: () => {},
   };
 
   constructor(props) {

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -37,15 +37,10 @@ exports[`MultiSelect should render 1`] = `
   }
   label="Field"
   light={false}
-  listBoxMenuIconTranslationIds={
-    Object {
-      "close.menu": "Close menu",
-      "open.menu": "Open menu",
-    }
-  }
   locale="en"
   sortItems={[Function]}
   title={false}
+  translateWithId={[Function]}
   type="default"
 >
   <Selection
@@ -130,8 +125,7 @@ exports[`MultiSelect should render 1`] = `
                   className="bx--list-box__menu-icon"
                 >
                   <Icon
-                    alt="Open menu"
-                    description="Open menu"
+                    description="Provide a description that will be used as the title"
                     fillRule="evenodd"
                     focusable="false"
                     icon={
@@ -160,8 +154,8 @@ exports[`MultiSelect should render 1`] = `
                     role="img"
                   >
                     <svg
-                      alt="Open menu"
-                      aria-label="Open menu"
+                      alt="Provide a description that will be used as the title"
+                      aria-label="Provide a description that will be used as the title"
                       fillRule="evenodd"
                       focusable="false"
                       height="5"
@@ -170,7 +164,7 @@ exports[`MultiSelect should render 1`] = `
                       width="10"
                     >
                       <title>
-                        Open menu
+                        Provide a description that will be used as the title
                       </title>
                       <path
                         d="M0 0l5 4.998L10 0z"

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -37,6 +37,12 @@ exports[`MultiSelect should render 1`] = `
   }
   label="Field"
   light={false}
+  listBoxMenuIconTranslationIds={
+    Object {
+      "close.menu": "Close menu",
+      "open.menu": "Open menu",
+    }
+  }
   locale="en"
   sortItems={[Function]}
   title={false}

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -40,7 +40,6 @@ exports[`MultiSelect should render 1`] = `
   locale="en"
   sortItems={[Function]}
   title={false}
-  translateWithId={[Function]}
   type="default"
 >
   <Selection
@@ -125,7 +124,8 @@ exports[`MultiSelect should render 1`] = `
                   className="bx--list-box__menu-icon"
                 >
                   <Icon
-                    description="Provide a description that will be used as the title"
+                    alt="Open menu"
+                    description="Open menu"
                     fillRule="evenodd"
                     focusable="false"
                     icon={
@@ -154,8 +154,8 @@ exports[`MultiSelect should render 1`] = `
                     role="img"
                   >
                     <svg
-                      alt="Provide a description that will be used as the title"
-                      aria-label="Provide a description that will be used as the title"
+                      alt="Open menu"
+                      aria-label="Open menu"
                       fillRule="evenodd"
                       focusable="false"
                       height="5"
@@ -164,7 +164,7 @@ exports[`MultiSelect should render 1`] = `
                       width="10"
                     >
                       <title>
-                        Provide a description that will be used as the title
+                        Open menu
                       </title>
                       <path
                         d="M0 0l5 4.998L10 0z"


### PR DESCRIPTION
Closes IBM/carbon-components-react#1801

This PR will add support for translatable SVG titles in `<ListBox />`

#### Changelog

**New**

- `listBoxMenuIconTranslationIds` prop, which takes an object with `close.menu` and `open.menu` properties

**Changed**

- return SVG `<title>` if `description` prop is truthy for experimental `ListBoxMenuIcon`