### PR TITLE
fix(ToggleSmall): replace `class` prop with `className`

### DIFF
--- a/src/components/ToggleSmall/ToggleSmall-story.js
+++ b/src/components/ToggleSmall/ToggleSmall-story.js
@@ -15,8 +15,6 @@ import ToggleSmallSkeleton from '../ToggleSmall/ToggleSmall.Skeleton';
 const toggleProps = () => ({
   className: 'some-class',
   ariaLabel: text('ARIA label (ariaLabel)', 'Label Name'),
-  labelA: text('Label for untoggled state (labelA)', 'Off'),
-  labelB: text('Label for toggled state (labelB)', 'On'),
   onChange: action('onChange'),
   onToggle: action('onToggle'),
 });

--- a/src/components/ToggleSmall/ToggleSmall.js
+++ b/src/components/ToggleSmall/ToggleSmall.js
@@ -67,7 +67,7 @@ const ToggleSmall = ({
             </svg>
           )}
         </span>
-        <span class={`${prefix}--assistive-text`}>{ariaLabel}</span>
+        <span className={`${prefix}--assistive-text`}>{ariaLabel}</span>
       </label>
     </div>
   );


### PR DESCRIPTION
Closes IBM/carbon-components-react#1901

also removes unused props from component story