### PR TITLE
docs(ModalWrapper): use unique radio button values

### DIFF
--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -183,7 +183,7 @@ storiesOf('ModalWrapper', module)
             className="some-class"
           />
           <RadioButton
-            value="standard"
+            value="disabled"
             labelText="Radio Button label 3"
             id="radio-3"
             className="some-class"


### PR DESCRIPTION
Closes IBM/carbon-components-react#2143

This PR makes the `value` attribute of each radio button in the `<ModalWrapper>` input modal example unique to avoid unexpected behavior when interacting with the form controls.