### PR TITLE
chore(lint): ensure lint-staged formats the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:staged": "eslint",
     "prepublish": "yarn build",
     "prettier": "prettier --write \"**/*.{scss,css,js,md}\"",
-    "prettier:staged": "prettier",
+    "prettier:staged": "prettier --write",
     "prettier:diff": "prettier --list-different \"**/*.{scss,css,js,md}\"",
     "semantic-release": "semantic-release",
     "start": "yarn storybook",


### PR DESCRIPTION
This change ensures that `lint-staged` re-formats the staged files.

#### Changelog

**Changed**

- Fixed `prettier:staged` script.
