### PR TITLE
docs(OverflowMenu): highlight floatingMenu and primaryFocus

### DIFF
--- a/src/components/OverflowMenu/README.md
+++ b/src/components/OverflowMenu/README.md
@@ -1,0 +1,52 @@
+# `OverflowMenu` component
+
+> Overflow Menu is used when additional options are available to the user and there is a space constraint.
+> Create Overflow Menu Item components for each option on the menu.
+
+## Table of Contents
+
+<!-- To run doctoc, just do `npx doctoc README.md` in this directory! -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Installation](#installation)
+- [Usage](#usage)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Installation
+
+This component comes with any installation of the `carbon-components-react` package on NPM. You can install this package by running the following in your terminal:
+
+```bash
+npm i carbon-components carbon-components-react carbon-icons --save
+# Or, with yarn
+yarn add carbon-components carbon-components-react carbon-icons
+```
+
+## Usage
+
+You can include `OverflowMenu` and `OverflowMenuItem` by doing the following in your project:
+
+```js
+import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
+```
+
+You can then create the menu by the following:
+
+```js
+<OverflowMenu floatingMenu>
+  <OverflowMenuItem itemText="Option 1" primaryFocus />
+  <OverflowMenuItem itemText="Option 2" />
+  ...
+</OverflowMenu>
+```
+
+There are two important React props:
+
+- `floatingMenu` in `OverflowMenu`: This is required if you want to out `OverflowMenu` in a table
+- `primaryFocus` in `OverflowMenuItem`: This is required for the menu item you put keyboard focus on when `OverflowMenu` gets open
+
+Please refer to [our Storybook](http://react.carbondesignsystem.com/?selectedKind=OverflowMenu&selectedStory=basic) for more details.


### PR DESCRIPTION
#### Changelog

**New**

- `README.md` for overflow menu, highlighting `floatingMenu` and `primaryFocus` React props