### PR TITLE
fix(tabs): dropdown label matches updated tabs

### DIFF
--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -251,7 +251,7 @@ export default class Tabs extends React.Component {
       }),
     };
 
-    const selectedTab = this.getTabAt(this.state.selected);
+    const selectedTab = tabsWithProps[this.state.selected];
     const selectedLabel = selectedTab ? selectedTab.props.label : '';
 
     return (


### PR DESCRIPTION
This PR fixes #2204 where the wrong selected dropdown label is shown when `props.children` and `props.selected` are both updated. 

Currently, updating `props.children` and `props.selected` at the same time uses `prevProps.children`'s label in the dropdown. This occurs because `getTabAt` checks the refs cached in the class, which are not updated until `ref` is called (after `selectedLabel` is populated). 