### PR TITLE
docs(migration): misc updates

### DIFF
--- a/docs/migration/migrate-to-7.x.md
+++ b/docs/migration/migrate-to-7.x.md
@@ -64,7 +64,7 @@ Anything in this document is subject to change up until v10 is released._
 | `Notification`        | Deprecated, use `InlineNotification` or `ToastNotification` instead |
 | `NumberInput`         | [Migrate](../../src/components/NumberInput/migrate-to-7.x.md)       |
 | `OverflowMenu`        | [Migrate](../../src/components/OverflowMenu/migrate-to-7.x.md)      |
-| `OverflowMenuItem`    | No breaking changes                                                 |
+| `OverflowMenuItem`    | [Migrate](../../src/components/OverflowMenuItem/migrate-to-7.x.md)  |
 | `Pagination`          | Export now points to `PaginationV2`                                 |
 | `PaginationV2`        | Renamed to `Pagination`                                             |
 | `PrimaryButton`       | No breaking changes                                                 |
@@ -81,7 +81,7 @@ Anything in this document is subject to change up until v10 is released._
 | `SelectItemGroup`     | No breaking changes                                                 |
 | `SkeletonPlaceholder` | No breaking changes                                                 |
 | `SkeletonText`        | No breaking changes                                                 |
-| `Slider`              | No breaking changes                                                 |
+| `Slider`              | [Migrate](../../src/components/Slider/migrate-to-7.x.md)            |
 | `StructuredList`      | No breaking changes                                                 |
 | `Switch`              | No breaking changes                                                 |
 | `Tab`                 | No breaking changes                                                 |

--- a/docs/migration/migrate-to-7.x.md
+++ b/docs/migration/migrate-to-7.x.md
@@ -40,7 +40,7 @@ Anything in this document is subject to change up until v10 is released._
 | `CopyButton`          | No breaking changes                                                 |
 | `DangerButton`        | No breaking changes                                                 |
 | `DataTable`           | [Migrate](../../src/components/DataTable/migrate-to-7.x.md)         |
-| `DatePicker`          | No breaking changes                                                 |
+| `DatePicker`          | [Migrate](../../src/components/DatePicker/migrate-to-7.x.md)        |
 | `DatePickerInput`     | No breaking changes                                                 |
 | `Dropdown`            | Existing import remapped to `DropdownV2`                            |
 | `DropdownItem`        | No breaking changes                                                 |
@@ -94,7 +94,7 @@ Anything in this document is subject to change up until v10 is released._
 | `TableRow`            | Export now points to `DataTable.TableRow`                           |
 | `TableRowExpanded`    | Removed                                                             |
 | `Tabs`                | No breaking changes                                                 |
-| `Tag`                 | No breaking changes                                                 |
+| `Tag`                 | [Migrate](../../src/components/Tag/migrate-to-7.x.md)               |
 | `TextArea`            | No breaking changes                                                 |
 | `TextInput`           | No breaking changes                                                 |
 | `Tile`                | No breaking changes                                                 |

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -257,7 +257,7 @@ export default class DatePicker extends Component {
       if (typeof appendTo === 'string' && !breakingChangesX) {
         warning(
           false,
-          `The DatePicker appendTo prop will be deprecated in Carbon X. 
+          `CSS selector (string) for the DatePicker appendTo prop will be deprecated in Carbon X. 
           - If you were using appendTo for styling, consider using a className.
           - If you were using appendTo for attaching to a specific DOM node, consider a React portal.`
         );

--- a/src/components/DatePicker/migrate-to-7.x.md
+++ b/src/components/DatePicker/migrate-to-7.x.md
@@ -1,0 +1,7 @@
+# Props
+
+`<DatePicker>`
+
+| Prop       | v9                                   | v10                     |
+| ---------- | ------------------------------------ | ----------------------- |
+| `appendTo` | Accepts a CSS selector or a DOM node | Accepts a DOM node only |

--- a/src/components/OverflowMenu/migrate-to-7.x.md
+++ b/src/components/OverflowMenu/migrate-to-7.x.md
@@ -2,11 +2,12 @@
 
 `<OverflowMenu>`
 
-| v9                                        | v10                                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| `floatingMenu`                            | Removed - `<OverflowMenu>` always works as a floating menu                       |
-| `icon`, icon name from `carbon-icons`     | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
-| `iconName`, icon data from `carbon-icons` | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
+| v9                                             | v10                                                                              |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| `floatingMenu`                                 | Removed - `<OverflowMenu>` always works as a floating menu                       |
+| `icon`, icon name from `carbon-icons`          | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
+| `iconName`, icon data from `carbon-icons`      | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
+| `ref` grabs the React class instance reference | `ref` grabs the trigger button                                                   |
 
 ## `v10` example
 

--- a/src/components/OverflowMenuItem/migrate-to-10.x.md
+++ b/src/components/OverflowMenuItem/migrate-to-10.x.md
@@ -1,3 +1,0 @@
-# Props
-
-`floatingMenu` prop in `<OverflowMenu>` has been gone, and overflow menu always works as a floating menu.

--- a/src/components/OverflowMenuItem/migrate-to-7.x.md
+++ b/src/components/OverflowMenuItem/migrate-to-7.x.md
@@ -1,0 +1,3 @@
+# Props
+
+`floatingMenu` prop that is set from `<OverflowMenu>` has been gone, and overflow menu always works as a floating menu.

--- a/src/components/RadioButton/migrate-to-7.x.md
+++ b/src/components/RadioButton/migrate-to-7.x.md
@@ -6,3 +6,9 @@
 | ------------------------------------------- | ---------------------------------------- | ------------------- |
 | `ref`                                       | Grabs the React class instance reference | Grabs the `<input>` |
 | `top`/`bottom` for `labelPosition` property |                                          | Removed             |
+
+# CSS
+
+`<RadioButtonSkeleton>`
+
+No longer adds `radioButtonWrapper` class to the top-level element. Please use `bx--radio-button-wrapper` for style overrides.

--- a/src/components/Slider/migrate-to-7.x.md
+++ b/src/components/Slider/migrate-to-7.x.md
@@ -1,0 +1,7 @@
+# Props
+
+`<Slider>`
+
+| Prop       | v9                                                       | v10                        |
+| ---------- | -------------------------------------------------------- | -------------------------- |
+| `onChange` | Fires on `value` prop change in addition to user gesture | Fires only on user gesture |

--- a/src/components/Tag/migrate-to-7.x.md
+++ b/src/components/Tag/migrate-to-7.x.md
@@ -1,0 +1,9 @@
+# Props
+
+`<Tag>`
+
+See [our website](https://www.carbondesignsystem.com/components/tag/code) for details.
+
+| Prop   | v9                                | v10                            |
+| ------ | --------------------------------- | ------------------------------ |
+| `type` | Accepts `beta`, `community`, etc. | Accepts `red`, `magenta`, etc. |

--- a/src/components/Tooltip/migrate-to-7.x.md
+++ b/src/components/Tooltip/migrate-to-7.x.md
@@ -2,10 +2,11 @@
 
 `<Tooltip>`
 
-| v9                                        | v10                                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| `icon`, icon name from `carbon-icons`     | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
-| `iconName`, icon data from `carbon-icons` | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
+| v9                                             | v10                                                                              |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| `icon`, icon name from `carbon-icons`          | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
+| `iconName`, icon data from `carbon-icons`      | `renderIcon`, which takes a React component, e.g. one from `@carbon/icons-react` |
+| `ref` grabs the React class instance reference | `ref` grabs the trigger button                                                   |
 
 ## `v10` example
 


### PR DESCRIPTION
Refs #2100.
Refs #1759.

#### Changelog

**New**

- `migrate-to-7.x.md` for `<DatePicker>`, `<Slider>`, `<Tag>`

**Changed**

- Root migration guide to link to the additions/changes.
- `migrate-to-7.x.md` in `<OverflowMenu>`, to cover change in `ref` behavior.
- `migrate-to-7.x.md` in `<OverflowMenuItem>`, the file name and made it a bit clearer.
- `migrate-to-7.x.md` in `<Tooltip>`, to cover change in `ref` behavior.
