### PR TITLE
refactor(Slider): replace Carbon TextInput

### DIFF
--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import isEqual from 'lodash.isequal';
 import { settings } from 'carbon-components';
-import TextInput from '../TextInput';
 import { sliderValuePropSync } from '../../internal/FeatureFlags';
 import { componentsX } from '../../internal/FeatureFlags';
 
@@ -407,9 +406,14 @@ export default class Slider extends PureComponent {
       className
     );
 
-    const inputClasses = classNames(`${prefix}--slider-text-input`, {
-      [`${prefix}--text-input--light`]: light,
-    });
+    const inputClasses = classNames(
+      `${prefix}--text-input`,
+      `${prefix}--slider-text-input`,
+      {
+        [`${prefix}--text-input--light`]: light,
+        [`${prefix}--text-input--invalid`]: this.props.invalid,
+      }
+    );
 
     const filledTrackStyle = {
       transform: `translate(0%, -50%) scaleX(${left / 100})`,
@@ -483,7 +487,7 @@ export default class Slider extends PureComponent {
             {formatLabel(max, maxLabel)}
           </span>
           {!hideTextInput && (
-            <TextInput
+            <input
               type={inputType}
               id={`${id}-input-for-slider`}
               className={inputClasses}


### PR DESCRIPTION
Closes IBM/carbon-components-react#2082

`<TextInput>` (and several other form components) include the `<FormItem>` wrapper out of the box. This PR replaces `<TextInput>` in the `<Slider>` component with native text inputs so that `<Form>` styles are not applied.

Related: https://github.com/IBM/carbon-components-react/issues/1681