### PR TITLE
feat(OverflowMenu): add menuOptionsClass to overflowMenu

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/src/components/OverflowMenu/OverflowMenu-test.js
@@ -110,7 +110,7 @@ describe('OverflowMenu', () => {
 
     it('should render a ul with the appropriate class', () => {
       const rootWrapper = mount(
-        <OverflowMenu>
+        <OverflowMenu menuOptionsClass="extra-menu-class">
           <div className="test-child" />
           <div className="test-child" />
         </OverflowMenu>
@@ -124,6 +124,7 @@ describe('OverflowMenu', () => {
       const list = rootWrapper.find('ul');
       expect(list.length).toEqual(1);
       expect(list.hasClass('bx--overflow-menu-options')).toEqual(true);
+      expect(list.hasClass('extra-menu-class')).toEqual(true);
     });
 
     it('should render children as expected', () => {

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -297,6 +297,11 @@ class OverflowMenu extends Component {
     onClose: PropTypes.func,
 
     /**
+     * The class to apply to the menu options
+     */
+    menuOptionsClass: PropTypes.string,
+
+    /**
      * Function called when menu is closed
      */
     onOpen: PropTypes.func,
@@ -613,6 +618,7 @@ class OverflowMenu extends Component {
     );
 
     const overflowMenuOptionsClasses = classNames(
+      this.props.menuOptionsClass,
       `${prefix}--overflow-menu-options`,
       {
         [`${prefix}--overflow-menu--flip`]: this.props.flipped,

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -582,6 +582,7 @@ class OverflowMenu extends Component {
       onOpen, // eslint-disable-line
       renderIcon: IconElement,
       innerRef: ref,
+      menuOptionsClass,
       ...other
     } = this.props;
     const floatingMenu = !!breakingChangesX || origFloatingMenu;
@@ -618,7 +619,7 @@ class OverflowMenu extends Component {
     );
 
     const overflowMenuOptionsClasses = classNames(
-      this.props.menuOptionsClass,
+      menuOptionsClass,
       `${prefix}--overflow-menu-options`,
       {
         [`${prefix}--overflow-menu--flip`]: this.props.flipped,


### PR DESCRIPTION
Added a new property, `menuOptionsClass`, to `overflowMenu`. This allows a class to be specified on the `overflowMenu` options. This is particularly useful when `floatingMenu` is set, as the menu is appended to the body and has no obvious selector.

#### Changelog

**Changed**

- Changed `overflowMenu` to accept a new property `menuOptionsClass` and pass it down to the menu body.