### PR TITLE
chore(Storybook): add knob for danger in ModalWrapper

### DIFF
--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -33,6 +33,7 @@ const props = () => ({
   className: 'some-class',
   disabled: boolean('Disable the launcher button (disabled)', false),
   passiveModal: boolean('Without footer (passiveModal)', false),
+  danger: boolean('Danger mode (danger)', false),
   buttonTriggerText: text(
     'The text in the trigger button (buttonTriggerText)',
     'Launch Modal'


### PR DESCRIPTION
Fixes #640.

#### Changelog

**New**

- A knob for `danger` in `<ModalWrapper>` story