### PR TITLE
Update 'InnerClickListener' 

### DIFF
--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -39,11 +39,10 @@ export default class InnerClickListener extends React.Component {
 
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
-    // 'body' necessary for IE
     if (
       this.element &&
-      (this.element.ownerDocument === event.target ||
-        this.element.ownerDocument.body.contains(event.target))
+      (this.element.parentNode.contains &&
+        this.element.parentNode.contains(event.target))
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -41,8 +41,9 @@ export default class InnerClickListener extends React.Component {
     // Ensure that the target exists in the DOM before checking the element
     if (
       this.element &&
-      (this.element.parentNode.contains &&
-        this.element.parentNode.contains(event.target))
+      (this.element.parentNode === null ||
+        (this.element.parentNode.contains &&
+          this.element.parentNode.contains(event.target)))
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -39,10 +39,10 @@ export default class InnerClickListener extends React.Component {
 
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
-    // documentElement necessary for IE
+    // body necessary for IE
     if (
       this.element &&
-      this.element.ownerDocument.documentElement.contains(event.target)
+      this.element.ownerDocument.body.contains(event.target)
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -40,7 +40,10 @@ export default class InnerClickListener extends React.Component {
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
     // documentElement necessary for IE
-    if (this.element.ownerDocument.documentElement.contains(event.target) && this.element) {
+    if (
+      this.element.ownerDocument.documentElement.contains(event.target) &&
+      this.element
+    ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);
       }

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -41,9 +41,9 @@ export default class InnerClickListener extends React.Component {
     // Ensure that the target exists in the DOM before checking the element
     // documentElement necessary for IE
     if (document.documentElement.contains(event.target) && this.element) {
-        if (this.element.contains && !this.element.contains(event.target)) {
-            this.props.onClickOutside(event);
-        }
+      if (this.element.contains && !this.element.contains(event.target)) {
+        this.props.onClickOutside(event);
+      }
     }
   }
 

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -42,7 +42,7 @@ export default class InnerClickListener extends React.Component {
     // 'body' necessary for IE
     if (
       this.element &&
-      (this.element.ownerDocument.body === event.target ||
+      (this.element.ownerDocument === event.target ||
         this.element.ownerDocument.body.contains(event.target))
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -40,7 +40,7 @@ export default class InnerClickListener extends React.Component {
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
     // documentElement necessary for IE
-    if (document.documentElement.contains(event.target) && this.element) {
+    if (this.element.ownerDocument.documentElement.contains(event.target) && this.element) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);
       }

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -41,8 +41,8 @@ export default class InnerClickListener extends React.Component {
     // Ensure that the target exists in the DOM before checking the element
     // documentElement necessary for IE
     if (
-      this.element.ownerDocument.documentElement.contains(event.target) &&
-      this.element
+      this.element &&
+      this.element.ownerDocument.documentElement.contains(event.target)
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -38,10 +38,12 @@ export default class InnerClickListener extends React.Component {
   }
 
   handleDocumentClick(event) {
-    if (this.element) {
-      if (this.element.contains && !this.element.contains(event.target)) {
-        this.props.onClickOutside(event);
-      }
+    // Ensure that the target exists in the DOM before checking the element
+    // documentElement necessary for IE
+    if (document.documentElement.contains(event.target) && this.element) {
+        if (this.element.contains && !this.element.contains(event.target)) {
+            this.props.onClickOutside(event);
+        }
     }
   }
 

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -39,10 +39,11 @@ export default class InnerClickListener extends React.Component {
 
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
-    // body necessary for IE
+    // 'body' necessary for IE
     if (
       this.element &&
-      this.element.ownerDocument.body.contains(event.target)
+      (this.element.ownerDocument.body === event.target ||
+        this.element.ownerDocument.body.contains(event.target))
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -39,7 +39,6 @@ export default class InnerClickListener extends React.Component {
 
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
-    // 'body' necessary for IE
     if (
       this.element &&
       (this.element.ownerDocument === event.target ||

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -39,11 +39,11 @@ export default class InnerClickListener extends React.Component {
 
   handleDocumentClick(event) {
     // Ensure that the target exists in the DOM before checking the element
+    // 'body' necessary for IE
     if (
       this.element &&
-      (this.element.parentNode === null ||
-        (this.element.parentNode.contains &&
-          this.element.parentNode.contains(event.target)))
+      (this.element.ownerDocument === event.target ||
+        this.element.ownerDocument.body.contains(event.target))
     ) {
       if (this.element.contains && !this.element.contains(event.target)) {
         this.props.onClickOutside(event);

--- a/src/internal/__tests__/InnerClickListener-test.js
+++ b/src/internal/__tests__/InnerClickListener-test.js
@@ -84,4 +84,26 @@ describe('InnerClickListener', () => {
     document.dispatchEvent(new MouseEvent('click'));
     expect(onClickOutside).toHaveBeenCalledTimes(2);
   });
+
+  it('should not call `onClickOutside` if click target disappears', () => {
+    const rootNode2 = document.createElement('div');
+    rootNode2.setAttribute('id', 'root2');
+
+    document.body.appendChild(rootNode2);
+
+    mount(
+      <InnerClickListener refKey="innerRef" onClickOutside={onClickOutside}>
+        <InnerChild />
+      </InnerClickListener>,
+      {
+        attachTo: rootNode2,
+      }
+    );
+
+    document.getElementById('1').addEventListener('click', function() {
+      this.parentNode.removeChild(this);
+    });
+    document.getElementById('1').click();
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Update InnerClickListener as the current implementation does not work if elements disappear from the DOM; if an element is clicked and it goes away such as a toggle open/close icon switching states, it should not trigger an onClickOutside event

#### Changelog

**New**

- added test case for InnerClickListener-test

**Changed**

- check if event target exists in DOM
