### PR TITLE
fix(Modal): fix button type in danger mode

### DIFF
--- a/src/components/ComposedModal/ComposedModal-test.js
+++ b/src/components/ComposedModal/ComposedModal-test.js
@@ -135,10 +135,10 @@ describe('<ModalFooter />', () => {
       <ModalFooter secondaryButtonText="test" danger />
     );
 
-    it('renders danger--primary button if primary text && danger', () => {
+    it('renders danger button if primary text && danger', () => {
       const buttonComponent = primaryWrapper.find(Button);
       expect(buttonComponent.exists()).toBe(true);
-      expect(buttonComponent.props().kind).toBe('danger--primary');
+      expect(buttonComponent.props().kind).toBe('danger');
     });
 
     it('renders tertiary button if secondary text && danger', () => {

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -522,7 +522,7 @@ export class ModalFooter extends Component {
             onClick={onRequestSubmit}
             className={primaryClass}
             disabled={primaryButtonDisabled}
-            kind={danger ? 'danger--primary' : 'primary'}
+            kind={danger ? 'danger' : 'primary'}
             ref={this.props.inputref}>
             {primaryButtonText}
           </Button>

--- a/src/components/Modal/Modal-test.js
+++ b/src/components/Modal/Modal-test.js
@@ -226,7 +226,7 @@ describe('Danger Modal', () => {
       expect(modalButtons[0].props.kind).toEqual(
         !componentsX ? 'tertiary' : 'secondary'
       );
-      expect(modalButtons[1].props.kind).toEqual('danger--primary');
+      expect(modalButtons[1].props.kind).toEqual('danger');
     });
   });
 });

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -346,7 +346,7 @@ export default class Modal extends Component {
               {secondaryButtonText}
             </Button>
             <Button
-              kind={danger ? 'danger--primary' : 'primary'}
+              kind={danger ? 'danger' : 'primary'}
               disabled={primaryButtonDisabled}
               onClick={onRequestSubmit}
               inputref={this.button}>


### PR DESCRIPTION
Fixes #2249.

#### Changelog

**Changed**

- Changed the primary button of danger mode from `danger--primary` to `danger`