### PR TITLE
improve multiselect

### DIFF
--- a/src/internal/Selection.js
+++ b/src/internal/Selection.js
@@ -25,6 +25,14 @@ export default class Selection extends React.Component {
     };
   }
 
+  componentDidUpdate() {
+    if (this.props.initialSelectedItems.length !== this.state.selectedItems.length) {
+      this.setState({
+        selectedItems: this.props.initialSelectedItems
+      });
+    }
+  }
+
   internalSetState = (stateToSet, callback) =>
     this.setState(stateToSet, () => {
       if (callback) {


### PR DESCRIPTION
Closes IBM/carbon-components-react#

{{currently the `Multiselect` component does not support changes of initialSelectedItems, which prevent us from using Redux to control the selected state of every checkbox in the dropdown. This PR is for improving the functionalities of this component}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
