### PR TITLE
fix(DropdownV2): uses strict equality operator to know if item is highlighted, resolves #1898

### DIFF
--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -187,9 +187,7 @@ export default class DropdownV2 extends React.Component {
                     key={itemToString(item)}
                     isActive={selectedItem === item}
                     isHighlighted={
-                      highlightedIndex === index ||
-                      (selectedItem && selectedItem.id === item.id) ||
-                      false
+                      highlightedIndex === index || selectedItem === item
                     }
                     {...getItemProps({ item, index })}>
                     {itemToElement ? (


### PR DESCRIPTION
Closes IBM/carbon-components-react#1898
