### PR TITLE
chore(Tooltip): deprecate non-click-to-open in regular tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -28,7 +28,10 @@ const directions = {
 
 const props = {
   withIcon: () => ({
-    clickToOpen: boolean('Click to open (clickToOpen)', false),
+    clickToOpen: boolean(
+      'Click to open (clickToOpen, using `false` here is deprecated)',
+      true
+    ),
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import Icon from '../Icon';
 import classNames from 'classnames';
+import warning from 'warning';
 import { iconInfoGlyph } from 'carbon-icons';
 // TODO: import { Information } from '@carbon/icons-react';
 import Information from '@carbon/icons-react/lib/information/16';
@@ -21,7 +22,7 @@ import FloatingMenu, {
   DIRECTION_BOTTOM,
 } from '../../internal/FloatingMenu';
 import ClickListener from '../../internal/ClickListener';
-import { componentsX } from '../../internal/FeatureFlags';
+import { breakingChangesX, componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -107,6 +108,8 @@ const getMenuOffset = (menuBody, menuDirection) => {
     };
   }
 };
+
+let didWarnAboutDeprecation = false;
 
 export default class Tooltip extends Component {
   state = {};
@@ -212,6 +215,7 @@ export default class Tooltip extends Component {
     iconTitle: '',
     triggerText: 'Provide triggerText',
     menuOffset: getMenuOffset,
+    clickToOpen: breakingChangesX ? true : false,
   };
 
   /**
@@ -359,11 +363,19 @@ export default class Tooltip extends Component {
       iconDescription,
       menuOffset,
       // Exclude `clickToOpen` from `other` to avoid passing it along to `<div>`
-      // eslint-disable-next-line no-unused-vars
       clickToOpen,
       tabIndex = 0,
       ...other
     } = this.props;
+
+    if (!clickToOpen && __DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `clickToOpen=false` option in `Tooltip` component is being updated in the next release of ' +
+          '`carbon-components-react`. Please use `TooltipIcon` or `TooltipDefinition` instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
 
     const { open } = this.state;
 

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -215,7 +215,7 @@ export default class Tooltip extends Component {
     iconTitle: '',
     triggerText: 'Provide triggerText',
     menuOffset: getMenuOffset,
-    clickToOpen: breakingChangesX ? true : false,
+    clickToOpen: breakingChangesX,
   };
 
   /**

--- a/src/internal/FeatureFlags.js
+++ b/src/internal/FeatureFlags.js
@@ -18,6 +18,11 @@
  */
 
 /**
+ * Breaking changes for next release.
+ */
+export const breakingChangesX = false;
+
+/**
  * Next gen of Carbon component design.
  */
 export const componentsX = false;


### PR DESCRIPTION
Fixes #1864.

#### Changelog

**New**

- Deprecation warning for `clickToOpen=false` in `<Tooltip>`.
- Default prop for `clickToOpen`, `true` is set there for `v10`.