### PR TITLE
feat(Tabs): allow custom className for `<TabContent>`

### DIFF
--- a/src/components/Tabs/Tabs-story.js
+++ b/src/components/Tabs/Tabs-story.js
@@ -30,9 +30,12 @@ const props = {
     onClick: action('onClick'),
     onKeyDown: action('onKeyDown'),
     onSelectionChange: action('onSelectionChange'),
+    tabContentClassName: text(
+      'The className for the child `<TabContent>` components',
+      'tab-content'
+    ),
   }),
   tab: () => ({
-    className: 'another-class',
     href: text('The href for tab (href in <Tab>)', '#'),
     role: text('ARIA role (role in <Tab>)', 'presentation'),
     tabIndex: number('Tab index (tabIndex in <Tab>)', 0),

--- a/src/components/Tabs/Tabs-test.js
+++ b/src/components/Tabs/Tabs-test.js
@@ -107,6 +107,18 @@ describe('Tabs', () => {
       expect(wrapper.find('TabContent').length).toEqual(2);
     });
 
+    it('allows for custom classNames on <TabContent>', () => {
+      const customTabContentClassWrapper = shallow(
+        <Tabs tabContentClassName="tab-content">
+          <Tab label="firstTab">content1</Tab>
+          <Tab label="lastTab">content2</Tab>
+        </Tabs>
+      );
+      expect(customTabContentClassWrapper.find('.tab-content').length).toEqual(
+        2
+      );
+    });
+
     it('renders hidden props with boolean value', () => {
       const hiddenProp = wrapper
         .find('TabContent')

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -83,6 +83,11 @@ export default class Tabs extends React.Component {
      * for the dropdown menu of items
      */
     iconDescription: PropTypes.string.isRequired,
+
+    /**
+     * Provide a className that is applied to the <TabContent> components
+     */
+    tabContentClassName: PropTypes.string,
   };
 
   static defaultProps = {
@@ -192,6 +197,7 @@ export default class Tabs extends React.Component {
       triggerHref,
       role,
       onSelectionChange,
+      tabContentClassName,
       ...other
     } = this.props;
 
@@ -230,7 +236,7 @@ export default class Tabs extends React.Component {
 
       return (
         <TabContent
-          className="tab-content"
+          className={tabContentClassName}
           aria-hidden={!selected}
           hidden={!selected}
           selected={selected}>


### PR DESCRIPTION
Closes IBM/carbon-components-react#1854

Related:

#1790

#1784

#1846

This PR exposes a `tabContentClassName` prop for the consumer to attach custom classNames to the tab content container element