### PR TITLE
feat: Add footer component

### DIFF
--- a/src/components/Footer/Footer-story.js
+++ b/src/components/Footer/Footer-story.js
@@ -11,6 +11,8 @@ import { action } from '@storybook/addon-actions';
 
 import { withKnobs, text } from '@storybook/addon-knobs';
 import Footer from '../Footer';
+import FooterItem from '../FooterItem';
+import Link from '../Link';
 
 const props = () => ({
   className: text('CSS class name (className)', 'some-class'),
@@ -41,6 +43,27 @@ storiesOf('Footer', module)
     {
       info: {
         text: 'Footer is used on configuration screens.',
+      },
+    }
+  )
+  .add(
+    'with footer items',
+    () => (
+      <Footer {...props()}>
+        <FooterItem
+          link={<Link href="#">First Link</Link>}
+          label="First Label"
+        />
+        <FooterItem
+          link={<Link href="#">Second Link</Link>}
+          label="Second Label"
+        />
+      </Footer>
+    ),
+    {
+      info: {
+        text:
+          'Children will be rendered instead of the default footer information. The `FooterItem` component is provided to ',
       },
     }
   );

--- a/src/components/FooterItem/FooterItem-test.js
+++ b/src/components/FooterItem/FooterItem-test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import FooterItem from '../FooterItem';
+import { mount } from 'enzyme';
+import Link from '../Link';
+
+describe('FooterItem', () => {
+  describe('Renders as expected', () => {
+    const wrapper = mount(
+      <FooterItem
+        className="extra-class"
+        link={
+          <Link className="custom-link" href="#">
+            First Link
+          </Link>
+        }
+        label="First Label"
+      />
+    );
+
+    const item = wrapper.find('div');
+    const label = wrapper.find('p');
+
+    it('renders a footer item', () => {
+      expect(wrapper.length).toEqual(1);
+    });
+
+    it('renders a custom link element', () => {
+      expect(wrapper.exists('.custom-link')).toEqual(true);
+    });
+
+    it('has the expected classes', () => {
+      expect(item.hasClass('bx--footer-info__item')).toEqual(true);
+      expect(label.hasClass('bx--footer-label')).toEqual(true);
+    });
+
+    it('should add extra classes that are passed via className', () => {
+      expect(item.hasClass('extra-class')).toEqual(true);
+    });
+  });
+});

--- a/src/components/FooterItem/FooterItem.js
+++ b/src/components/FooterItem/FooterItem.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
+
+const FooterItem = ({ link, label, className, ...other }) => {
+  const footerItemClassnames = classnames(
+    `${prefix}--footer-info__item`,
+    className
+  );
+
+  return (
+    <div {...other} className={footerItemClassnames}>
+      <p className={`${prefix}--footer-label`}>{label}</p>
+      {link}
+    </div>
+  );
+};
+
+FooterItem.propTypes = {
+  /**
+   * Provide a Link or custom anchor element to render
+   */
+  link: PropTypes.node.isRequired,
+
+  /**
+   * Provide a label to be displayed with the link
+   */
+  label: PropTypes.string.isRequired,
+
+  /**
+   * Provide a custom className to be applied to the item
+   */
+  className: PropTypes.string,
+};
+
+export default FooterItem;

--- a/src/components/FooterItem/index.js
+++ b/src/components/FooterItem/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default from './FooterItem';


### PR DESCRIPTION
Closes IBM/carbon-components-react#1445

At the moment, the footer takes four separate props to create 2 footer items. If more than 2 items are needed, devs need to copy the markup. The FooterItem is intended to be used as a child of the Footer component.

#### Changelog

**New**

- ++FooterItem

**Changed**

- Footer stories now include an example using children (FooterItem)
