### PR TITLE
feat(Notification): allow composable notification content

### DIFF
--- a/src/components/Notification/Notification-story.js
+++ b/src/components/Notification/Notification-story.js
@@ -38,12 +38,10 @@ storiesOf('Notifications', module)
   .add(
     'Deprecated: <Notfication />',
     () => (
-      <div>
-        <Notification
-          {...notificationProps()}
-          caption={text('Caption (caption)', 'Time stamp [00:00:00]')}
-        />
-      </div>
+      <Notification
+        {...notificationProps()}
+        caption={text('Caption (caption)', 'Time stamp [00:00:00]')}
+      />
     ),
     {
       info: {
@@ -55,16 +53,10 @@ storiesOf('Notifications', module)
     }
   )
   .add('Toast', () => (
-    <div>
-      <ToastNotification
-        {...notificationProps()}
-        caption={text('Caption (caption)', 'Time stamp [00:00:00]')}
-        style={{ minWidth: '30rem', marginBottom: '.5rem' }}
-      />
-    </div>
+    <ToastNotification
+      {...notificationProps()}
+      caption={text('Caption (caption)', 'Time stamp [00:00:00]')}
+      style={{ minWidth: '30rem', marginBottom: '.5rem' }}
+    />
   ))
-  .add('inline', () => (
-    <div>
-      <InlineNotification {...notificationProps()} />
-    </div>
-  ));
+  .add('inline', () => <InlineNotification {...notificationProps()} />);

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -126,20 +126,21 @@ export class NotificationButton extends Component {
 export class NotificationTextDetails extends Component {
   static propTypes = {
     /**
+     * Pass in the children that will be rendered in NotificationTextDetails
+     */
+    children: PropTypes.node,
+    /**
      * Specify the title
      */
     title: PropTypes.string,
-
     /**
      * Specify the sub-title
      */
     subtitle: PropTypes.node,
-
     /**
      * Specify the caption
      */
     caption: PropTypes.node,
-
     /**
      * Specify the notification type
      */
@@ -165,6 +166,7 @@ export class NotificationTextDetails extends Component {
           <div className={`${prefix}--toast-notification__caption`}>
             {caption}
           </div>
+          {this.props.children}
         </div>
       );
     }
@@ -178,6 +180,7 @@ export class NotificationTextDetails extends Component {
           <div className={`${prefix}--inline-notification__subtitle`}>
             {subtitle}
           </div>
+          {this.props.children}
         </div>
       );
     }
@@ -320,8 +323,9 @@ export class ToastNotification extends Component {
           title={title}
           subtitle={subtitle}
           caption={caption}
-          notificationType={notificationType}
-        />
+          notificationType={notificationType}>
+          {this.props.children}
+        </NotificationTextDetails>
         {!hideCloseButton && (
           <NotificationButton
             iconDescription={iconDescription}
@@ -463,8 +467,9 @@ export class InlineNotification extends Component {
           <NotificationTextDetails
             title={title}
             subtitle={subtitle}
-            notificationType={notificationType}
-          />
+            notificationType={notificationType}>
+            {this.props.children}
+          </NotificationTextDetails>
         </div>
         {!hideCloseButton && (
           <NotificationButton

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -186,6 +186,9 @@ export class NotificationTextDetails extends Component {
 
 export class ToastNotification extends Component {
   static propTypes = {
+    /**
+     * Pass in the children that will be rendered within the ToastNotification
+     */
     children: PropTypes.node,
 
     /**
@@ -333,6 +336,9 @@ export class ToastNotification extends Component {
 
 export class InlineNotification extends Component {
   static propTypes = {
+    /**
+     * Pass in the children that will be rendered within the InlineNotification
+     */
     children: PropTypes.node,
 
     /**

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -19,6 +19,8 @@ import { settings } from 'carbon-components';
 import Icon from '../Icon';
 // temporary workaround for a11y warning icon. TODO: for @carbon/icons-react
 import a11yIconWarningSolid from './a11yIconWarningSolid';
+import Close16 from '@carbon/icons-react/lib/close/16';
+import { componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -105,13 +107,17 @@ export class NotificationButton extends Component {
 
     return (
       <button {...other} type={type} className={buttonClasses}>
-        <Icon
-          description={iconDescription}
-          className={iconClasses}
-          aria-label={ariaLabel}
-          icon={!icon && !name ? iconClose : icon}
-          name={name}
-        />
+        {componentsX ? (
+          <Close16 className={iconClasses} aria-label={ariaLabel} />
+        ) : (
+          <Icon
+            description={iconDescription}
+            className={iconClasses}
+            aria-label={ariaLabel}
+            icon={!icon && !name ? iconClose : icon}
+            name={name}
+          />
+        )}
       </button>
     );
   }

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -180,6 +180,8 @@ export class NotificationTextDetails extends Component {
 
 export class ToastNotification extends Component {
   static propTypes = {
+    children: PropTypes.node,
+
     /**
      * Specify an optional className to be applied to the notification box
      */
@@ -325,6 +327,8 @@ export class ToastNotification extends Component {
 
 export class InlineNotification extends Component {
   static propTypes = {
+    children: PropTypes.node,
+
     /**
      * Specify an optional className to be applied to the notification box
      */


### PR DESCRIPTION
Closes IBM/carbon-components-react#1834

This PR adds support for the `children` prop so that users can compose their own notification content

#### Changelog

**New**

- `children` prop for `<NotificationTextDetails>` which is passed through from `<ToastNotification>` or `<InlineNotification>`

**Changed**

- support experimental close icon