### PR TITLE
fix(accordion): remove role=presentation

### DIFF
--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -128,7 +128,6 @@ export default class AccordionItem extends Component {
         className={classNames}
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}
-        role="presentation"
         {...other}>
         <Expando
           type="button"


### PR DESCRIPTION
closes #2251 

Removes the invalid role attribute from AccordionItem component since the role was causing an Axe error.

#### Changelog

- remove `role=presentation` from AccordionItem's `<li>` element.