### PR TITLE
fix(Pagination): pageInputDisabled won't append disabled class to buttons

### DIFF
--- a/src/components/Pagination/Pagination-test.js
+++ b/src/components/Pagination/Pagination-test.js
@@ -353,6 +353,29 @@ describe('Pagination', () => {
           );
           expect(right.length).toEqual(0);
         });
+
+        it('should not append `pagination__button--no-index` class if input is disabled', () => {
+          const pagination = shallow(
+            <Pagination
+              page={2}
+              pageSizes={[100]}
+              pagesUnknown={true}
+              pageInputDisabled={true}
+            />
+          );
+          const forwardButton = pagination.find(
+            '.bx--pagination__button--forward'
+          );
+          const backwardButton = pagination.find(
+            '.bx--pagination__button--backward'
+          );
+          expect(
+            backwardButton.hasClass('bx--pagination__button--no-index')
+          ).toEqual(false);
+          expect(
+            forwardButton.hasClass('bx--pagination__button--no-index')
+          ).toEqual(false);
+        });
       });
 
       describe('pagination navigation', () => {

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -260,8 +260,7 @@ export default class Pagination extends Component {
       `${prefix}--pagination__button`,
       `${prefix}--pagination__button--backward`,
       {
-        [`${prefix}--pagination__button--no-index`]:
-          pageInputDisabled || backButtonDisabled,
+        [`${prefix}--pagination__button--no-index`]: backButtonDisabled,
       }
     );
     const forwardButtonDisabled =
@@ -270,8 +269,7 @@ export default class Pagination extends Component {
       `${prefix}--pagination__button`,
       `${prefix}--pagination__button--forward`,
       {
-        [`${prefix}--pagination__button--no-index`]:
-          pageInputDisabled || forwardButtonDisabled,
+        [`${prefix}--pagination__button--no-index`]: forwardButtonDisabled,
       }
     );
     const selectItems = this.renderSelectItems(totalPages);


### PR DESCRIPTION
Closes IBM/carbon-components-react#2264

Pagination component with `pageInputDisabled: true` prop would display forward and backward buttons as disabled, while they'd still work when clicking.

This PR disables check for `pageInputDisabled` so the buttons' styling is not affected by it.

`disabled` prop disables next/previous page buttons so it can be used in parallel with `pageInputDisabled` if that functionality is needed. 
