### PR TITLE
fix(InputField) -  adds aria-label property on `input` element

### DIFF
--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -135,6 +135,7 @@ class NumberInput extends Component {
     value: 0,
     invalid: false,
     invalidText: 'Provide invalidText',
+    ariaLabel: 'A Numeric Input field with increment and decrement buttons',
     helperText: '',
     light: false,
     allowEmpty: false,
@@ -221,6 +222,7 @@ class NumberInput extends Component {
       invalid,
       invalidText,
       helperText,
+      ariaLabel,
       light,
       allowEmpty,
       innerRef: ref,
@@ -272,7 +274,7 @@ class NumberInput extends Component {
     });
 
     const labelText = label ? (
-      <label htmlFor={id} className={labelClasses}>
+      <label htmlFor={id} className={labelClasses} aria-label={ariaLabel}>
         {label}
       </label>
     ) : null;

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -103,6 +103,10 @@ class NumberInput extends Component {
      */
     helperText: PropTypes.node,
     /**
+     * Provide a description that would be used to best describe the use case of the NumberInput component
+     */
+    ariaLabel: PropTypes.string,
+    /**
      * `true` to use the light version.
      */
     light: PropTypes.bool,

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -249,6 +249,7 @@ class NumberInput extends Component {
       step,
       onChange: this.handleChange,
       value: this.state.value,
+      ariaLabel,
     };
 
     const buttonProps = {
@@ -274,7 +275,7 @@ class NumberInput extends Component {
     });
 
     const labelText = label ? (
-      <label htmlFor={id} className={labelClasses} aria-label={ariaLabel}>
+      <label htmlFor={id} className={labelClasses}>
         {label}
       </label>
     ) : null;

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -135,7 +135,7 @@ class NumberInput extends Component {
     value: 0,
     invalid: false,
     invalidText: 'Provide invalidText',
-    ariaLabel: 'A Numeric Input field with increment and decrement buttons',
+    ariaLabel: 'Numeric input field with increment and decrement buttons',
     helperText: '',
     light: false,
     allowEmpty: false,


### PR DESCRIPTION
Hello you all and happy Tuesday morning! ☀️ 🌸 

Closes https://github.com/IBM/carbon-components-react/issues/2188

As discussed in https://github.com/IBM/carbon-components-react/issues/2188, the issue seems to be that the label element is present, but it is empty and hidden. Adding a label on the `input` element should fix that a11y violation.
#### Changelog

**New**

adds aria-label property on `input` element

**Changed**

- `src/components/NumberInput/NumberInput.js`

