### PR TITLE
fix(Modal): NPE check for focusable element ref

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -225,7 +225,7 @@ export default class Modal extends Component {
       primaryFocusElement.focus();
       return;
     }
-    if (this.button) {
+    if (this.button && this.button.current) {
       this.button.current.focus();
     }
   };


### PR DESCRIPTION
Closes IBM/carbon-components-react#1880

This PR adds a null pointer exception check for the primary focusable button ref