### PR TITLE
fix(DataTableSkeleton): headers prop can now be array of objects to match DataTable

### DIFF
--- a/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -29,10 +29,8 @@ const DataTableSkeleton = ({
 
   let normalizedHeaders;
 
-  if (typeof headers[0] === 'object') {
-    normalizedHeaders = headers.reduce((filtered, current) =>
-      filtered.push(current.header)
-    );
+  if (headers[0] === Object(headers[0]) && !Array.isArray(headers[0])) {
+    normalizedHeaders = headers.map(current => current.header);
   } else {
     normalizedHeaders = headers;
   }

--- a/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -27,6 +27,16 @@ const DataTableSkeleton = ({
     [`${prefix}--data-table-v2--compact`]: compact,
   });
 
+  let normalizedHeaders;
+
+  if (typeof headers[0] === 'object') {
+    normalizedHeaders = headers.reduce((filtered, current) =>
+      filtered.push(current.header)
+    );
+  } else {
+    normalizedHeaders = headers;
+  }
+
   const rowRepeat = rowCount - 1;
   const rows = Array(rowRepeat);
   const columnsArray = Array.from({ length: columnCount }, (_, index) => index);
@@ -45,7 +55,7 @@ const DataTableSkeleton = ({
       <thead>
         <tr>
           {columnsArray.map(i => (
-            <th key={i}>{headers[i]}</th>
+            <th key={i}>{normalizedHeaders[i]}</th>
           ))}
         </tr>
       </thead>
@@ -88,7 +98,13 @@ DataTableSkeleton.propTypes = {
   /**
    * Optionally specify the displayed headers
    */
-  headers: PropTypes.array,
+  headers: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.shape({
+      key: PropTypes.string,
+      header: PropTypes.node,
+    }),
+  ]),
 };
 
 DataTableSkeleton.defaultProps = {


### PR DESCRIPTION
Closes IBM/carbon-components-react#1963

Right now the `headers` prop for the `DataTableSkeleton` can only be an array of strings, whereas the `headers` prop for the `DataTable` is required to be an array of objects.

This change will allow the `DataTableSkeleton` to accept an array of strings (so as not to break existing usage) and an array of objects (to match `DataTable` and resolve #1963).

#### Changelog

**Changed**

- `headers` prop for `DataTableSkeleton` can now accept array of objects as well
- if you pass `headers` as an array of objects to `DataTableSkeleton`, it will create a new array of "normalized" headers (just an array of strings) to match existing component structure