### PR TITLE
chore(Icon): remove name prop for v10

### DIFF
--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -8,8 +8,10 @@
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
 import React from 'react';
+import warning from 'warning';
 import icons from 'carbon-icons';
 import isRequiredOneOf from '../../prop-types/isRequiredOneOf';
+import { breakingChangesX } from '../../internal/FeatureFlags';
 
 /**
  * The icons list object from `carbon-icons`.
@@ -112,6 +114,11 @@ export function isPrefixed(name) {
   return name && name.split('--')[0] === 'icon';
 }
 
+let didWarnAboutDeprecation;
+
+const findIconWithPrefix = name =>
+  isPrefixed(name) ? findIcon(name) : findIcon(`icon--${name}`);
+
 const Icon = ({
   className,
   iconTitle,
@@ -120,13 +127,22 @@ const Icon = ({
   fillRule,
   height,
   name,
-  icon = isPrefixed(name) ? findIcon(name) : findIcon(`icon--${name}`),
+  icon = !breakingChangesX && findIconWithPrefix(name),
   role,
   style,
   width,
   iconRef,
   ...other
 }) => {
+  if (__DEV__ && breakingChangesX && name) {
+    warning(
+      didWarnAboutDeprecation,
+      'The `name` property in the `Icon` component is being removed in the next release of ' +
+        '`carbon-components-react`. Please use `icon` instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+
   const props = {
     className,
     fill,


### PR DESCRIPTION
Refs #2100.

Aligns the actual behavior to that doc update.

#### Changelog

**Removed**

- `name` prop in `<Icon>` (for `v10`)
