### PR TITLE
docs(Search): make input value editable

### DIFF
--- a/src/components/Search/Search-story.js
+++ b/src/components/Search/Search-story.js
@@ -22,7 +22,7 @@ const props = () => ({
   small: boolean('Small UI (small)', false),
   light: boolean('Light variant (light)', false),
   name: text('Form item name (name)', ''),
-  value: text('Value (value)', ''),
+  defaultValue: text('Default value (defaultValue)', ''),
   labelText: text('Label text (labelText)', 'Search'),
   closeButtonLabelText: text(
     'The label text for the close button (closeButtonLabelText)',

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -59,6 +59,16 @@ export default class Search extends Component {
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * Specify the value of the <input>
+     */
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * Optionally provide the default value of the <input>
+     */
+    defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };
 
   static defaultProps = {


### PR DESCRIPTION
Closes IBM/carbon-components-react#2120

This PR removes the `value` storybook knob for `<Search>` and replaces it with `defaultValue` (consistent with our `<TextInput>` story)

#### Changelog

**Changed**

- `<Search>` storybook knobs
- `<Search>` prop types