### PR TITLE
fix(MultiSelect): fixed translateWithId prop-type, resolves #1847

### DIFF
--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -95,7 +95,7 @@ export default class MultiSelect extends React.Component {
     /**
      * Callback function for translating ListBoxMenuIcon SVG title
      */
-    translateWithId: PropTypes.function,
+    translateWithId: PropTypes.func,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Closes IBM/carbon-components-react#[1847](https://github.com/IBM/carbon-components-react/issues/1847)

* `translateWithId` is optional field. And hence we are not defining this prop parameter in code.
* But we see Warning: Failed prop type: MultiSelect: prop type `translateWithId` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.

#### Changelog

**Changed**

- src/components/MultiSelect/MultiSelect.js
