### PR TITLE
chore: bump webpack-dev-server in example package.json

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -41,7 +41,7 @@
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",
     "webpack": "3.8.1",
-    "webpack-dev-server": "2.9.4",
+    "webpack-dev-server": ">=3.1.11",
     "webpack-manifest-plugin": "1.3.2",
     "whatwg-fetch": "2.0.3"
   },

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -41,7 +41,7 @@
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",
     "webpack": "3.8.1",
-    "webpack-dev-server": ">=3.1.11",
+    "webpack-dev-server": "^3.1.11",
     "webpack-manifest-plugin": "1.3.2",
     "whatwg-fetch": "2.0.3"
   },


### PR DESCRIPTION
This PR bumps the `webpack-dev-server` version in the `create-react-app` example `package.json` to avoid a security vulnerability in an old version of the package and remove GitHub's vulnerability warning

Alternatively, we can probably just dismiss the warning because this code is not actually used outside of example environments