### PR TITLE
feat(DataTableSkeleton): add optional headers property

### DIFF
--- a/src/components/DataTableSkeleton/DataTableSkeleton-story.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton-story.js
@@ -10,10 +10,15 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withKnobs, boolean, array } from '@storybook/addon-knobs';
 import DataTableSkeleton from '../DataTableSkeleton';
 
 const props = () => ({
+  headers: array(
+    'Optional table headers (headers)',
+    ['Name', 'Protocol', 'Port', 'Rule', 'Attached Groups'],
+    ','
+  ),
   zebra: boolean('Use zebra stripe (zebra)', false),
   compact: boolean('Compact variant (compact)', false),
 });

--- a/src/components/DataTableSkeleton/DataTableSkeleton-test.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton-test.js
@@ -13,11 +13,13 @@ describe('DataTableSkeleton', () => {
   describe('Renders as expected', () => {
     const rowCount = 20;
     const columnCount = 3;
+    const headers = ['Name', 'Protocol', 'Port'];
     const wrapper = shallow(
       <DataTableSkeleton
         compact
         rowCount={rowCount}
         columnCount={columnCount}
+        headers={headers}
       />
     );
 
@@ -32,6 +34,12 @@ describe('DataTableSkeleton', () => {
       expect(wrapper.find('tbody > tr > td').length).toEqual(
         rowCount * columnCount
       );
+    });
+
+    it('Has the correct headers', () => {
+      wrapper
+        .find('thead > tr > th')
+        .forEach((header, index) => expect(header.text()).toBe(headers[index]));
     });
   });
 });

--- a/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -17,6 +17,7 @@ const DataTableSkeleton = ({
   columnCount,
   zebra,
   compact,
+  headers,
   ...other
 }) => {
   const dataTableSkeletonClasses = classNames({
@@ -44,7 +45,7 @@ const DataTableSkeleton = ({
       <thead>
         <tr>
           {columnsArray.map(i => (
-            <th key={i} />
+            <th key={i}>{headers[i]}</th>
           ))}
         </tr>
       </thead>
@@ -90,6 +91,7 @@ DataTableSkeleton.defaultProps = {
   columnCount: 5,
   zebra: false,
   compact: false,
+  headers: [],
 };
 
 export default DataTableSkeleton;

--- a/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -84,6 +84,11 @@ DataTableSkeleton.propTypes = {
    * compact DataTable
    */
   compact: PropTypes.bool,
+
+  /**
+   * Optionally specify the displayed headers
+   */
+  headers: PropTypes.array,
 };
 
 DataTableSkeleton.defaultProps = {


### PR DESCRIPTION
Most of the time we have headers already in place while loading the table data, so why not to display them? This prop is optional and looks really cool when passed to the component.

<img width="804" alt="zrzut ekranu 2019-02-13 o 00 38 16" src="https://user-images.githubusercontent.com/23037261/52675686-e0027c00-2f27-11e9-825c-42019857caee.png">


#### Changelog

**New**

- optional headers prop