### PR TITLE
chore: format GitHub issue templates and update snapshots

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility-issue--.md
+++ b/.github/ISSUE_TEMPLATE/accessibility-issue--.md
@@ -4,7 +4,6 @@ about: Report an accessibility or usability issue
 title: ''
 labels: 'type: a11y ♿'
 assignees: ''
-
 ---
 
 <!-- Feel free to remove sections that aren't relevant.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!-- Feel free to remove sections that aren't relevant.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 Use this template if you want to request a new feature, or a change to an existing feature.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,7 +4,6 @@ about: Usage question or discussion about Carbon Components React.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--


### PR DESCRIPTION
Closes IBM/carbon-components-react#2098

Our issue templates were not properly formatted and caused all CI builds to fail. This PR formats them to pass CI