### PR TITLE
chore(code-snippet): add margin to seperate skeletons

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet-story.js
+++ b/src/components/CodeSnippet/CodeSnippet-story.js
@@ -140,7 +140,7 @@ $z-indexes: (
     'skeleton',
     () => (
       <div style={{ width: '800px' }}>
-        <CodeSnippetSkeleton type="single" tyle={{ paddingBottom: 8 }} />
+        <CodeSnippetSkeleton type="single" style={{ paddingBottom: 8 }} />
         <CodeSnippetSkeleton type="multi" />
       </div>
     ),

--- a/src/components/CodeSnippet/CodeSnippet-story.js
+++ b/src/components/CodeSnippet/CodeSnippet-story.js
@@ -140,7 +140,7 @@ $z-indexes: (
     'skeleton',
     () => (
       <div style={{ width: '800px' }}>
-        <CodeSnippetSkeleton type="single" />
+        <CodeSnippetSkeleton type="single" tyle={{ paddingBottom: '8px' }} />
         <CodeSnippetSkeleton type="multi" />
       </div>
     ),

--- a/src/components/CodeSnippet/CodeSnippet-story.js
+++ b/src/components/CodeSnippet/CodeSnippet-story.js
@@ -140,7 +140,7 @@ $z-indexes: (
     'skeleton',
     () => (
       <div style={{ width: '800px' }}>
-        <CodeSnippetSkeleton type="single" tyle={{ paddingBottom: '8px' }} />
+        <CodeSnippetSkeleton type="single" tyle={{ paddingBottom: 8 }} />
         <CodeSnippetSkeleton type="multi" />
       </div>
     ),


### PR DESCRIPTION
Closes IBM/carbon-components-react#2041

#### Changelog

**Changed**

- add padding inline to storybook to differentiate between skeleton states.
- added padding in single line at the end 

Related: https://github.com/IBM/carbon-components/pull/2169
