### PR TITLE
fix(notification): adds aria-label to button

### DIFF
--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -665,7 +665,6 @@ class Notification extends Component {
         className={notificationClasses.toast}>
         <NotificationTextDetails
           title={title}
-          aria-label="catcatcat"
           subtitle={subtitle}
           caption={caption}
           notificationType="toast"

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -155,6 +155,7 @@ export class NotificationButton extends Component {
       <button
         {...other}
         type={type}
+        aria-label={iconDescription}
         title={iconDescription}
         className={buttonClasses}>
         {NotificationButtonIcon}
@@ -664,6 +665,7 @@ class Notification extends Component {
         className={notificationClasses.toast}>
         <NotificationTextDetails
           title={title}
+          aria-label="catcatcat"
           subtitle={subtitle}
           caption={caption}
           notificationType="toast"


### PR DESCRIPTION
closes #2246 

adds aria-label to close button on toast notification so that the button's purpose can be known to screen reader users.

#### Changelog

- adds `aria-label={iconDescription}` to the `<button>` component
