### PR TITLE
fix: apply correct aria label prop for radio

### DIFF
--- a/src/components/DataTable/TableSelectRow.js
+++ b/src/components/DataTable/TableSelectRow.js
@@ -25,13 +25,16 @@ const TableSelectRow = ({
     name,
     onClick: onSelect,
     checked,
-    ariaLabel,
     disabled,
   };
   const InlineInputComponent = radio ? RadioButton : InlineCheckbox;
   return (
     <td className={className}>
-      <InlineInputComponent {...selectionInputProps} />
+      <InlineInputComponent
+        {...selectionInputProps}
+        {...radio && { labelText: ariaLabel }}
+        {...!radio && { ariaLabel }}
+      />
     </td>
   );
 };

--- a/src/components/DataTable/TableSelectRow.js
+++ b/src/components/DataTable/TableSelectRow.js
@@ -32,7 +32,10 @@ const TableSelectRow = ({
     <td className={className}>
       <InlineInputComponent
         {...selectionInputProps}
-        {...radio && { labelText: ariaLabel }}
+        {...radio && {
+          labelText: ariaLabel,
+          hideLabel: true,
+        }}
         {...!radio && { ariaLabel }}
       />
     </td>

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -647,19 +647,20 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                   >
                     <td>
                       <ForwardRef(RadioButton)
-                        ariaLabel="Select row"
                         checked={false}
+                        hideLabel={true}
                         id="data-table-11__select-row-b"
+                        labelText="Select row"
                         name="select-row-b"
                         onClick={[Function]}
                       >
                         <RadioButton
-                          ariaLabel="Select row"
                           checked={false}
+                          hideLabel={true}
                           id="data-table-11__select-row-b"
                           innerRef={null}
                           labelPosition="right"
-                          labelText=""
+                          labelText="Select row"
                           name="select-row-b"
                           onChange={[Function]}
                           onClick={[Function]}
@@ -669,7 +670,6 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                             className="bx--radio-button-wrapper"
                           >
                             <input
-                              ariaLabel="Select row"
                               checked={false}
                               className="bx--radio-button"
                               id="data-table-11__select-row-b"
@@ -680,13 +680,18 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                               value=""
                             />
                             <label
-                              aria-label=""
+                              aria-label="Select row"
                               className="bx--radio-button__label"
                               htmlFor="data-table-11__select-row-b"
                             >
                               <span
                                 className="bx--radio-button__appearance"
                               />
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select row
+                              </span>
                             </label>
                           </div>
                         </RadioButton>
@@ -723,19 +728,20 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                   >
                     <td>
                       <ForwardRef(RadioButton)
-                        ariaLabel="Select row"
                         checked={false}
+                        hideLabel={true}
                         id="data-table-11__select-row-a"
+                        labelText="Select row"
                         name="select-row-a"
                         onClick={[Function]}
                       >
                         <RadioButton
-                          ariaLabel="Select row"
                           checked={false}
+                          hideLabel={true}
                           id="data-table-11__select-row-a"
                           innerRef={null}
                           labelPosition="right"
-                          labelText=""
+                          labelText="Select row"
                           name="select-row-a"
                           onChange={[Function]}
                           onClick={[Function]}
@@ -745,7 +751,6 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                             className="bx--radio-button-wrapper"
                           >
                             <input
-                              ariaLabel="Select row"
                               checked={false}
                               className="bx--radio-button"
                               id="data-table-11__select-row-a"
@@ -756,13 +761,18 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                               value=""
                             />
                             <label
-                              aria-label=""
+                              aria-label="Select row"
                               className="bx--radio-button__label"
                               htmlFor="data-table-11__select-row-a"
                             >
                               <span
                                 className="bx--radio-button__appearance"
                               />
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select row
+                              </span>
                             </label>
                           </div>
                         </RadioButton>
@@ -799,19 +809,20 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                   >
                     <td>
                       <ForwardRef(RadioButton)
-                        ariaLabel="Select row"
                         checked={false}
+                        hideLabel={true}
                         id="data-table-11__select-row-c"
+                        labelText="Select row"
                         name="select-row-c"
                         onClick={[Function]}
                       >
                         <RadioButton
-                          ariaLabel="Select row"
                           checked={false}
+                          hideLabel={true}
                           id="data-table-11__select-row-c"
                           innerRef={null}
                           labelPosition="right"
-                          labelText=""
+                          labelText="Select row"
                           name="select-row-c"
                           onChange={[Function]}
                           onClick={[Function]}
@@ -821,7 +832,6 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                             className="bx--radio-button-wrapper"
                           >
                             <input
-                              ariaLabel="Select row"
                               checked={false}
                               className="bx--radio-button"
                               id="data-table-11__select-row-c"
@@ -832,13 +842,18 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                               value=""
                             />
                             <label
-                              aria-label=""
+                              aria-label="Select row"
                               className="bx--radio-button__label"
                               htmlFor="data-table-11__select-row-c"
                             >
                               <span
                                 className="bx--radio-button__appearance"
                               />
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select row
+                              </span>
                             </label>
                           </div>
                         </RadioButton>

--- a/src/components/RadioButton/RadioButton-test.js
+++ b/src/components/RadioButton/RadioButton-test.js
@@ -66,7 +66,25 @@ describe('RadioButton', () => {
 
       it('should render a span with the correct class', () => {
         const span = label.find('span');
-        expect(span.hasClass('bx--radio-button__appearance')).toEqual(true);
+        expect(span.at(0).hasClass('bx--radio-button__appearance')).toEqual(
+          true
+        );
+      });
+
+      it('should render a span for the label text', () => {
+        const span = label.find('span');
+        expect(span.at(1).hasClass('')).toEqual(true);
+        expect(span.at(1).text()).toEqual('testlabel');
+      });
+
+      it('should render a span with hidden class name to hide label text', () => {
+        wrapper.setProps({
+          hideLabel: true,
+        });
+        const label = wrapper.find('span');
+        const span = label.find('span');
+        expect(span.at(1).hasClass('bx--visually-hidden')).toEqual(true);
+        expect(span.at(1).text()).toEqual('testlabel');
       });
 
       it('should render label text', () => {

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -49,6 +49,11 @@ class RadioButton extends React.Component {
     labelText: PropTypes.node.isRequired,
 
     /**
+     * Specify whether the label should be hidden, or not
+     */
+    hideLabel: PropTypes.bool,
+
+    /**
      * Provide where label text should be placed
      */
     labelPosition: PropTypes.string,
@@ -94,6 +99,7 @@ class RadioButton extends React.Component {
       labelText,
       labelPosition,
       innerRef: ref,
+      hideLabel,
       ...other
     } = this.props;
     if (__DEV__) {
@@ -103,6 +109,9 @@ class RadioButton extends React.Component {
           'and being removed in the next release of `carbon-components-react`.'
       );
     }
+    const innerLabelClasses = classNames({
+      [`${prefix}--visually-hidden`]: hideLabel,
+    });
     const wrapperClasses = classNames(
       className,
       `${prefix}--radio-button-wrapper`,
@@ -127,7 +136,7 @@ class RadioButton extends React.Component {
           className={`${prefix}--radio-button__label`}
           aria-label={labelText}>
           <span className={`${prefix}--radio-button__appearance`} />
-          {labelText}
+          <span className={innerLabelClasses}>{labelText}</span>
         </label>
       </div>
     );

--- a/src/components/RadioTile/RadioTile-test.js
+++ b/src/components/RadioTile/RadioTile-test.js
@@ -63,9 +63,17 @@ describe('RadioButton', () => {
         expect(label.props().className).toEqual('bx--radio-button__label');
       });
 
-      it('should render a span with the correct class', () => {
+      it('should render a span with the correct class for radio style', () => {
         const span = label.find('span');
-        expect(span.hasClass('bx--radio-button__appearance')).toEqual(true);
+        expect(span.at(0).hasClass('bx--radio-button__appearance')).toEqual(
+          true
+        );
+      });
+
+      it('should render a span for the label text', () => {
+        const span = label.find('span');
+        expect(span.at(1).hasClass('')).toEqual(true);
+        expect(span.at(1).text()).toEqual('testlabel');
       });
 
       it('should render label text', () => {


### PR DESCRIPTION
apply correct aria label prop for radio select on data table. resolving the dev warning about `Invalid ARIA attribute`

#### Changelog

**Changed**
- apply correct aria label prop for radio select on data table.

