### PR TITLE
chore(lint): Add no-typos for react linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
       "react/jsx-uses-vars": 1,
       "react/jsx-uses-react": 1,
       "react/no-find-dom-node": 1,
+      "react/no-typos": 2,
       "jsdoc/check-param-names": 2,
       "jsdoc/check-tag-names": 2,
       "jsdoc/check-types": 2,


### PR DESCRIPTION
I noticed that a typo made it in for a propType on a previous PR.
Someone added PropTypes.function instead of PropTypes.func.
This change adds the linting for react/no-typos that would catch this typo plus a few others.
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-typos.md

#### Changelog
package.json - Simply added no-typos to the eslintConfig as an error. 
The types of things it catches should be considered errors.

#### Testing

I tested by converting the PropType in DatePicker to be function:
```
    /**
     * The `change` event handler.
     */
    onChange: PropTypes.function,
```
It properly spits out:
```
git\carbon-components-react\src\components\DatePicker\DatePicker.js
  206:25  error  Typo in declared prop type: function  react/no-typos
```