### PR TITLE
feat(components): support forwardRef for button and stateful

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -202,4 +202,12 @@ Button.defaultProps = {
   kind: 'primary',
 };
 
-export default Button;
+export default (!breakingChangesX
+  ? Button
+  : (() => {
+      const forwardRef = (props, ref) => {
+        return <Button {...props} inputref={ref} />;
+      };
+      forwardRef.displayName = 'Button';
+      return React.forwardRef(forwardRef);
+    })());

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -21,7 +21,7 @@ const Checkbox = ({
   hideLabel,
   wrapperClassName,
   title = '',
-  forwardRef: ref,
+  innerRef: ref,
   ...other
 }) => {
   const labelClasses = classNames(`${prefix}--checkbox-label`, className);
@@ -126,7 +126,7 @@ Checkbox.defaultProps = {
   indeterminate: false,
 };
 
-const forwardRef = (props, ref) => <Checkbox {...props} forwardRef={ref} />;
+const forwardRef = (props, ref) => <Checkbox {...props} innerRef={ref} />;
 
 forwardRef.displayName = 'Checkbox';
 

--- a/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/src/components/InlineCheckbox/InlineCheckbox.js
@@ -8,10 +8,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
+import { breakingChangesX } from '../../internal/FeatureFlags';
+import mergeRefs from '../../tools/mergeRefs';
 
 const { prefix } = settings;
 
-export default class InlineCheckbox extends React.Component {
+class InlineCheckbox extends React.Component {
   static propTypes = {
     /**
      * Specify the label for the control
@@ -97,6 +99,7 @@ export default class InlineCheckbox extends React.Component {
       onClick,
       onKeyDown,
       title = undefined,
+      forwardRef: ref,
     } = this.props;
     const inputProps = {
       id,
@@ -108,7 +111,7 @@ export default class InlineCheckbox extends React.Component {
       onKeyDown,
       className: `${prefix}--checkbox`,
       type: 'checkbox',
-      ref: this.handleRef,
+      ref: mergeRefs(ref, this.handleRef),
       checked: false,
       disabled,
     };
@@ -138,3 +141,13 @@ export default class InlineCheckbox extends React.Component {
     );
   }
 }
+
+export default (!breakingChangesX
+  ? InlineCheckbox
+  : (() => {
+      const forwardRef = (props, ref) => (
+        <InlineCheckbox {...props} forwardRef={ref} />
+      );
+      forwardRef.displayName = 'InlineCheckbox';
+      return React.forwardRef(forwardRef);
+    })());

--- a/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/src/components/InlineCheckbox/InlineCheckbox.js
@@ -99,7 +99,7 @@ class InlineCheckbox extends React.Component {
       onClick,
       onKeyDown,
       title = undefined,
-      forwardRef: ref,
+      innerRef: ref,
     } = this.props;
     const inputProps = {
       id,
@@ -146,7 +146,7 @@ export default (!breakingChangesX
   ? InlineCheckbox
   : (() => {
       const forwardRef = (props, ref) => (
-        <InlineCheckbox {...props} forwardRef={ref} />
+        <InlineCheckbox {...props} innerRef={ref} />
       );
       forwardRef.displayName = 'InlineCheckbox';
       return React.forwardRef(forwardRef);

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -14,7 +14,8 @@ import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
 import CaretDownGlyph from '@carbon/icons-react/lib/caret--down/index';
 import CaretUpGlyph from '@carbon/icons-react/lib/caret--up/index';
 import Icon from '../Icon';
-import { componentsX } from '../../internal/FeatureFlags';
+import { breakingChangesX, componentsX } from '../../internal/FeatureFlags';
+import mergeRefs from '../../tools/mergeRefs';
 
 const { prefix } = settings;
 
@@ -28,7 +29,7 @@ const defaultTranslations = {
   [translationIds['decrement.number']]: 'Decrement number',
 };
 
-export default class NumberInput extends Component {
+class NumberInput extends Component {
   constructor(props) {
     super(props);
     let value = props.value;
@@ -215,6 +216,7 @@ export default class NumberInput extends Component {
       light,
       allowEmpty,
       translateWithId: t,
+      forwardRef: ref,
       ...other
     } = this.props;
 
@@ -283,7 +285,7 @@ export default class NumberInput extends Component {
                   pattern="[0-9]*"
                   {...other}
                   {...props}
-                  ref={this._handleInputRef}
+                  ref={mergeRefs(ref, this._handleInputRef)}
                 />
                 {invalid && (
                   <WarningFilled16
@@ -359,7 +361,7 @@ export default class NumberInput extends Component {
                 pattern="[0-9]*"
                 {...other}
                 {...props}
-                ref={this._handleInputRef}
+                ref={mergeRefs(ref, this._handleInputRef)}
               />
             </>
           )}
@@ -370,3 +372,13 @@ export default class NumberInput extends Component {
     );
   }
 }
+
+export default (!breakingChangesX
+  ? NumberInput
+  : (() => {
+      const forwardRef = (props, ref) => (
+        <NumberInput {...props} forwardRef={ref} />
+      );
+      forwardRef.displayName = 'NumberInput';
+      return React.forwardRef(forwardRef);
+    })());

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -215,8 +215,8 @@ class NumberInput extends Component {
       helperText,
       light,
       allowEmpty,
+      innerRef: ref,
       translateWithId: t,
-      forwardRef: ref,
       ...other
     } = this.props;
 
@@ -377,7 +377,7 @@ export default (!breakingChangesX
   ? NumberInput
   : (() => {
       const forwardRef = (props, ref) => (
-        <NumberInput {...props} forwardRef={ref} />
+        <NumberInput {...props} innerRef={ref} />
       );
       forwardRef.displayName = 'NumberInput';
       return React.forwardRef(forwardRef);

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -86,7 +86,7 @@ class RadioButton extends React.Component {
       'radioButtonWrapper',
       this.props.className
     );
-    const { labelText, forwardRef: ref, ...other } = this.props;
+    const { labelText, innerRef: ref, ...other } = this.props;
     return (
       <div className={wrapperClasses}>
         <input
@@ -113,7 +113,7 @@ export default (!breakingChangesX
   ? RadioButton
   : (() => {
       const forwardRef = (props, ref) => (
-        <RadioButton {...props} forwardRef={ref} />
+        <RadioButton {...props} innerRef={ref} />
       );
       forwardRef.displayName = 'RadioButton';
       return React.forwardRef(forwardRef);

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -10,10 +10,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import uid from '../../tools/uniqueId';
+import { breakingChangesX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
-export default class RadioButton extends React.Component {
+class RadioButton extends React.Component {
   static propTypes = {
     /**
      * Specify whether the <RadioButton> is currently checked
@@ -85,7 +86,7 @@ export default class RadioButton extends React.Component {
       'radioButtonWrapper',
       this.props.className
     );
-    const { labelText, ...other } = this.props;
+    const { labelText, forwardRef: ref, ...other } = this.props;
     return (
       <div className={wrapperClasses}>
         <input
@@ -94,6 +95,7 @@ export default class RadioButton extends React.Component {
           className={`${prefix}--radio-button`}
           onChange={this.handleChange}
           id={this.uid}
+          ref={ref}
         />
         <label
           htmlFor={this.uid}
@@ -106,3 +108,13 @@ export default class RadioButton extends React.Component {
     );
   }
 }
+
+export default (!breakingChangesX
+  ? RadioButton
+  : (() => {
+      const forwardRef = (props, ref) => (
+        <RadioButton {...props} forwardRef={ref} />
+      );
+      forwardRef.displayName = 'RadioButton';
+      return React.forwardRef(forwardRef);
+    })());

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -29,7 +29,7 @@ const Select = ({
   invalidText,
   helperText,
   light,
-  forwardRef: ref,
+  innerRef: ref,
   ...other
 }) => {
   const selectClasses = classNames({
@@ -180,7 +180,7 @@ Select.defaultProps = {
   light: false,
 };
 
-const forwardRef = (props, ref) => <Select {...props} forwardRef={ref} />;
+const forwardRef = (props, ref) => <Select {...props} innerRef={ref} />;
 
 forwardRef.displayName = 'Select';
 

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -25,7 +25,7 @@ const TextInput = ({
   invalidText,
   helperText,
   light,
-  forwardRef: ref,
+  innerRef: ref,
   ...other
 }) => {
   const textInputProps = {
@@ -183,7 +183,7 @@ TextInput.defaultProps = {
   light: false,
 };
 
-const forwardRef = (props, ref) => <TextInput {...props} forwardRef={ref} />;
+const forwardRef = (props, ref) => <TextInput {...props} innerRef={ref} />;
 
 forwardRef.displayName = 'TextInput';
 

--- a/src/tools/__tests__/mergeRefs-test.js
+++ b/src/tools/__tests__/mergeRefs-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import mergeRefs from '../mergeRefs';
+
+describe('mergeRefs', () => {
+  it('supports forwardRef as well as ref callback', () => {
+    const elem = document.createElement('div');
+    const ref = React.createRef();
+    let functionRefResult;
+    mergeRefs(ref, el => {
+      functionRefResult = el;
+    })(elem);
+    expect(ref.current).toBe(elem);
+    expect(functionRefResult).toBe(elem);
+  });
+
+  it('skips empty ref', () => {
+    expect(() => {
+      mergeRefs(undefined)(document.createElement('div'));
+    }).not.toThrow(Error);
+  });
+});

--- a/src/tools/mergeRefs.js
+++ b/src/tools/mergeRefs.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @param {...Ref<Element>} refs List of React refs to merge.
+ * @returns {Ref<Element>} Merged React ref.
+ */
+const mergeRefs = (...refs) => el => {
+  refs.forEach(ref => {
+    // https://github.com/facebook/react/issues/13029#issuecomment-410002316
+    if (typeof ref === 'function') {
+      ref(el);
+    } else if (Object(ref) === ref) {
+      ref.current = el;
+    }
+  });
+};
+
+export default mergeRefs;


### PR DESCRIPTION
Refs #1191, #1777.

#### Changelog

**New**

- Supports `ref` for `<Button>`, `<InlineCheckbox>`, `<NumberInput>` and `<RadioButton>`.