### PR TITLE
fix(ui-shell): add aria label to sidenav with complimentary landmark

### DIFF
--- a/src/components/UIShell/SideNav.js
+++ b/src/components/UIShell/SideNav.js
@@ -79,7 +79,7 @@ export default class SideNav extends React.Component {
     });
 
     return (
-      <aside className={className}>
+      <aside aria-label="side navigation" className={className}>
         <nav
           className={`${prefix}--side-nav__navigation`}
           role="navigation"

--- a/src/components/UIShell/SideNav.js
+++ b/src/components/UIShell/SideNav.js
@@ -79,19 +79,16 @@ export default class SideNav extends React.Component {
     });
 
     return (
-      <aside aria-label="side navigation" className={className}>
-        <nav
-          className={`${prefix}--side-nav__navigation`}
-          role="navigation"
-          {...accessibilityLabel}>
-          {children}
-          <SideNavFooter
-            assistiveText={assistiveText}
-            isExpanded={isExpanded}
-            onToggle={this.handleExpand}
-          />
-        </nav>
-      </aside>
+      <nav
+        className={`${prefix}--side-nav__navigation ${className}`}
+        {...accessibilityLabel}>
+        {children}
+        <SideNavFooter
+          assistiveText={assistiveText}
+          isExpanded={isExpanded}
+          onToggle={this.handleExpand}
+        />
+      </nav>
     );
   }
 }

--- a/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
+++ b/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
@@ -6,6 +6,7 @@ exports[`SideNav should render 1`] = `
   translateById={[Function]}
 >
   <aside
+    aria-label="side navigation"
     className="bx--side-nav bx--side-nav--expanded"
   >
     <nav
@@ -79,6 +80,7 @@ exports[`SideNav should toggle the menu expansion state when clicking on the foo
   translateById={[Function]}
 >
   <aside
+    aria-label="side navigation"
     className="bx--side-nav"
   >
     <nav

--- a/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
+++ b/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
@@ -5,72 +5,66 @@ exports[`SideNav should render 1`] = `
   aria-label="Navigation"
   translateById={[Function]}
 >
-  <aside
-    aria-label="side navigation"
-    className="bx--side-nav bx--side-nav--expanded"
+  <nav
+    aria-label="Navigation"
+    className="bx--side-nav__navigation bx--side-nav bx--side-nav--expanded"
   >
-    <nav
-      aria-label="Navigation"
-      className="bx--side-nav__navigation"
-      role="navigation"
+    <h2>
+      Navigation
+    </h2>
+    <SideNavFooter
+      assistiveText="Close"
+      isExpanded={true}
+      onToggle={[Function]}
     >
-      <h2>
-        Navigation
-      </h2>
-      <SideNavFooter
-        assistiveText="Close"
-        isExpanded={true}
-        onToggle={[Function]}
+      <footer
+        className="bx--side-nav__footer"
       >
-        <footer
-          className="bx--side-nav__footer"
+        <button
+          className="bx--side-nav__toggle"
+          onClick={[Function]}
+          title="Close"
+          type="button"
         >
-          <button
-            className="bx--side-nav__toggle"
-            onClick={[Function]}
-            title="Close"
-            type="button"
+          <div
+            className="bx--side-nav__icon"
           >
-            <div
-              className="bx--side-nav__icon"
+            <Close20
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <Close20
+              <svg
+                aria-hidden={true}
+                focusable="false"
                 height={20}
                 preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
                 viewBox="0 0 32 32"
                 width={20}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={20}
-                  preserveAspectRatio="xMidYMid meet"
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
-                  viewBox="0 0 32 32"
-                  width={20}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
-                  />
-                </svg>
-              </Close20>
-            </div>
-            <span
-              className="bx--assistive-text"
-            >
-              Close
-            </span>
-          </button>
-        </footer>
-      </SideNavFooter>
-    </nav>
-  </aside>
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+                />
+              </svg>
+            </Close20>
+          </div>
+          <span
+            className="bx--assistive-text"
+          >
+            Close
+          </span>
+        </button>
+      </footer>
+    </SideNavFooter>
+  </nav>
 </SideNav>
 `;
 
@@ -79,71 +73,65 @@ exports[`SideNav should toggle the menu expansion state when clicking on the foo
   aria-label="Navigation"
   translateById={[Function]}
 >
-  <aside
-    aria-label="side navigation"
-    className="bx--side-nav"
+  <nav
+    aria-label="Navigation"
+    className="bx--side-nav__navigation bx--side-nav"
   >
-    <nav
-      aria-label="Navigation"
-      className="bx--side-nav__navigation"
-      role="navigation"
+    <h2>
+      Navigation
+    </h2>
+    <SideNavFooter
+      assistiveText="Open"
+      isExpanded={false}
+      onToggle={[Function]}
     >
-      <h2>
-        Navigation
-      </h2>
-      <SideNavFooter
-        assistiveText="Open"
-        isExpanded={false}
-        onToggle={[Function]}
+      <footer
+        className="bx--side-nav__footer"
       >
-        <footer
-          className="bx--side-nav__footer"
+        <button
+          className="bx--side-nav__toggle"
+          onClick={[Function]}
+          title="Open"
+          type="button"
         >
-          <button
-            className="bx--side-nav__toggle"
-            onClick={[Function]}
-            title="Open"
-            type="button"
+          <div
+            className="bx--side-nav__icon"
           >
-            <div
-              className="bx--side-nav__icon"
+            <ChevronRight20
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <ChevronRight20
+              <svg
+                aria-hidden={true}
+                focusable="false"
                 height={20}
                 preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
                 viewBox="0 0 32 32"
                 width={20}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden={true}
-                  focusable="false"
-                  height={20}
-                  preserveAspectRatio="xMidYMid meet"
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
-                  viewBox="0 0 32 32"
-                  width={20}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M22 16L12 26l-1.4-1.4 8.6-8.6-8.6-8.6L12 6z"
-                  />
-                </svg>
-              </ChevronRight20>
-            </div>
-            <span
-              className="bx--assistive-text"
-            >
-              Open
-            </span>
-          </button>
-        </footer>
-      </SideNavFooter>
-    </nav>
-  </aside>
+                <path
+                  d="M22 16L12 26l-1.4-1.4 8.6-8.6-8.6-8.6L12 6z"
+                />
+              </svg>
+            </ChevronRight20>
+          </div>
+          <span
+            className="bx--assistive-text"
+          >
+            Open
+          </span>
+        </button>
+      </footer>
+    </SideNavFooter>
+  </nav>
 </SideNav>
 `;


### PR DESCRIPTION
Elements having a WAI-ARIA complementary role such as `<aside>` used in our sidenav must have a label specified with aria-label.

This PR gives the `<aside>` element in the sidenav an `aria-label="side navigation"` silencing the error thrown by our automated test and providing a more adequate description for our users.