### PR TITLE
fix(modal): uses secondary button on danger modal for componentsX

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -323,7 +323,7 @@ export default class Modal extends Component {
         {!passiveModal && (
           <div className={`${prefix}--modal-footer`}>
             <Button
-              kind={danger ? 'tertiary' : 'secondary'}
+              kind={danger && !componentsX ? 'tertiary' : 'secondary'}
               onClick={onSecondaryButtonClick}>
               {secondaryButtonText}
             </Button>


### PR DESCRIPTION
Uses the secondary button for danger modals in componentsX, [as seen here](https://next.carbondesignsystem.com/components/modal/code).

#### Changelog

**Changed**

- Uses tertiary button only for non-componentsX component
