### PR TITLE
fix(Loading): adds aria-label and description property to component

### DIFF
--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -34,12 +34,18 @@ export default class Loading extends React.Component {
      * Specify whether you would like the small variant of <Loading>
      */
     small: PropTypes.bool,
+
+    /**
+     * Specify an description that would be used to best describe the Loading state..
+     */
+    description: PropTypes.string,
   };
 
   static defaultProps = {
     active: true,
     withOverlay: true,
     small: false,
+    description: 'Active loading indicator',
   };
 
   render() {

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -49,7 +49,14 @@ export default class Loading extends React.Component {
   };
 
   render() {
-    const { active, className, withOverlay, small, ...other } = this.props;
+    const {
+      active,
+      className,
+      withOverlay,
+      small,
+      description,
+      ...other
+    } = this.props;
 
     const loadingClasses = classNames(`${prefix}--loading`, className, {
       [`${prefix}--loading--small`]: small,
@@ -63,6 +70,7 @@ export default class Loading extends React.Component {
     const loading = (
       <div
         {...other}
+        aria-label={description}
         aria-live={active ? 'assertive' : 'off'}
         className={loadingClasses}>
         <svg className={`${prefix}--loading__svg`} viewBox="-75 -75 150 150">

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -36,7 +36,7 @@ export default class Loading extends React.Component {
     small: PropTypes.bool,
 
     /**
-     * Specify an description that would be used to best describe the loading state.
+     * Specify an description that would be used to best describe the loading state
      */
     description: PropTypes.string,
   };

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -36,7 +36,7 @@ export default class Loading extends React.Component {
     small: PropTypes.bool,
 
     /**
-     * Specify an description that would be used to best describe the Loading state..
+     * Specify an description that would be used to best describe the loading state.
      */
     description: PropTypes.string,
   };


### PR DESCRIPTION
🌏 👋  hello you all 
Closes https://github.com/IBM/carbon-components-react/issues/2191

Adds property `description` which is added as `aria-label` to the loading indicators (both inline and normal). This way VO will now announce the loading state.

Tested locally with iOS and VO. Reader will now announce that a loader is on the screen.


#### Changelog

**New**

Property `description` which is added as `aria-label` to the `Loading` component.

