### PR TITLE
chore(ci): re-enable storybook, remove experimental

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,35 +16,27 @@ jobs:
       - run:
           name: Run Continuous Integration checks
           command: PATH=$HOME/.yarn/bin:$PATH yarn ci-check
-      # - deploy:
-          # name: deploy to IBM Cloud
-          # command: |
-            # if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              # # Install `ibmcloud` CLI
-              # curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+      - deploy:
+          name: deploy to IBM Cloud
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              # Install `ibmcloud` CLI
+              curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 
-              # # Login and push staging manifest
-              # ibmcloud login \
-                # --apikey $CLOUD_API_KEY \
-                # -a https://api.ng.bluemix.net \
-                # -o carbon-design-system \
-                # -s production
+              # Login and push staging manifest
+              ibmcloud login \
+                --apikey $CLOUD_API_KEY \
+                -a https://api.ng.bluemix.net \
+                -o carbon-design-system \
+                -s production
 
-              # ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-              # ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
+              ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+              ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
 
-              # # Default storybook build
-              # yarn build-storybook
+              # Default storybook build
+              yarn build-storybook
 
-              # ibmcloud cf blue-green-deploy carbon-storybook \
-                # -f .circleci/manifest.yml \
-                # --delete-old-apps
-
-              # # Experimental storybook build
-              # rm -rf storybook-static
-              # CARBON_USE_EXPERIMENTAL_FEATURES=true yarn build-storybook
-
-              # ibmcloud cf blue-green-deploy carbon-storybook-experimental \
-                # -f .circleci/manifest.experimental.yml \
-                # --delete-old-apps
-            # fi
+              ibmcloud cf blue-green-deploy carbon-storybook \
+                -f .circleci/manifest.yml \
+                --delete-old-apps
+            fi


### PR DESCRIPTION
Re-enable CI deployment for React storybook. This should be merged in after a v6 route is setup.

TODO

- [x] v6 route for React is setup and published with v6 codebase