### PR TITLE
docs(DataTable): Update documentation for DataTable expansion

### DIFF
--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -418,11 +418,9 @@ In practice, the combination of these components looks like the following:
               </TableExpandRow>
               {/* toggle based off of if the row is expanded. If it is, render TableExpandedRow */}
               {row.isExpanded && (
-                <TableExpandedRow>
-                  <TableCell colSpan={headers.length + 1}>
-                    <h1>Expandable row content</h1>
-                    <p>Description here</p>
-                  </TableCell>
+                <TableExpandedRow colSpan={headers.length + 1}>
+                  <h1>Expandable row content</h1>
+                  <p>Description here</p>
                 </TableExpandedRow>
               )}
             </React.Fragment>
@@ -440,7 +438,8 @@ Some things to note:
 - `TableExpandRow` is what you use instead of `TableRow` for the content of your row. We make sure to add `getRowProps` so that it has the right props
 - `row.isExpanded` is the field available on `row` to know if the `row` is expanded or not
 - `TableExpandedRow` is used as a wrapper for any content you want to appear in the expanded row
-  - Tip: the `colSpan` attribute on the `TableCell` should be `headers.length + 1` in order to span the whole table
+  - Tip: the `colSpan` attribute on the `TableExpandedRow` should be `headers.length + 1` in order to span the whole table
+  - `TableExpandedRow` should not have a `TableCell` child
 
 #### Programmatic expansion
 


### PR DESCRIPTION
#### Notes

The documentation for the `DataTable` expansion components seems to be out of date or misaligned with what I needed to get it to work. In order to get it to work properly, I had to remove the `TableCell` component from inside `TableExpandedRow` and set the `colSpan` property of `TableExpandedRow` to `headers.length + 1`

#### Changelog

**Changed**

- Update to reflect that no `TableCell` should be a child of `TableExpandedRow`
- Update to add `colSpan` property to the `TableExpandedRow` element

**Removed**

- Removed `TableCell` from being a child of `TableExpandedRow` in the `DataTable` expansion docs
