### PR TITLE
chore: Update wai-aria on tooltip. resolve #1494

### DIFF
--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -29,6 +29,10 @@ describe('Tooltip', () => {
     const trigger = wrapper.find('.bx--tooltip__trigger');
 
     describe('tooltip trigger', () => {
+      it('renders a tooltip container', () => {
+        expect(trigger.length).toEqual(1);
+      });
+
       it('renders the info icon', () => {
         const icon = trigger.find(Icon);
         expect(icon.length).toBe(1);

--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -29,10 +29,6 @@ describe('Tooltip', () => {
     const trigger = wrapper.find('.bx--tooltip__trigger');
 
     describe('tooltip trigger', () => {
-      it('renders a tooltip container', () => {
-        expect(trigger.length).toEqual(1);
-      });
-
       it('renders the info icon', () => {
         const icon = trigger.find(Icon);
         expect(icon.length).toBe(1);

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -390,10 +390,9 @@ export default class Tooltip extends Component {
           {showIcon ? (
             <div className={triggerClasses}>
               {triggerText}
-              <div
+              <button
                 id={triggerId}
-                className={componentsX ? `${prefix}--tooltip__trigger` : null}
-                role="button"
+                className={prefix + '--tooltip__trigger'}
                 tabIndex={tabIndex}
                 onClick={this.handleMouse}
                 onKeyDown={this.handleKeyPress}
@@ -425,10 +424,10 @@ export default class Tooltip extends Component {
                     }}
                   />
                 )}
-              </div>
+              </button>
             </div>
           ) : (
-            <div
+            <button
               tabIndex={tabIndex}
               id={triggerId}
               className={triggerClasses}
@@ -441,10 +440,9 @@ export default class Tooltip extends Component {
               onBlur={this.handleMouse}
               aria-haspopup="true"
               aria-expanded={open}
-              {...ariaOwnsProps}
-              role="tooltip">
+              {...ariaOwnsProps}>
               {triggerText}
-            </div>
+            </button>
           )}
         </ClickListener>
         {open && (
@@ -466,7 +464,8 @@ export default class Tooltip extends Component {
               onMouseOut={this.handleMouse}
               onFocus={this.handleMouse}
               onBlur={this.handleMouse}
-              onContextMenu={this.handleMouse}>
+              onContextMenu={this.handleMouse}
+              role="tooltip">
               <span className={`${prefix}--tooltip__caret`} />
               {children}
             </div>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -390,9 +390,10 @@ export default class Tooltip extends Component {
           {showIcon ? (
             <div className={triggerClasses}>
               {triggerText}
-              <button
+              <div
+                role="button"
                 id={triggerId}
-                className={prefix + '--tooltip__trigger'}
+                className={componentsX ? `${prefix}--tooltip__trigger` : null}
                 tabIndex={tabIndex}
                 onClick={this.handleMouse}
                 onKeyDown={this.handleKeyPress}
@@ -424,10 +425,11 @@ export default class Tooltip extends Component {
                     }}
                   />
                 )}
-              </button>
+              </div>
             </div>
           ) : (
-            <button
+            <div
+              role="button"
               tabIndex={tabIndex}
               id={triggerId}
               className={triggerClasses}
@@ -442,7 +444,7 @@ export default class Tooltip extends Component {
               aria-expanded={open}
               {...ariaOwnsProps}>
               {triggerText}
-            </button>
+            </div>
           )}
         </ClickListener>
         {open && (


### PR DESCRIPTION
Closes IBM/carbon-components-react#

Changes the Tooltip trigger element to be `<button>` instead of a `<div>` element per #1494 

#### Changelog

**Changed**

- Change `<div>` elements to `<button>` elements.
- On the Tooltip variation with Icon, the icon container element now needs the style reset that comes with the `prefix + '--tooltip__trigger'` classname.
- Moved the `role="tooltip"` attribute to the tooltip container element.

