### PR TITLE
refactor(Notification): remove unused props

### DIFF
--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -180,8 +180,6 @@ export class NotificationTextDetails extends Component {
 
 export class ToastNotification extends Component {
   static propTypes = {
-    children: PropTypes.node,
-
     /**
      * Specify an optional className to be applied to the notification box
      */
@@ -327,8 +325,6 @@ export class ToastNotification extends Component {
 
 export class InlineNotification extends Component {
   static propTypes = {
-    children: PropTypes.node,
-
     /**
      * Specify an optional className to be applied to the notification box
      */


### PR DESCRIPTION
Closes IBM/carbon-components-react#1831

This PR removes `children` from `propTypes` to prevent it from being listed in our documentation, since it is not used at all