### PR TITLE
fix(DatePickerInput): update logic for displaying icon for CarbonX

### DIFF
--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -78,7 +78,10 @@ export default class DatePickerInput extends Component {
     });
 
     const datePickerIcon = (() => {
-      if (datePickerType !== 'single') {
+      if (!componentsX && datePickerType !== 'single') {
+        return;
+      }
+      if (componentsX && datePickerType === 'simple') {
         return;
       }
       if (componentsX) {


### PR DESCRIPTION
Closes #1904 

In the current Carbon X design kit, the calendar icon should be displayed for all calendar variations *except* for the `simple` type.

`DatePickerInput` controls logic for displaying the icon in Carbon X, but the following prevents the icon for rendering for the `range` type:

```javascript
if (datePickerType !== 'single') {
  return;
}
```

This PR proposes 2 updates to this logic to both maintain the current logic for existing Carbon `DatePicker`s and also add an extra if-statement to make sure the Carbon X version gets the right icons for the right types.

#### Changelog

**Changed**

- update icon render logic in `DatePickerInput` to match Carbon X design spec
