### PR TITLE
fix(overflowMenu): include iconProps for CarbonX version

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -655,7 +655,7 @@ export default class OverflowMenu extends Component {
           />
         );
       }
-      return <OverflowMenuVertical16 />;
+      return <OverflowMenuVertical16 {...iconProps} />;
     })();
 
     return (


### PR DESCRIPTION
Closes #1877 

Include `iconProps` when rendering the Carbon X icon version.

**NOTE:** My understanding was that it made sense to include icon props to this icon, but let me know if you want certain props or just the classNames here 🤔 

With this change, you start to get some expected props...
![screen shot 2019-02-14 at 2 41 37 pm](https://user-images.githubusercontent.com/9057921/52816420-d0d61800-3066-11e9-9cc8-9b152f69741b.png)


#### Changelog

**Changed**

- add `iconProps` to Carbon X `OverflowMenu` icon
